### PR TITLE
all: update to TinyGo 0.6

### DIFF
--- a/content/compiler-internals/volatile.md
+++ b/content/compiler-internals/volatile.md
@@ -3,13 +3,8 @@ title: "The volatile keyword"
 weight: 3
 ---
 
-Go does not have the `volatile` keyword like C/C++. This keyword is unnecessary in most desktop use cases but is required for memory mapped I/O on microcontrollers and interrupt handlers. As a workaround, any variable of a type annotated with the `//go:volatile` pragma will be marked volatile. For example:
+Go does not have the `volatile` keyword like C/C++. Volatile is used to read and write memory mapped registers that can change or have side effects that the compiler does not know about.
 
-```go
-//go:volatile
-type volatileBool bool
+To implement volatile operations, the runtime/volatile package has been added with functions that are treated specially by the compiler. For example, you can use `volatile.LoadUint32` to load an `*uint32`, a type that is often used in memory mapped peripherals on 32-bit microcontrollers.
 
-var isrFlag volatileBool
-```
-
-This is a workaround for a limitation in the Go language and should at some point be replaced with something else.
+In practice, you do not normally need to use these functions. Memory mapped registers are available with special `Get` and `Set` functions that call these volatile operations behind the scenes. One exception is when you want to communicate between normal code and interrupt handlers, in which case you need to use volatile operations for all variables that are accessed by both the normal code and the interrupt handler.

--- a/content/lang-support/_index.md
+++ b/content/lang-support/_index.md
@@ -7,15 +7,15 @@ While TinyGo supports a big subset of the Go language, not everything is support
 
 Here is a list of features that are supported:
 
-* The subset of Go that directly translates to C is well supported. This includes all basic types (except for `complex64` and `complex128`) and all regular control flow (including `switch`).
+* The subset of Go that directly translates to C is well supported. This includes all basic types and all regular control flow (including `switch`).
 * Slices are well supported, with the exception of 3-index slicing (see below).
-* Interfaces, while tested less than other features, are quite stable and should work well in almost all cases. Type switches and type asserts are also supported, as well as calling methods on interfaces.
+* Interfaces are quite stable and should work well in almost all cases. Type switches and type asserts are also supported, as well as calling methods on interfaces.
 * Closures and bound methods are supported, for example inline anonymous (lambda-like) functions.
 * The `defer` keyword is supported, with the exception of deferring a call on a function pointer. Immediately applied functions that are deferred are supported, however. In practice, function pointers are little used in deferred calls.
 
 ## Concurrency
 
-At the time of writing (2019-04-18), support for goroutines and channels is weak. There is some support, but you will often encounter compiler errors when trying to use concurrency in more complicated ways (for example with function pointers). Also, some things may unexpectedly allocate memory like calling a function that blocks. This situation should certainly improve in the future, but at the moment you shouldn't rely on concurrency features to work well.
+At the time of writing (2019-07-05), support for goroutines and channels has not been fully realized but simple programs usually work. There may be problems with function pointers or starting more than two goroutines. Also, some things may unexpectedly allocate heap memory like calling a function that blocks. This situation should certainly improve in the future: at the moment, you should treat goroutines as an experimental feature.
 
 ## Cgo
 
@@ -27,14 +27,9 @@ Many packages, especially in the standard library, rely on reflection to work. T
 
 ## Maps
 
-Support for maps is still very limited and in general you shouldn't rely on their availability. The main reason they are supported is so the `unicode` package compiles.
+Support for maps is not yet complete but is usable. You can use any type as a value, but only some types are acceptable as map keys. Also, they have not been optimized for performance and will cause linear lookup times in some cases.
 
-To use maps, you will currently have to deal with the following limitations:
-
-* A map can store at most 8 entries. The exception is when it is initialized as a global variable, in which case it can store more entries.
-* Map keys must be either strings, integers, or (nested) structs that contain only integers. Supporting more will likely depend on reflection for code size reasons.
-* Map operations are likely to be very slow.
-* The current implementation is little tested so may contain bugs.
+Types supported as map keys include strings, integers, pointers, and structs/arrays that contain only these types. More complex types will depend on better reflection support.
 
 ## Standard library
 
@@ -53,5 +48,4 @@ Careful design may avoid memory allocations in main loops. You may want to compi
 Some features are little used and there hasn't been a real need to implement them yet. These include:
 
 * `recover()`: this can be useful sometimes but in general most programs work just fine with a `panic()` that simply aborts. Supporting `recover()` will also likely increase code size so it has also been left out at the moment for that reason. When `recover()` gets implemented, it will likely be disabled by default and can be enabled with a compiler flag.
-* Arithmetic on complex numbers is not yet supported (add, sub, mul, div). However, the `complex`, `real` and `imag` builtins, as well as complex number constants, are all supported. Apart from the fact that complex number operations are little used, they are also [hard to implement correctly](https://github.com/golang/go/issues/29846).
 * Slice expessions with 3 indexes that sets the capacity as well as the length. This feature was [introduced in Go 1.2](https://tip.golang.org/doc/go1.2#three_index).

--- a/content/usage/important-options.md
+++ b/content/usage/important-options.md
@@ -58,3 +58,12 @@ Only allocate memory, never free it. This is the simplest allocator possible and
 
  - `-gc=marksweep`
 Simple conservative mark/sweep garbage collector. This collector does not yet work on all platforms. Also, the performance of the collector is highly unpredictable as any allocation may trigger a garbage collection cycle.
+
+- `-panic`
+Use the specified panic strategy. That is, what the compiled program should do when a panic occurs.
+
+  - `-panic=abort`
+    Print the panic message and abort the program. This is the default. On a desktop system this results in a call to [`abort`](https://manpages.debian.org/stretch/manpages-dev/abort.3.en.html). On WebAssembly this is implemented as the [`unreachable`](https://webassembly.github.io/spec/core/syntax/instructions.html#syntax-instr-control) instruction. On microcontrollers, it results in a hang (endless loop).
+
+  - `-panic=trap`
+    Do not print the panic message but instead of printing anything, it directly hits a trap instruction. This instruction varies by platform but it will result in the immediate termination of the program. It could either exit with `SIGILL` or cause a call to the `HardFault_Handler`. It can be used to reduce the size of the compiled program while keeping standard Go safety rules intact at the cost of debuggability.


### PR DESCRIPTION
There were a few changes that affect the docs, in particular in language support.

I'm not sure in which branch this is supposed to be merged.