### PR TITLE
Making GOPATH command work on newer systems

### DIFF
--- a/content/getting-started/linux.md
+++ b/content/getting-started/linux.md
@@ -146,7 +146,7 @@ Now, obtain the TinyGo source code, which should also obtain the various needed 
 
 ```shell
 go get -d -u github.com/tinygo-org/tinygo
-cd $GOPATH/src/github.com/tinygo-org/tinygo
+cd $(go env GOPATH)/src/github.com/tinygo-org/tinygo
 ```
 
 You now have two options: build LLVM manually or use a LLVM distributed with


### PR DESCRIPTION
When installing Go out of the box, setting a GOPATH isn't necessary any more, but the internal one is still being used for go get, which is in $HOME/go. To access GOPATH also when it is not set in the shell you use, use go env GOPATH instead of $GOPATH.