### PR TITLE
static: add redirect for go-llvm

### DIFF
--- a/static/x/go-llvm/index.html
+++ b/static/x/go-llvm/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+<meta name="go-import" content="tinygo.org/x/go-llvm git https://github.com/tinygo-org/go-llvm">
+<meta name="go-source" content="tinygo.org/x/go-llvm _ https://github.com/tinygo-org/go-llvm/tree/master{/dir} https://github.com/tinygo-org/go-llvm/blob/master{/dir}/{file}#L{line}">
+<meta http-equiv="refresh" content="0; url=https://tinygo.org/">
+</head>
+<body>
+Nothing to see here; <a href="https://tinygo.org/">move along</a>.
+</body>


### PR DESCRIPTION
go-llvm has moved, add a redirect for vanity imports.