### PR TITLE
boards: add installation instructions for Arduino Uno

### DIFF
--- a/content/microcontrollers/arduino-uno.md
+++ b/content/microcontrollers/arduino-uno.md
@@ -18,6 +18,24 @@ Note: the AVR backend of LLVM is still experimental so you may encounter bugs.
 | ADC      | YES | YES |
 | PWM      | YES | YES |
 
+## Installing dependencies
+
+The Arduino Uno needs a few extra dependencies to work, for example, if you get an error like this:
+
+```text
+/usr/lib/gcc/avr/5.4.0/../../../avr/bin/ld: cannot find -lm
+/usr/lib/gcc/avr/5.4.0/../../../avr/bin/ld: cannot find -lc
+collect2: error: ld returned 1 exit status
+```
+
+Or like this:
+
+```text
+/bin/sh: 1: avrdude: not found
+```
+
+To fix this, see the installation guide for [Linux](../../getting-started/linux/#avr-arduino) and for [macOS](../../getting-started/macos/#avr-arduino).
+
 ## Flashing
 
 ### AVRDude


### PR DESCRIPTION
It's a bit of duplication (especially the `avrdude` part, which is mentioned twice on this page) but it may help people new to TinyGo.
I wasn't sure whether to include these error messages, they take up quite a bit of space but may be helpful to quickly diagnose the problem.

See https://github.com/tinygo-org/tinygo/issues/504