### PR TITLE
boards: add info about support for the Arduino Nano33 IoT board

### DIFF
--- a/content/microcontrollers/_index.md
+++ b/content/microcontrollers/_index.md
@@ -8,7 +8,7 @@ weight: 3
 
 TinyGo lets you run Go directly on microcontrollers.
 
-TinyGo has support for 14 different boards such as the Arduino Uno, Adafruit Circuit Playground Express, and BBC micro:bit. Click to see the supported hardware.
+TinyGo has support for 15 different boards such as the Arduino Nano33 IoT, Adafruit Circuit Playground Express, and BBC micro:bit. Click to see the supported hardware.
 
 We also give you the ability to add new boards. If your target isn't listed here, please raise an issue in the [issue tracker](https://github.com/tinygo-org/tinygo/issues).
 

--- a/content/microcontrollers/arduino-nano33-iot.md
+++ b/content/microcontrollers/arduino-nano33-iot.md
@@ -1,0 +1,57 @@
+---
+title: "Arduino Nano33 IoT"
+weight: 3
+---
+
+The [Arduino Nano33 IoT](https://store.arduino.cc/nano-33-iot) is a very small ARM development board based on the Atmel [SAMD21](https://www.microchip.com/wwwproducts/en/ATSAMD21G18) family of processors. It also has a NINA-W102 chip onboard which provides an wireless communication abilities based on the popular ESP32 family of wireless chips from Espressif.
+
+## Interfaces
+
+| Interface | Hardware Supported | TinyGo Support |
+| --------- | ------------- | ----- |
+| GPIO      | YES | YES |
+| UART      | YES | YES |
+| SPI      | YES | YES |
+| I2C      | YES | YES |
+| ADC      | YES | YES |
+| PWM      | YES | YES |
+
+## Installing BOSSA
+
+In order to flash your TinyGo programs onto the Arduino Nano33 IoT board, you will need to install the "bossac" command line utility which is part of the [BOSSA command line utilities](https://github.com/shumatech/BOSSA).
+
+### macOS
+
+On macOS, download the installer from https://github.com/shumatech/BOSSA/releases/download/1.9.1/bossa-1.9.1.dmg
+
+One you have downloaded it, double click on the .dmg file to perform the installation.
+
+### Linux
+
+On Linux, install from source:
+
+```shell
+git clone https://github.com/shumatech/BOSSA.git
+cd BOSSA
+make
+```
+
+## Flashing
+
+Once you have installed the needed BOSSA command line utility, as in the previous section, you are ready to build and flash code to your Arduino Nano33 IoT board.
+
+- Plug your Arduino Nano33 IoT board into your computer's USB port.
+- Press the "RESET" button on the board two times to get the Arduino Nano33 IoT board ready to receive code.
+- Build and flash your TinyGo code using the `tinygo flash` command. This command flashes the Arduino Nano33 IoT with the blinky1 example:
+
+```
+tinygo build -target=arduino-nano33 examples/blinky1
+```
+
+- The Arduino Nano33 IoT board should restart and then begin running your program.
+
+## Notes
+
+You can use the USB port to the Arduino Nano33 IoT as a serial port. `UART0` refers to this connection.
+
+For information on how to use the built-in NINA-W102 wireless chip, please see the "espat" driver in the TinyGo drivers repository located at [https://github.com/tinygo-org/drivers/tree/master/espat](https://github.com/tinygo-org/drivers/tree/master/espat).


### PR DESCRIPTION
Adds information about using TinyGo on the Arduino Nano33 IoT board.