### PR TITLE
Update `CLI Flashing on Windows`

### DIFF
--- a/content/microcontrollers/arduino-nano33-iot.md
+++ b/content/microcontrollers/arduino-nano33-iot.md
@@ -101,8 +101,6 @@ Once you have installed the needed BOSSA command line utility, as in the previou
 ### CLI Flashing on Windows
 
 - Plug your Arduino Nano33 IoT board into your computer's USB port.
-- Double tap the "RESET" button on the board.
-- Wait until the Arduino Nano33 IoT board appears as a serial drive.
 - Build and flash your TinyGo code using the `tinygo flash` command. This command flashes the Arduino Nano33 IoT with the blinky1 example:
 
     ```

--- a/content/microcontrollers/circuit-playground-bluefruit.md
+++ b/content/microcontrollers/circuit-playground-bluefruit.md
@@ -51,8 +51,6 @@ The Circuit Playground Bluefruit comes with the [UF2 bootloader](https://github.
 ### CLI Flashing on Windows
 
 - Plug your Circuit Playground Bluefruit into your computer's USB port.
-- Double tap the "RESET" button on the board.
-- Wait until the Circuit Playground Bluefruit board appears as a flash drive.
 - Flash your TinyGo program to the board using this command:
 
     ```shell

--- a/content/microcontrollers/circuit-playground-express.md
+++ b/content/microcontrollers/circuit-playground-express.md
@@ -51,8 +51,6 @@ The Circuit Playground Express comes with the [UF2 bootloader](https://github.co
 ### CLI Flashing on Windows
 
 - Plug your Circuit Playground Express into your computer's USB port.
-- Double tap the "RESET" button on the board.
-- Wait until the Circuit Playground Express board appears as a flash drive.
 - Flash your TinyGo program to the board using this command:
 
     ```shell

--- a/content/microcontrollers/clue-alpha.md
+++ b/content/microcontrollers/clue-alpha.md
@@ -51,8 +51,6 @@ The CLUE comes with the [UF2 bootloader](https://github.com/Microsoft/uf2) alrea
 ### CLI Flashing on Windows
 
 - Plug your CLUE into your computer's USB port.
-- Double tap the "RESET" button on the board.
-- Wait until the CLUE board appears as a flash drive.
 - Flash your TinyGo program to the board using this command:
 
     ```shell

--- a/content/microcontrollers/feather-m0.md
+++ b/content/microcontrollers/feather-m0.md
@@ -51,8 +51,6 @@ The Feather M0 comes with the [UF2 bootloader](https://github.com/Microsoft/uf2)
 ### CLI Flashing on Windows
 
 - Plug your Feather M0 into your computer's USB port.
-- Double tap the "RESET" button on the board.
-- Wait until the Feather M0 board appears as a flash drive.
 - Flash your TinyGo program to the board using this command:
 
     ```shell

--- a/content/microcontrollers/feather-m4.md
+++ b/content/microcontrollers/feather-m4.md
@@ -51,8 +51,6 @@ The Feather M4 comes with the [UF2 bootloader](https://github.com/Microsoft/uf2)
 ### CLI Flashing on Windows
 
 - Plug your Feather M4 into your computer's USB port.
-- Double tap the "RESET" button on the board.
-- Wait until the Feather M4 board appears as a flash drive.
 - Flash your TinyGo program to the board using this command:
 
     ```shell

--- a/content/microcontrollers/itsybitsy-m0.md
+++ b/content/microcontrollers/itsybitsy-m0.md
@@ -51,8 +51,6 @@ The ItsyBitsy M0 comes with the [UF2 bootloader](https://github.com/Microsoft/uf
 ### CLI Flashing on Windows
 
 - Plug your ItsyBitsy M0 into your computer's USB port.
-- Double tap the "RESET" button on the board.
-- Wait until the ItsyBitsy M0 board appears as a flash drive.
 - Flash your TinyGo program to the board using this command:
 
     ```shell

--- a/content/microcontrollers/itsybitsy-m4.md
+++ b/content/microcontrollers/itsybitsy-m4.md
@@ -51,8 +51,6 @@ The ItsyBitsy M4 comes with the [UF2 bootloader](https://github.com/Microsoft/uf
 ### CLI Flashing on Windows
 
 - Plug your ItsyBitsy M4 into your computer's USB port.
-- Double tap the "RESET" button on the board.
-- Wait until the ItsyBitsy M4 board appears as a flash drive.
 - Flash your TinyGo program to the board using this command:
 
     ```shell

--- a/content/microcontrollers/metro-m4-airlift.md
+++ b/content/microcontrollers/metro-m4-airlift.md
@@ -51,8 +51,6 @@ The Metro M4 Express comes with the [UF2 bootloader](https://github.com/Microsof
 ### CLI Flashing on Windows
 
 - Plug your Metro M4 Express into your computer's USB port.
-- Double tap the "RESET" button on the board.
-- Wait until the Metro M4 Express board appears as a flash drive.
 - Flash your TinyGo program to the board using this command:
 
     ```shell

--- a/content/microcontrollers/pybadge.md
+++ b/content/microcontrollers/pybadge.md
@@ -53,8 +53,6 @@ The PyBadge comes with the [UF2 bootloader](https://github.com/Microsoft/uf2) al
 ### CLI Flashing on Windows
 
 - Plug your PyBadge into your computer's USB port.
-- Double tap the "RESET" button on the board.
-- Wait until the PyBadge board appears as a flash drive.
 - Flash your TinyGo program to the board using this command:
 
     ```shell

--- a/content/microcontrollers/pyportal.md
+++ b/content/microcontrollers/pyportal.md
@@ -53,8 +53,6 @@ The PyPortal comes with the [UF2 bootloader](https://github.com/Microsoft/uf2) a
 ### CLI Flashing on Windows
 
 - Plug your PyPortal into your computer's USB port.
-- Double tap the "RESET" button on the board.
-- Wait until the PyPortal board appears as a flash drive.
 - Flash your TinyGo program to the board using this command:
 
     ```shell

--- a/content/microcontrollers/trinket-m0.md
+++ b/content/microcontrollers/trinket-m0.md
@@ -51,8 +51,6 @@ The Trinket M0 comes with the [UF2 bootloader](https://github.com/Microsoft/uf2)
 ### CLI Flashing on Windows
 
 - Plug your Trinket M0 into your computer's USB port.
-- Double tap the "RESET" button on the board.
-- Wait until the Trinket M0 board appears as a flash drive.
 - Flash your TinyGo program to the board using this command:
 
     ```shell


### PR DESCRIPTION
The following changes make the CLI Flash method on Windows the same as
on other operating systems (linux, macOS).

https://github.com/tinygo-org/tinygo/pull/1084
https://github.com/tinygo-org/tinygo/pull/1085