### PR TITLE
update link to Espressif llvm project

### DIFF
--- a/content/faq/what-about-esp8266-esp32.md
+++ b/content/faq/what-about-esp8266-esp32.md
@@ -9,6 +9,4 @@ For the discussion of this see [this forum thread](https://www.esp32.com/viewtop
 
 The repository that contains the Xtensa fork of LLVM is located at [https://github.com/espressif/llvm-project](https://github.com/espressif/llvm-project)
 
-The repository that contains the Xtensa fork of Clang is located at [https://github.com/espressif/clang-xtensa](https://github.com/espressif/clang-xtensa).
-
 It is not yet in a usable state, but once it is we will start the process of supporting it in TinyGo.

--- a/content/faq/what-about-esp8266-esp32.md
+++ b/content/faq/what-about-esp8266-esp32.md
@@ -7,7 +7,7 @@ As of February 2019 there is now an official project from Espressif to add the X
 
 For the discussion of this see [this forum thread](https://www.esp32.com/viewtopic.php?t=9226).
 
-The repository that contains the Xtensa fork of LLVM is located at [https://github.com/espressif/llvm-xtensa](https://github.com/espressif/llvm-xtensa)
+The repository that contains the Xtensa fork of LLVM is located at [https://github.com/espressif/llvm-project](https://github.com/espressif/llvm-project)
 
 The repository that contains the Xtensa fork of Clang is located at [https://github.com/espressif/clang-xtensa](https://github.com/espressif/clang-xtensa).
 


### PR DESCRIPTION
both the Clang fork and the LLVM fork archived. I updated the link to the LLVM fork.