### PR TITLE
update link to correct zephyrproject URL in pca100xx files

### DIFF
--- a/content/microcontrollers/pca10031.md
+++ b/content/microcontrollers/pca10031.md
@@ -24,7 +24,7 @@ Programs are loaded onto the pca10031 board using the `nrfjprog` command line ut
 
 First install the J-Link Software and Documentation Pack from Segger: [https://www.segger.com/downloads/jlink/#J-LinkSoftwareAndDocumentationPack](https://www.segger.com/downloads/jlink/#J-LinkSoftwareAndDocumentationPack)
 
-Then install the nRF5x Command-Line Tools: [https://docs.zephyrproject.org/latest/guides/tools/nordic_segger.html#nordic-segger](https://docs.zephyrproject.org/latest/guides/tools/nordic_segger.html#nordic-segger)
+Then install the nRF5x Command-Line Tools: [https://docs.zephyrproject.org/latest/guides/tools/nordic_segger.html#nrf5x-command-line-tools-installation](https://docs.zephyrproject.org/latest/guides/tools/nordic_segger.html#nrf5x-command-line-tools-installation)
 
 Once you have installed both of these correctly, you will be able to flash the pca10031 board with your TinyGo code.
 

--- a/content/microcontrollers/pca10031.md
+++ b/content/microcontrollers/pca10031.md
@@ -24,7 +24,7 @@ Programs are loaded onto the pca10031 board using the `nrfjprog` command line ut
 
 First install the J-Link Software and Documentation Pack from Segger: [https://www.segger.com/downloads/jlink/#J-LinkSoftwareAndDocumentationPack](https://www.segger.com/downloads/jlink/#J-LinkSoftwareAndDocumentationPack)
 
-Then install the nRF5x Command-Line Tools: [https://docs.zephyrproject.org/latest/tools/nordic_segger.html#nordic-segger](https://docs.zephyrproject.org/latest/tools/nordic_segger.html#nordic-segger)
+Then install the nRF5x Command-Line Tools: [https://docs.zephyrproject.org/latest/guides/tools/nordic_segger.html#nordic-segger](https://docs.zephyrproject.org/latest/guides/tools/nordic_segger.html#nordic-segger)
 
 Once you have installed both of these correctly, you will be able to flash the pca10031 board with your TinyGo code.
 

--- a/content/microcontrollers/pca10040.md
+++ b/content/microcontrollers/pca10040.md
@@ -24,7 +24,7 @@ Programs are loaded onto the pca10040 board using the `nrfjprog` command line ut
 
 First install the J-Link Software and Documentation Pack from Segger: [https://www.segger.com/downloads/jlink/#J-LinkSoftwareAndDocumentationPack](https://www.segger.com/downloads/jlink/#J-LinkSoftwareAndDocumentationPack)
 
-Then install the nRF5x Command-Line Tools: [https://docs.zephyrproject.org/latest/guides/tools/nordic_segger.html#nordic-segger](https://docs.zephyrproject.org/latest/guides/tools/nordic_segger.html#nordic-segger)
+Then install the nRF5x Command-Line Tools: [https://docs.zephyrproject.org/latest/guides/tools/nordic_segger.html#nrf5x-command-line-tools-installation](https://docs.zephyrproject.org/latest/guides/tools/nordic_segger.html#nrf5x-command-line-tools-installation)
 
 Once you have installed both of these correctly, you will be able to flash the pca10040 board with your TinyGo code.
 

--- a/content/microcontrollers/pca10040.md
+++ b/content/microcontrollers/pca10040.md
@@ -24,7 +24,7 @@ Programs are loaded onto the pca10040 board using the `nrfjprog` command line ut
 
 First install the J-Link Software and Documentation Pack from Segger: [https://www.segger.com/downloads/jlink/#J-LinkSoftwareAndDocumentationPack](https://www.segger.com/downloads/jlink/#J-LinkSoftwareAndDocumentationPack)
 
-Then install the nRF5x Command-Line Tools: [https://docs.zephyrproject.org/latest/tools/nordic_segger.html#nordic-segger](https://docs.zephyrproject.org/latest/tools/nordic_segger.html#nordic-segger)
+Then install the nRF5x Command-Line Tools: [https://docs.zephyrproject.org/latest/guides/tools/nordic_segger.html#nordic-segger](https://docs.zephyrproject.org/latest/guides/tools/nordic_segger.html#nordic-segger)
 
 Once you have installed both of these correctly, you will be able to flash the pca10040 board with your TinyGo code.
 

--- a/content/microcontrollers/pca10056.md
+++ b/content/microcontrollers/pca10056.md
@@ -24,7 +24,7 @@ Programs are loaded onto the pca10056 board using the `nrfjprog` command line ut
 
 First install the J-Link Software and Documentation Pack from Segger: [https://www.segger.com/downloads/jlink/#J-LinkSoftwareAndDocumentationPack](https://www.segger.com/downloads/jlink/#J-LinkSoftwareAndDocumentationPack)
 
-Then install the nRF5x Command-Line Tools: [https://docs.zephyrproject.org/latest/guides/tools/nordic_segger.html#nordic-segger](https://docs.zephyrproject.org/latest/guides/tools/nordic_segger.html#nordic-segger)
+Then install the nRF5x Command-Line Tools: [https://docs.zephyrproject.org/latest/guides/tools/nordic_segger.html#nrf5x-command-line-tools-installation](https://docs.zephyrproject.org/latest/guides/tools/nordic_segger.html#nrf5x-command-line-tools-installation)
 
 Once you have installed both of these correctly, you will be able to flash the pca10056 board with your TinyGo code.
 

--- a/content/microcontrollers/pca10056.md
+++ b/content/microcontrollers/pca10056.md
@@ -24,7 +24,7 @@ Programs are loaded onto the pca10056 board using the `nrfjprog` command line ut
 
 First install the J-Link Software and Documentation Pack from Segger: [https://www.segger.com/downloads/jlink/#J-LinkSoftwareAndDocumentationPack](https://www.segger.com/downloads/jlink/#J-LinkSoftwareAndDocumentationPack)
 
-Then install the nRF5x Command-Line Tools: [https://docs.zephyrproject.org/latest/tools/nordic_segger.html#nordic-segger](https://docs.zephyrproject.org/latest/tools/nordic_segger.html#nordic-segger)
+Then install the nRF5x Command-Line Tools: [https://docs.zephyrproject.org/latest/guides/tools/nordic_segger.html#nordic-segger](https://docs.zephyrproject.org/latest/guides/tools/nordic_segger.html#nordic-segger)
 
 Once you have installed both of these correctly, you will be able to flash the pca10056 board with your TinyGo code.
 


### PR DESCRIPTION
I followed the link and it returned a 404, found the new URL in their docs