### PR TITLE
Add platform specific installation links in getting started page

### DIFF
--- a/content/getting-started/_index.md
+++ b/content/getting-started/_index.md
@@ -6,4 +6,4 @@ weight: 1
 
 # Getting Started
 
-To use TinyGo, you must install it on your system. We have instructions for Linux, macOS, Windows, and Docker. You can also install TinyGo from source.
+To use TinyGo, you must install it on your system. We have instructions for [Linux](linux), [macOS](macos), [Windows](windows), and [Docker](using-docker). You can also install TinyGo from source.


### PR DESCRIPTION
Fix #27 