### PR TITLE
all: update to newer TinyGo version

### DIFF
--- a/content/compiler-internals/datatypes.md
+++ b/content/compiler-internals/datatypes.md
@@ -30,13 +30,7 @@ convention]({{<ref "calling-convention.md">}}) for details. The function pointer
 may be a real pointer or an arbitrary number, depending on the target platform.
 
 ### goroutine
-A goroutine is a linked list of [LLVM
-coroutines](https://llvm.org/docs/Coroutines.html). Every blocking call will
-create a new coroutine and pass itself to the coroutine as a parameter (see
-[calling convention]({{<ref "calling-convention.md">}})). The callee then
-re-activates the caller once it would otherwise return to the parent.
-Non-blocking calls are normal calls, unaware of the fact that they're running on
-a particular goroutine. For details, see
-[src/runtime/scheduler.go](https://github.com/tinygo-org/tinygo/blob/master/src/runtime/scheduler.go).
+Goroutines are implemented differently depending on the platform.
 
-This is rather expensive and should be optimized in the future. But the way it works now, a single stack can be used for all goroutines lowering memory consumption.
+  * For most platforms, it is implemented as a linked list of [LLVM coroutines](https://llvm.org/docs/Coroutines.html). Every blocking call will create a new coroutine and pass itself to the coroutine as a parameter (see [calling convention]({{<ref "calling-convention.md">}})). The callee then re-activates the caller once it would otherwise return to the parent.  Non-blocking calls are normal calls, unaware of the fact that they're running on a particular goroutine. For details, see [src/runtime/scheduler.go](https://github.com/tinygo-org/tinygo/blob/master/src/runtime/scheduler.go). This is rather expensive but has the advantage of being portable and requiring only a single stack.
+  * For Cortex-M (which includes most supported microcontrollers as of this time), a real stack is allocated and scheduling happens much like the main Go implementation by saving and restoring registers in assembly.

--- a/content/compiler-internals/differences-from-go.md
+++ b/content/compiler-internals/differences-from-go.md
@@ -3,8 +3,8 @@ title: "Differences from Go"
 weight: 2
 ---
 
-* A whole program is compiled in a single step, without intermediate linking. This makes incremental development much slower for large programs but enables far more optimization opportunities. In the future, an option should be added for incremental compilation during edit-compile-test cycles.
-* Interfaces are always represented as a `{typecode, value}` pair. Unlike Go [https://research.swtch.com/interfaces](https://research.swtch.com/interfaces), TinyGo will not precompute a list of function pointers for fast interface method calls. Instead, all interface method calls are looked up where they are used. This may sound expensive, but it avoids memory allocation at interface creation.
+* A whole program is compiled in a single step, without intermediate linking. This makes incremental development much slower for large programs but enables far more optimization opportunities. We are actively working on build caching so that at least part of the work does not need to be redone on every compilation.
+* Interfaces are always represented as a `{typecode, value}` pair. Unlike Go [https://research.swtch.com/interfaces](https://research.swtch.com/interfaces), TinyGo will not precompute a list of function pointers for fast interface method calls. Instead, all interface method calls are looked up where they are used. This may sound expensive, but it sometimes avoids memory allocation at interface creation.
 * Global variables are computed during compilation whenever possible (unlike Go, which does not have the equivalent of a `.data` section). This is an important optimization for several reasons:
 
  - Startup time is reduced. This is nice, but not the main reason.

--- a/content/compiler-internals/heap-allocation.md
+++ b/content/compiler-internals/heap-allocation.md
@@ -3,7 +3,7 @@ title: "Heap allocation"
 weight: 2
 ---
 
-Many operations in Go rely on heap allocation. Some of these heap allocations are optimized away, but not all of them. Also, TinyGo does not yet contain a garbage collector so heap allocation must be avoided whenever possible outside of initialization code.
+Many operations in Go rely on heap allocation. TinyGo will try to optimize them away using escape analysis, but that is not always possible in practice.
 
 These operations currently do heap allocations:
 
@@ -53,6 +53,6 @@ These operations currently do heap allocations:
 
 * Closures where the collection of shared variables between the closure and the main function is larger than a pointer.
 
-* Creating and modifying maps. Maps have *very* little support at the moment and should not yet be used. They exist mostly for compatibility with some standard library packages.
+* Creating and modifying maps.
 
-* Starting goroutines. There is limited support for goroutines and currently they are not at all efficient. See [Go language support]({{<ref "lang-support/_index.md">}}) for details.
+* Starting goroutines.

--- a/content/compiler-internals/microcontrollers.md
+++ b/content/compiler-internals/microcontrollers.md
@@ -11,9 +11,15 @@ Microcontrollers have very little RAM and execute code directly from flash. Also
 
 ARM Cortex-M processors are well supported. There is support for multiple chips and the backend appears to be stable. In fact, it uses the same underlying technology (LLVM) as the proprietary ARM compiler for code generation.
 
+Please note that while Cortex-M is well supported, every chip and chip family needs to have some special support added for things like the memory map, clock configuration, timekeeping (`time.Now` and friends), and some more things. This extra code is required for TinyGo to be usable on a given chip. If you want to add support for a new board, take a look at [this wiki page](https://github.com/tinygo-org/tinygo/wiki/Adding-a-new-board).
+
 ## AVR
 
-The AVR backend of LLVM is still experimental so you may encounter bugs.
+The AVR backend of LLVM is still experimental so you may encounter bugs. Larger programs often fail to work due to this.
+
+## RISC-V
+
+There is some support for RISC-V, in particular the [HiFive1 rev B](https://github.com/tinygo-org/tinygo/wiki/Adding-a-new-board) board.
 
 ## Xtensa
 

--- a/content/lang-support/_index.md
+++ b/content/lang-support/_index.md
@@ -8,10 +8,10 @@ While TinyGo supports a big subset of the Go language, not everything is support
 Here is a list of features that are supported:
 
 * The subset of Go that directly translates to C is well supported. This includes all basic types and all regular control flow (including `switch`).
-* Slices are well supported, with the exception of 3-index slicing (see below).
-* Interfaces are quite stable and should work well in almost all cases. Type switches and type asserts are also supported, as well as calling methods on interfaces.
+* Slices are well supported.
+* Interfaces are quite stable and should work well in almost all cases. Type switches and type asserts are also supported, as well as calling methods on interfaces. The only exception is comparing two interface values (but comparing against `nil` works).
 * Closures and bound methods are supported, for example inline anonymous (lambda-like) functions.
-* The `defer` keyword is supported, with the exception of deferring a call on a function pointer. Immediately applied functions that are deferred are supported, however. In practice, function pointers are little used in deferred calls.
+* The `defer` keyword is supported, with the exception of a deferred call on an interface. This happens very infrequently in practice.
 
 ## Concurrency
 
@@ -23,7 +23,7 @@ While TinyGo embeds the [Clang](https://clang.llvm.org/) compiler to parse `impo
 
 ## Reflection
 
-Many packages, especially in the standard library, rely on reflection to work. The `reflect` package in the standards library is closely coupled to the main Go compilers and the runtime, so will have to be replaced. [Work is underway](https://github.com/tinygo-org/tinygo/pull/104) that provides at least initial support for reflection.
+Many packages, especially in the standard library, rely on reflection to work. The `reflect` package has been re-implemented in TinyGo and most common types like numbers, strings, and structs are supported now.
 
 ## Maps
 
@@ -33,13 +33,13 @@ Types supported as map keys include strings, integers, pointers, and structs/arr
 
 ## Standard library
 
-Due to the above missing pieces and because parts of the standard library depend on the particular compiler/runtime in use, many packages do not yet compile.
+Due to the above missing pieces and because parts of the standard library depend on the particular compiler/runtime in use, many packages do not yet compile. See the [list of compiling packages here]({{<ref "stdlib.md">}}).
 
 ## Garbage collection
 
 While not directly a language feature (the Go spec doesn't mention it), garbage collection is important for most Go programs to make sure their memory usage stays in reasonable bounds.
 
-Garbage collection is currently only supported on ARM microcontrollers (Cortex-M). For this platform, a simple conservative mark-sweep collector has been implemented. Other platforms will just allocate memory without ever freeing it.
+Garbage collection is currently supported on all platforms except AVR. A simple conservative mark-sweep collector is used that will trigger a collection cycle when the heap runs out (that is fixed at compile time) or when requested manually using `runtime.GC()`.
 
 Careful design may avoid memory allocations in main loops. You may want to compile with `-gc=none` and look at link errors to find out where allocations happen: the compiler inserts calls to `runtime.alloc` to allocate memory. For more information, see [heap allocation]({{<ref "heap-allocation.md">}}).
 
@@ -48,4 +48,3 @@ Careful design may avoid memory allocations in main loops. You may want to compi
 Some features are little used and there hasn't been a real need to implement them yet. These include:
 
 * `recover()`: this can be useful sometimes but in general most programs work just fine with a `panic()` that simply aborts. Supporting `recover()` will also likely increase code size so it has also been left out at the moment for that reason. When `recover()` gets implemented, it will likely be disabled by default and can be enabled with a compiler flag.
-* Slice expessions with 3 indexes that sets the capacity as well as the length. This feature was [introduced in Go 1.2](https://tip.golang.org/doc/go1.2#three_index).


### PR DESCRIPTION
Lots of things have changed, so I went through most compiler docs and
updated them. For example, one page said there was no GC support yet,
that's fixed now.

Fixes #41.