### PR TITLE
compiler-internals: add page on interrupts

### DIFF
--- a/content/compiler-internals/calling-convention.md
+++ b/content/compiler-internals/calling-convention.md
@@ -1,6 +1,6 @@
 ---
 title: "Calling convention"
-weight: 4
+weight: 7
 ---
 
 Go uses a stack-based calling convention and passes a pointer to the argument list as the first argument in the function. There were/are [plans to switch to a register-based calling convention](https://github.com/golang/go/issues/18597) but they're now on hold.

--- a/content/compiler-internals/calling-convention.md
+++ b/content/compiler-internals/calling-convention.md
@@ -28,7 +28,7 @@ TinyGo, however, uses a register based calling convention. In fact it is somewha
 
     This is the calling convention as implemented by LLVM, with the extension that `i64` return values are returned in the same way as aggregate types.
 
-  * Non-exported functions have two extra `i8` (roughly equivalent to
+  * Non-exported functions have two extra `i8*` (roughly equivalent to
     `unsafe.Pointer`) parameters appended at the end of the argument list. The
     first extra parameter is the context for when the function is a function
     pointer. If it is known not to be a closure, this value may be left

--- a/content/compiler-internals/datatypes.md
+++ b/content/compiler-internals/datatypes.md
@@ -1,6 +1,6 @@
 ---
 title: "Datatypes"
-weight: 3
+weight: 6
 ---
 
 TinyGo uses a different representation for some data types than standard Go.

--- a/content/compiler-internals/differences-from-go.md
+++ b/content/compiler-internals/differences-from-go.md
@@ -1,6 +1,6 @@
 ---
 title: "Differences from Go"
-weight: 2
+weight: 8
 ---
 
 * A whole program is compiled in a single step, without intermediate linking. This makes incremental development much slower for large programs but enables far more optimization opportunities. We are actively working on build caching so that at least part of the work does not need to be redone on every compilation.

--- a/content/compiler-internals/harvard-arch.md
+++ b/content/compiler-internals/harvard-arch.md
@@ -1,6 +1,6 @@
 ---
 title: "Harvard architectures (AVR)"
-weight: 5
+weight: 10
 ---
 
 The AVR architecture is a modified Harvard architecture, which means that flash and RAM live in different address spaces. In practice, this means that any given pointer may either point to RAM or flash, but this is not visible from the pointer itself.

--- a/content/compiler-internals/heap-allocation.md
+++ b/content/compiler-internals/heap-allocation.md
@@ -1,6 +1,6 @@
 ---
 title: "Heap allocation"
-weight: 2
+weight: 5
 ---
 
 Many operations in Go rely on heap allocation. TinyGo will try to optimize them away using escape analysis, but that is not always possible in practice.

--- a/content/compiler-internals/interrupts.md
+++ b/content/compiler-internals/interrupts.md
@@ -1,0 +1,120 @@
+---
+title: "Interrupts"
+weight: 2
+---
+
+Interrupts are crucial if you want to do anything high-performance on microcontrollers. Unfortunately, the only close substitute in the Go language ([`os/signal.Notify`](https://godoc.org/os/signal#Notify)) is rather heavyweight. Therefore TinyGo uses a simpler way to work with interrupts.
+
+Note: in most cases, you shouldn't need to work directly with interrupts. The machine package tries to abstract it away to provide a simple interface to work with. However, this page is here if you want to work on the machine package or need to override an interrupt.
+
+## Basics
+
+Interrupts are a bit like threads, but without any real concurrency. You could see them as a kind of callbacks at the hardware level.
+
+Perhaps the most simple example of an interrupt is the UART (serial) interrupt on receiving a byte. Almost every microcontroller supports this. To use it, you generally will need to take the following steps:
+
+ 1. You need to define an interrupt handler. This is a function like any other, but is somehow marked specially to function as an interrupt handler. It depends on the compiler and programming language how this is done exactly.
+ 2. You need to configure the UART to enable receive interrupts. This is a setting in the UART peripheral itself, not in the interrupt handler.
+ 3. Depending on the chip, you need to set a priority for the interrupt. Not all microcontrollers support interrupt priorities, but many (especially more advanced) do. You set this not in the peripheral but in a centralized interrupt controller.
+ 4. Finally, you need to enable the interrupt. Some very simple chips (like the AVR) do not support this: you are expected to control the interrupt by enabling/disabling interrupt sources as in step 2.
+
+TinyGo abstracts most of the complications away, but it's good to be aware of what is going on behind the scenes.
+
+## Example
+
+The following is an example of how interrupts work:
+
+```go
+func (uart UART) Configure(config UARTConfig) {
+	// [...] other configuration
+
+	// Enable the receive interrupt (step 2).
+	// What the below line does is that it enables exactly one interrupt source
+	// in the UART: the RXDRDY (RX ready) source. Enabling this makes sure the
+	// interrupt is triggered whenever a byte is received in the UART.
+	nrf.UART0.INTENSET.Set(nrf.UART_INTENSET_RXDRDY_Msk)
+	
+	// Register a new interrupt handler (step 1). This is the TinyGo way of
+	// saying to the compiler that the UART0.handleInterrupt function is
+	// special and should be called whenever the UART0 interrupt is triggered.
+	intr := interrupt.New(nrf.IRQ_UART0, UART0.handleInterrupt)
+
+	// Now we have a handle to the interrupt. The default on this chip is the
+	// highest possible priority. We'd like to set the UART to a lower
+	// priority, which we do here. The magic constant here will in a future
+	// version be replaced with a regular constant for a low-priority
+	// interrupt.
+	intr.SetPriority(0xc0)
+
+	// Finally, the interrupt must be enabled. Without this, the interrupt will
+	// still be triggered but the handler will never be called.
+	intr.Enable()
+}
+
+// This is the function that will be called. As a convenience, the interrupt
+// handle is also provided as a parameter but you can usually ignore it.
+func (uart *UART) handleInterrupt(intr interrupt.Interrupt) {
+	// Multiple interrupt sources are often mapped to a single interrupt
+	// handler. Therefore, we need to differentiate between various events.
+	// In this case, only one interrupt source has been configured so
+	// technically we could avoid this check, but it's good practice (for
+	// future changes) to check for the event anyway.
+	if nrf.UART0.EVENTS_RXDRDY.Get() != 0 {
+		// This particular chip won't retrigger the interrupt when this event
+		// is not cleared, but it won't clear the event either. So if we want
+		// to differentiate between events in the next interrupt (when this
+		// interrupt was triggered by a hypothetical other interrupt source) we
+		// need to manually clear it first.
+		nrf.UART0.EVENTS_RXDRDY.Set(0x0)
+
+		// And finally, we can receive the byte from the UART. This is done by
+		// reading the RXD register, which also has the side effect of
+		// informing the hardware that this byte has been read.
+		b := byte(nrf.UART0.RXD.Get())
+
+		// Now do whatever you'd like with the just received byte.
+		uart.Receive(b)
+	}
+}
+```
+
+
+## Troubleshooting
+
+### The interrupt won't fire
+
+  * Check that you have enabled the interrupt source in the peripheral (step 2).
+  * Check that you have enabled the interrupt with the `intr.Enable()` call (step 4).
+  * Check that you are listening for the correct interrupt and not for an interrupt for a different peripheral, for example (step 1).
+
+### The interrupt keeps firing
+
+Depending on the chip family, you may need to clear an interrupt source. This is for example the case in the Microchip SAM family of microcontrollers. If you don't do this, the interrupt will fire continuously thinking it still needs to be handled even though you have long since handled the interrupt.
+
+### I get a compile error
+
+You may get a compile error like the following:
+
+```text
+src/machine/machine_nrf.go:91:23: closures are not supported in interrupt.New
+```
+
+This could mean several things:
+
+  * If you're passing an inline function closure to `interrupt.New`, you are not allowed to use variables from the outer scope. However, global variables are fine.
+  * If you're passing a bound method, make sure the method has a function receiver. That is, define the interrupt handler like so:
+    
+    ```go
+    func (uart *UART) handleInterrupt(intr interrupt.Interrupt) { ... }
+    ```
+    
+    instead of like so:
+    
+    ```go
+    // this won't compile
+    func (uart UART) handleInterrupt(intr interrupt.Interrupt) { ... }
+    ```
+    
+    The reason is that the latter will actually make a copy of the UART variable to be stored with the interrupt, which is currently not supported in the compiler and will lead to reduced performance even when it becomes supported.
+    
+    Additionally, make sure the variable you're binding to is a global variable instead of a local variable.

--- a/content/compiler-internals/microcontrollers.md
+++ b/content/compiler-internals/microcontrollers.md
@@ -1,6 +1,6 @@
 ---
 title: "Microcontroller Targets"
-weight: 5
+weight: 1
 ---
 
 TinyGo was designed to run on microcontrollers, but the Go language wasn't. This means there are a few challenges to writing Go code for microcontrollers.

--- a/content/compiler-internals/pipeline.md
+++ b/content/compiler-internals/pipeline.md
@@ -1,6 +1,6 @@
 ---
 title: "Pipeline"
-weight: 5
+weight: 11
 ---
 
 Like most compilers, TinyGo is a compiler built as a pipeline of transformations

--- a/content/faq/why-a-new-compiler.md
+++ b/content/faq/why-a-new-compiler.md
@@ -25,7 +25,7 @@ Of course, it is possible to use ``gccgo``, but that has different problems (see
 
 * The standard Go compilers do a few special things for CGo calls. This is necessary because only Go code can use the (small) Go stack while C code will need a much bigger stack. A new compiler can avoid this limitation if it ensures stacks are big enough for C, greatly reducing the C ↔ Go calling overhead.
 
-[At one point](https://github.com/tinygo-org/tinygo-gccgo), a real Go compiler had been used to produce binaries for various platforms, and the result was painful enough to start writing a new compiler:
+[At one point](https://github.com/aykevl/tinygo-gccgo), a real Go compiler had been used to produce binaries for various platforms, and the result was painful enough to start writing a new compiler:
 
 * The ABI was fixed, so could not be optimized for speed. Also, the ABI didn't seem to be documented anywhere.
 


### PR DESCRIPTION
See: https://github.com/tinygo-org/tinygo/pull/782

Also reorder other pages a bit, in order from "relevant if you're doing low-level stuff as a user" to "if you want to dig deeper into the compiler".