### PR TITLE
Update arduino-nano33-iot for bossa install

### DIFF
--- a/content/microcontrollers/arduino-nano33-iot.md
+++ b/content/microcontrollers/arduino-nano33-iot.md
@@ -47,9 +47,11 @@ Once you have downloaded it, double click on the .dmg file to perform the instal
 On Linux, install from source:
 
 ```shell
+sudo apt install libreadline-dev libwxgtk3.0-* 
 git clone https://github.com/shumatech/BOSSA.git
 cd BOSSA
 make
+sudo cp bin/bossac /usr/local/bin
 ```
 
 ### Windows


### PR DESCRIPTION
Regard to https://github.com/tinygo-org/tinygo-site/issues/78.

I just added couple line for bossac installation in debian/ubuntu based system since it has some dependencies of wxgtk and readline libraries. 

But I am not sure if the originally guide was intentionally written in that simpler way for readability.
If so, please let me know and dismiss.