### PR TITLE
getting-started: add docs for building TinyGo on Windows

### DIFF
--- a/content/getting-started/linux.md
+++ b/content/getting-started/linux.md
@@ -191,9 +191,10 @@ sudo apt-get install build-essential git cmake ninja
 ```
 
 The following command takes care of downloading and building LLVM. It places the
-source code in `llvm-build/` and the build output in `llvm/`. It only needs to
-be done once until the next LLVM release. Note that the `export` lines are
-optional, but using Clang during the build speeds up the build significantly.
+source code in `llvm-project/` and the build output in `llvm-build/`. It only
+needs to be done once until the next LLVM release. Note that the `export` lines
+are optional, but using Clang during the build speeds up the build
+significantly.
 
 ```shell
 export CC=clang

--- a/content/getting-started/macos.md
+++ b/content/getting-started/macos.md
@@ -103,8 +103,8 @@ brew install cmake ninja
 ```
 
 The following command takes care of downloading and building LLVM. It places the
-source code in `llvm-build/` and the build output in `llvm/`. It only needs to
-be done once until the next LLVM release.
+source code in `llvm-project/` and the build output in `llvm-build/`. It only
+needs to be done once until the next LLVM release.
 
 ```shell
 make llvm-build

--- a/content/getting-started/windows.md
+++ b/content/getting-started/windows.md
@@ -99,4 +99,73 @@ If you want to use TinyGo to compile your own or sample code, you should be able
 
 ## Docker Install
 
-The other option is to use the Docker image. This has the benefit of making no changes to your system but has a large download and installation size. For instructions on using the Docker image, please see the page [here](../using-docker).
+Another option is to use the Docker image. This has the benefit of making no changes to your system but has a large download and installation size. For instructions on using the Docker image, please see the page [here](../using-docker).
+
+## Source Install
+
+***If you have already followed the "Windows Native Install" instructions above, you do not need to perform a source install. You are now done with the needed installation. The "Source Install" is for when you want to contribute to TinyGo.***
+
+Be warned that building TinyGo on Windows is not tested as well as building TinyGo on other operating systems (such as Linux). If you want to contribute to TinyGo but don't need to run natively on Windows, it may be easier and faster to do development within [WSL](https://docs.microsoft.com/en-us/windows/wsl/install-win10). See the [Linux page](../linux) for how to build TinyGo on Linux.
+
+### Dependencies
+
+You will need to have the following programs installed on your Windows system and configured to be accessible in your PATH variable:
+
+  * Git
+  * Go 1.14
+  * MinGW-w64
+  * GNU Make
+  * CMake
+  * Ninja
+  * Python
+
+The easiest way to install all these dependencies is through [Chocolatey](https://chocolatey.org/). Install Chocolatey first, and then run the following command in a command prompt or PowerShell with administrative privileges:
+
+    choco install --confirm git golang mingw make cmake ninja python
+
+Now open a Git Bash window for the remaining steps. The Git Bash window provides a Bash shell with some standard Unix utilities for convenience.
+
+The first thing to do is download the source code:
+
+```shell
+git clone --recursive https://github.com/tinygo-org/tinygo.git
+cd tinygo
+```
+
+Unfortunately there is no way to use a binary release of LLVM to build against (like on Linux and MacOS) so we'll have to build LLVM from scratch. This is a long process which takes at least one hour on most machines.
+
+The following command takes care of downloading and building LLVM. It places the
+source code in `llvm-project/` and the build output in `llvm-build/`. It only needs to
+be done once until the next LLVM release.
+
+```shell
+make llvm-build
+```
+
+Once this is finished, you can build TinyGo against this manually built LLVM:
+
+```shell
+make
+```
+
+This results in a `tinygo.exe` binary in the `build` directory:
+
+```text
+$ ./build/tinygo version
+tinygo version 0.13.1 windows/amd64 (using go version go1.14.1 and LLVM version 10.0.1)
+```
+
+### Additional Requirements for Microcontrollers
+
+Before anything can be built for a bare-metal target, you need to generate some
+files first:
+
+```shell
+make gen-device
+```
+
+This will generate register descriptions, interrupt vectors, and linker scripts
+for various devices. Also, you may need to re-run this command after updates,
+as some updates cause changes to the generated files.
+
+The same additional requirements to compile TinyGo programs that can run on microcontrollers must be fulfilled when installing TinyGo from source. Please follow [these instructions](#additional-requirements-for-microcontrollers) above.


### PR DESCRIPTION
This is probably missing something but it's better than nothing. Most importantly: it may require adding some paths to the `Path` environment variable and I'm not entirely sure whether MinGW-w64 works (but installing MinGW-w64 is easier than TDM-GCC which I did test). I think it should work because MinGW is installed on the hosted Azure CI agents.

I've also fixed some errors in the macos and linux guide.

EDIT: also note that this was my first time successfully building TinyGo on Windows. Previously I always did it on Azure CI.