### PR TITLE
all: changeover to eliminate all direct use of master/slave terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Once the site code is running locally, you can navigate to it by going to http:/
 
 ## Deploy to Netlify
 
-Pushing to the `master` branch automatically deploys the latest site to Netlify.
+Pushing to the `release` branch automatically deploys the latest site to Netlify.
 
 That's it.
 

--- a/config.toml
+++ b/config.toml
@@ -8,7 +8,7 @@ theme = "learn"
 themeVariant = "blue"
 # Disable search function. It will hide search bar
 disableSearch = true
-editURL = "https://github.com/tinygo-org/tinygo-site/edit/master/content/"
+editURL = "https://github.com/tinygo-org/tinygo-site/edit/release/content/"
 disableInlineCopyToClipBoard = true
 
 [[menu.shortcuts]] 

--- a/content/compiler-internals/datatypes.md
+++ b/content/compiler-internals/datatypes.md
@@ -6,10 +6,10 @@ weight: 6
 TinyGo uses a different representation for some data types than standard Go.
 
 ### string
-A string is encoded as a `{ptr, len}` tuple. The type is actually defined in the runtime as `runtime._string`, in [src/runtime/string.go](https://github.com/tinygo-org/tinygo/blob/master/src/runtime/string.go). That file also contains some compiler intrinsics for dealing with strings and UTF-8.
+A string is encoded as a `{ptr, len}` tuple. The type is actually defined in the runtime as `runtime._string`, in [src/runtime/string.go](https://github.com/tinygo-org/tinygo/blob/release/src/runtime/string.go). That file also contains some compiler intrinsics for dealing with strings and UTF-8.
 
 ### slice
-A slice is encoded as a `{ptr, len, cap}` tuple. There is no runtime definition of it as slices are a generic type and the pointer type is different for each slice. That said, the bit layout is exactly the same for every slice and generic `copy` and `append` functions are implemented in [src/runtime/slice.go](https://github.com/tinygo-org/tinygo/blob/master/src/runtime/slice.go).
+A slice is encoded as a `{ptr, len, cap}` tuple. There is no runtime definition of it as slices are a generic type and the pointer type is different for each slice. That said, the bit layout is exactly the same for every slice and generic `copy` and `append` functions are implemented in [src/runtime/slice.go](https://github.com/tinygo-org/tinygo/blob/release/src/runtime/slice.go).
 
 ### array
 Arrays are simple: they are simply lowered to a LLVM array type.
@@ -18,10 +18,10 @@ Arrays are simple: they are simply lowered to a LLVM array type.
 Complex numbers are implemented the same way as Clang implements them: as a struct with two `float32` or `float64` elements.
 
 ### map
-The map type is a very complex type and is implemented as an (incomplete) hashmap. It is defined as `runtime.hashmap` in [src/runtime/hashmap.go](https://github.com/tinygo-org/tinygo/blob/master/src/runtime/hashmap.go). As maps are reference types, they are lowered to a pointer to the aforementioned struct. See for example `runtime.hashmapMake` that is the compiler intrinsic to create a new hashmap.
+The map type is a very complex type and is implemented as an (incomplete) hashmap. It is defined as `runtime.hashmap` in [src/runtime/hashmap.go](https://github.com/tinygo-org/tinygo/blob/release/src/runtime/hashmap.go). As maps are reference types, they are lowered to a pointer to the aforementioned struct. See for example `runtime.hashmapMake` that is the compiler intrinsic to create a new hashmap.
 
 ### interface
-An interface is a `{typecode, value}` tuple and is defined as `runtime._interface` in [src/runtime/interface.go](https://github.com/tinygo-org/tinygo/blob/master/src/runtime/interface.go). The typecode is a small integer unique to the type of the value. See interface.go for a detailed description of how typeasserts and interface calls are implemented.
+An interface is a `{typecode, value}` tuple and is defined as `runtime._interface` in [src/runtime/interface.go](https://github.com/tinygo-org/tinygo/blob/release/src/runtime/interface.go). The typecode is a small integer unique to the type of the value. See interface.go for a detailed description of how typeasserts and interface calls are implemented.
 
 ### function value
 A function value is a fat function pointer in the form of `{context, function
@@ -32,5 +32,5 @@ may be a real pointer or an arbitrary number, depending on the target platform.
 ### goroutine
 Goroutines are implemented differently depending on the platform.
 
-  * For most platforms, it is implemented as a linked list of [LLVM coroutines](https://llvm.org/docs/Coroutines.html). Every blocking call will create a new coroutine and pass itself to the coroutine as a parameter (see [calling convention]({{<ref "calling-convention.md">}})). The callee then re-activates the caller once it would otherwise return to the parent.  Non-blocking calls are normal calls, unaware of the fact that they're running on a particular goroutine. For details, see [src/runtime/scheduler.go](https://github.com/tinygo-org/tinygo/blob/master/src/runtime/scheduler.go). This is rather expensive but has the advantage of being portable and requiring only a single stack.
+  * For most platforms, it is implemented as a linked list of [LLVM coroutines](https://llvm.org/docs/Coroutines.html). Every blocking call will create a new coroutine and pass itself to the coroutine as a parameter (see [calling convention]({{<ref "calling-convention.md">}})). The callee then re-activates the caller once it would otherwise return to the parent.  Non-blocking calls are normal calls, unaware of the fact that they're running on a particular goroutine. For details, see [src/runtime/scheduler.go](https://github.com/tinygo-org/tinygo/blob/release/src/runtime/scheduler.go). This is rather expensive but has the advantage of being portable and requiring only a single stack.
   * For Cortex-M (which includes most supported microcontrollers as of this time), a real stack is allocated and scheduling happens much like the main Go implementation by saving and restoring registers in assembly.

--- a/content/compiler-internals/pipeline.md
+++ b/content/compiler-internals/pipeline.md
@@ -28,7 +28,7 @@ This is roughly the pipeline for TinyGo:
   * Go does a lot of initialization at runtime, which is really bad for
     code size. This includes all global variables: they are all initialized at
     runtime, not at compile time like C. So TinyGo
-    [interprets these functions at compile time](https://github.com/tinygo-org/tinygo/tree/master/interp)
+    [interprets these functions at compile time](https://github.com/tinygo-org/tinygo/tree/release/interp)
     as far as it is able to.
   * The resulting IR is then first optimized by a mixture of handpicked LLVM
     optimization passes, TinyGo-specific

--- a/content/microcontrollers/arduino-nano33-iot.md
+++ b/content/microcontrollers/arduino-nano33-iot.md
@@ -126,4 +126,4 @@ Once you have updated your Arduino Nano33 IoT board the first time, after that y
 
 You can use the USB port to the Arduino Nano33 IoT as a serial port. `UART0` refers to this connection.
 
-For information on how to use the built-in NINA-W102 wireless chip, please see the "espat" driver in the TinyGo drivers repository located at [https://github.com/tinygo-org/drivers/tree/master/espat](https://github.com/tinygo-org/drivers/tree/master/espat).
+For information on how to use the built-in NINA-W102 wireless chip, please see the "espat" driver in the TinyGo drivers repository located at [https://github.com/tinygo-org/drivers/tree/release/espat](https://github.com/tinygo-org/drivers/tree/release/espat).

--- a/content/microcontrollers/circuit-playground-bluefruit.md
+++ b/content/microcontrollers/circuit-playground-bluefruit.md
@@ -77,6 +77,6 @@ Once you have updated your Circuit Playground Bluefruit board the first time, af
 
 You can use the USB port to the Circuit Playground Bluefruit as a serial port. `UART0` refers to this connection.
 
-For an example that uses the built-in Neopixel LEDs, take a look at the TinyGo drivers repository located at [https://github.com/tinygo-org/drivers/tree/master/examples](https://github.com/tinygo-org/drivers)
+For an example that uses the built-in Neopixel LEDs, take a look at the TinyGo drivers repository located at [https://github.com/tinygo-org/drivers/tree/release/examples](https://github.com/tinygo-org/drivers)
 
 Bluetooth support is also in development but not yet completed.

--- a/content/microcontrollers/circuit-playground-express.md
+++ b/content/microcontrollers/circuit-playground-express.md
@@ -77,4 +77,4 @@ Once you have updated your Circuit Playground Express board the first time, afte
 
 You can use the USB port to the Circuit Playground Express as a serial port. `UART0` refers to this connection.
 
-For an example that uses the built-in Neopixel LEDs, take a look at the TinyGo drivers repository located at [https://github.com/tinygo-org/drivers/tree/master/examples](https://github.com/tinygo-org/drivers)
+For an example that uses the built-in Neopixel LEDs, take a look at the TinyGo drivers repository located at [https://github.com/tinygo-org/drivers/tree/release/examples](https://github.com/tinygo-org/drivers)

--- a/content/microcontrollers/clue-alpha.md
+++ b/content/microcontrollers/clue-alpha.md
@@ -77,6 +77,6 @@ Once you have updated your CLUE board the first time, after that you should be a
 
 You can use the USB port to the CLUE as a serial port. `UART0` refers to this connection.
 
-For an example that uses the built-in Neopixel LEDs, take a look at the TinyGo drivers repository located at [https://github.com/tinygo-org/drivers/tree/master/examples](https://github.com/tinygo-org/drivers)
+For an example that uses the built-in Neopixel LEDs, take a look at the TinyGo drivers repository located at [https://github.com/tinygo-org/drivers/tree/release/examples](https://github.com/tinygo-org/drivers)
 
 Bluetooth support is in development but not yet completed.

--- a/static/x/drivers/adt7410/index.html
+++ b/static/x/drivers/adt7410/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 <meta name="go-import" content="tinygo.org/x/drivers git https://github.com/tinygo-org/drivers">
-<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/master{/dir} https://github.com/tinygo-org/drivers/blob/master{/dir}/{file}#L{line}">
+<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/release{/dir} https://github.com/tinygo-org/drivers/blob/release{/dir}/{file}#L{line}">
 <meta http-equiv="refresh" content="0; url=https://tinygo.org/">
 </head>
 <body>

--- a/static/x/drivers/adxl345/index.html
+++ b/static/x/drivers/adxl345/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 <meta name="go-import" content="tinygo.org/x/drivers git https://github.com/tinygo-org/drivers">
-<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/master{/dir} https://github.com/tinygo-org/drivers/blob/master{/dir}/{file}#L{line}">
+<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/release{/dir} https://github.com/tinygo-org/drivers/blob/release{/dir}/{file}#L{line}">
 <meta http-equiv="refresh" content="0; url=https://tinygo.org/">
 </head>
 <body>

--- a/static/x/drivers/apa102/index.html
+++ b/static/x/drivers/apa102/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 <meta name="go-import" content="tinygo.org/x/drivers git https://github.com/tinygo-org/drivers">
-<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/master{/dir} https://github.com/tinygo-org/drivers/blob/master{/dir}/{file}#L{line}">
+<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/release{/dir} https://github.com/tinygo-org/drivers/blob/release{/dir}/{file}#L{line}">
 <meta http-equiv="refresh" content="0; url=https://tinygo.org/">
 </head>
 <body>

--- a/static/x/drivers/at24cx/index.html
+++ b/static/x/drivers/at24cx/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 <meta name="go-import" content="tinygo.org/x/drivers git https://github.com/tinygo-org/drivers">
-<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/master{/dir} https://github.com/tinygo-org/drivers/blob/master{/dir}/{file}#L{line}">
+<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/release{/dir} https://github.com/tinygo-org/drivers/blob/release{/dir}/{file}#L{line}">
 <meta http-equiv="refresh" content="0; url=https://tinygo.org/">
 </head>
 <body>

--- a/static/x/drivers/bh1750/index.html
+++ b/static/x/drivers/bh1750/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 <meta name="go-import" content="tinygo.org/x/drivers git https://github.com/tinygo-org/drivers">
-<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/master{/dir} https://github.com/tinygo-org/drivers/blob/master{/dir}/{file}#L{line}">
+<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/release{/dir} https://github.com/tinygo-org/drivers/blob/release{/dir}/{file}#L{line}">
 <meta http-equiv="refresh" content="0; url=https://tinygo.org/">
 </head>
 <body>

--- a/static/x/drivers/blinkm/index.html
+++ b/static/x/drivers/blinkm/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 <meta name="go-import" content="tinygo.org/x/drivers git https://github.com/tinygo-org/drivers">
-<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/master{/dir} https://github.com/tinygo-org/drivers/blob/master{/dir}/{file}#L{line}">
+<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/release{/dir} https://github.com/tinygo-org/drivers/blob/release{/dir}/{file}#L{line}">
 <meta http-equiv="refresh" content="0; url=https://tinygo.org/">
 </head>
 <body>

--- a/static/x/drivers/bme280/index.html
+++ b/static/x/drivers/bme280/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 <meta name="go-import" content="tinygo.org/x/drivers git https://github.com/tinygo-org/drivers">
-<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/master{/dir} https://github.com/tinygo-org/drivers/blob/master{/dir}/{file}#L{line}">
+<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/release{/dir} https://github.com/tinygo-org/drivers/blob/release{/dir}/{file}#L{line}">
 <meta http-equiv="refresh" content="0; url=https://tinygo.org/">
 </head>
 <body>

--- a/static/x/drivers/bmp180/index.html
+++ b/static/x/drivers/bmp180/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 <meta name="go-import" content="tinygo.org/x/drivers git https://github.com/tinygo-org/drivers">
-<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/master{/dir} https://github.com/tinygo-org/drivers/blob/master{/dir}/{file}#L{line}">
+<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/release{/dir} https://github.com/tinygo-org/drivers/blob/release{/dir}/{file}#L{line}">
 <meta http-equiv="refresh" content="0; url=https://tinygo.org/">
 </head>
 <body>

--- a/static/x/drivers/buzzer/index.html
+++ b/static/x/drivers/buzzer/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 <meta name="go-import" content="tinygo.org/x/drivers git https://github.com/tinygo-org/drivers">
-<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/master{/dir} https://github.com/tinygo-org/drivers/blob/master{/dir}/{file}#L{line}">
+<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/release{/dir} https://github.com/tinygo-org/drivers/blob/release{/dir}/{file}#L{line}">
 <meta http-equiv="refresh" content="0; url=https://tinygo.org/">
 </head>
 <body>

--- a/static/x/drivers/ds1307/index.html
+++ b/static/x/drivers/ds1307/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 <meta name="go-import" content="tinygo.org/x/drivers git https://github.com/tinygo-org/drivers">
-<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/master{/dir} https://github.com/tinygo-org/drivers/blob/master{/dir}/{file}#L{line}">
+<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/release{/dir} https://github.com/tinygo-org/drivers/blob/release{/dir}/{file}#L{line}">
 <meta http-equiv="refresh" content="0; url=https://tinygo.org/">
 </head>
 <body>

--- a/static/x/drivers/ds3231/index.html
+++ b/static/x/drivers/ds3231/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 <meta name="go-import" content="tinygo.org/x/drivers git https://github.com/tinygo-org/drivers">
-<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/master{/dir} https://github.com/tinygo-org/drivers/blob/master{/dir}/{file}#L{line}">
+<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/release{/dir} https://github.com/tinygo-org/drivers/blob/release{/dir}/{file}#L{line}">
 <meta http-equiv="refresh" content="0; url=https://tinygo.org/">
 </head>
 <body>

--- a/static/x/drivers/easystepper/index.html
+++ b/static/x/drivers/easystepper/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 <meta name="go-import" content="tinygo.org/x/drivers git https://github.com/tinygo-org/drivers">
-<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/master{/dir} https://github.com/tinygo-org/drivers/blob/master{/dir}/{file}#L{line}">
+<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/release{/dir} https://github.com/tinygo-org/drivers/blob/release{/dir}/{file}#L{line}">
 <meta http-equiv="refresh" content="0; url=https://tinygo.org/">
 </head>
 <body>

--- a/static/x/drivers/espat/index.html
+++ b/static/x/drivers/espat/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 <meta name="go-import" content="tinygo.org/x/drivers git https://github.com/tinygo-org/drivers">
-<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/master{/dir} https://github.com/tinygo-org/drivers/blob/master{/dir}/{file}#L{line}">
+<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/release{/dir} https://github.com/tinygo-org/drivers/blob/release{/dir}/{file}#L{line}">
 <meta http-equiv="refresh" content="0; url=https://tinygo.org/">
 </head>
 <body>

--- a/static/x/drivers/espat/mqtt/index.html
+++ b/static/x/drivers/espat/mqtt/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 <meta name="go-import" content="tinygo.org/x/drivers git https://github.com/tinygo-org/drivers">
-<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/master{/dir} https://github.com/tinygo-org/drivers/blob/master{/dir}/{file}#L{line}">
+<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/release{/dir} https://github.com/tinygo-org/drivers/blob/release{/dir}/{file}#L{line}">
 <meta http-equiv="refresh" content="0; url=https://tinygo.org/">
 </head>
 <body>

--- a/static/x/drivers/espat/net/index.html
+++ b/static/x/drivers/espat/net/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 <meta name="go-import" content="tinygo.org/x/drivers git https://github.com/tinygo-org/drivers">
-<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/master{/dir} https://github.com/tinygo-org/drivers/blob/master{/dir}/{file}#L{line}">
+<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/release{/dir} https://github.com/tinygo-org/drivers/blob/release{/dir}/{file}#L{line}">
 <meta http-equiv="refresh" content="0; url=https://tinygo.org/">
 </head>
 <body>

--- a/static/x/drivers/espat/tls/index.html
+++ b/static/x/drivers/espat/tls/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 <meta name="go-import" content="tinygo.org/x/drivers git https://github.com/tinygo-org/drivers">
-<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/master{/dir} https://github.com/tinygo-org/drivers/blob/master{/dir}/{file}#L{line}">
+<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/release{/dir} https://github.com/tinygo-org/drivers/blob/release{/dir}/{file}#L{line}">
 <meta http-equiv="refresh" content="0; url=https://tinygo.org/">
 </head>
 <body>

--- a/static/x/drivers/gps/index.html
+++ b/static/x/drivers/gps/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 <meta name="go-import" content="tinygo.org/x/drivers git https://github.com/tinygo-org/drivers">
-<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/master{/dir} https://github.com/tinygo-org/drivers/blob/master{/dir}/{file}#L{line}">
+<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/release{/dir} https://github.com/tinygo-org/drivers/blob/release{/dir}/{file}#L{line}">
 <meta http-equiv="refresh" content="0; url=https://tinygo.org/">
 </head>
 <body>

--- a/static/x/drivers/hd44780/index.html
+++ b/static/x/drivers/hd44780/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 <meta name="go-import" content="tinygo.org/x/drivers git https://github.com/tinygo-org/drivers">
-<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/master{/dir} https://github.com/tinygo-org/drivers/blob/master{/dir}/{file}#L{line}">
+<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/release{/dir} https://github.com/tinygo-org/drivers/blob/release{/dir}/{file}#L{line}">
 <meta http-equiv="refresh" content="0; url=https://tinygo.org/">
 </head>
 <body>

--- a/static/x/drivers/hub75/index.html
+++ b/static/x/drivers/hub75/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 <meta name="go-import" content="tinygo.org/x/drivers git https://github.com/tinygo-org/drivers">
-<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/master{/dir} https://github.com/tinygo-org/drivers/blob/master{/dir}/{file}#L{line}">
+<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/release{/dir} https://github.com/tinygo-org/drivers/blob/release{/dir}/{file}#L{line}">
 <meta http-equiv="refresh" content="0; url=https://tinygo.org/">
 </head>
 <body>

--- a/static/x/drivers/ili9341/index.html
+++ b/static/x/drivers/ili9341/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 <meta name="go-import" content="tinygo.org/x/drivers git https://github.com/tinygo-org/drivers">
-<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/master{/dir} https://github.com/tinygo-org/drivers/blob/master{/dir}/{file}#L{line}">
+<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/release{/dir} https://github.com/tinygo-org/drivers/blob/release{/dir}/{file}#L{line}">
 <meta http-equiv="refresh" content="0; url=https://tinygo.org/">
 </head>
 <body>

--- a/static/x/drivers/index.html
+++ b/static/x/drivers/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 <meta name="go-import" content="tinygo.org/x/drivers git https://github.com/tinygo-org/drivers">
-<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/master{/dir} https://github.com/tinygo-org/drivers/blob/master{/dir}/{file}#L{line}">
+<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/release{/dir} https://github.com/tinygo-org/drivers/blob/release{/dir}/{file}#L{line}">
 <meta http-equiv="refresh" content="0; url=https://tinygo.org/">
 </head>
 <body>

--- a/static/x/drivers/l293x/index.html
+++ b/static/x/drivers/l293x/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 <meta name="go-import" content="tinygo.org/x/drivers git https://github.com/tinygo-org/drivers">
-<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/master{/dir} https://github.com/tinygo-org/drivers/blob/master{/dir}/{file}#L{line}">
+<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/release{/dir} https://github.com/tinygo-org/drivers/blob/release{/dir}/{file}#L{line}">
 <meta http-equiv="refresh" content="0; url=https://tinygo.org/">
 </head>
 <body>

--- a/static/x/drivers/l9110x/index.html
+++ b/static/x/drivers/l9110x/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 <meta name="go-import" content="tinygo.org/x/drivers git https://github.com/tinygo-org/drivers">
-<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/master{/dir} https://github.com/tinygo-org/drivers/blob/master{/dir}/{file}#L{line}">
+<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/release{/dir} https://github.com/tinygo-org/drivers/blob/release{/dir}/{file}#L{line}">
 <meta http-equiv="refresh" content="0; url=https://tinygo.org/">
 </head>
 <body>

--- a/static/x/drivers/lis3dh/index.html
+++ b/static/x/drivers/lis3dh/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 <meta name="go-import" content="tinygo.org/x/drivers git https://github.com/tinygo-org/drivers">
-<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/master{/dir} https://github.com/tinygo-org/drivers/blob/master{/dir}/{file}#L{line}">
+<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/release{/dir} https://github.com/tinygo-org/drivers/blob/release{/dir}/{file}#L{line}">
 <meta http-equiv="refresh" content="0; url=https://tinygo.org/">
 </head>
 <body>

--- a/static/x/drivers/lsm6ds3/index.html
+++ b/static/x/drivers/lsm6ds3/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 <meta name="go-import" content="tinygo.org/x/drivers git https://github.com/tinygo-org/drivers">
-<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/master{/dir} https://github.com/tinygo-org/drivers/blob/master{/dir}/{file}#L{line}">
+<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/release{/dir} https://github.com/tinygo-org/drivers/blob/release{/dir}/{file}#L{line}">
 <meta http-equiv="refresh" content="0; url=https://tinygo.org/">
 </head>
 <body>

--- a/static/x/drivers/mag3110/index.html
+++ b/static/x/drivers/mag3110/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 <meta name="go-import" content="tinygo.org/x/drivers git https://github.com/tinygo-org/drivers">
-<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/master{/dir} https://github.com/tinygo-org/drivers/blob/master{/dir}/{file}#L{line}">
+<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/release{/dir} https://github.com/tinygo-org/drivers/blob/release{/dir}/{file}#L{line}">
 <meta http-equiv="refresh" content="0; url=https://tinygo.org/">
 </head>
 <body>

--- a/static/x/drivers/mcp3008/index.html
+++ b/static/x/drivers/mcp3008/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 <meta name="go-import" content="tinygo.org/x/drivers git https://github.com/tinygo-org/drivers">
-<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/master{/dir} https://github.com/tinygo-org/drivers/blob/master{/dir}/{file}#L{line}">
+<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/release{/dir} https://github.com/tinygo-org/drivers/blob/release{/dir}/{file}#L{line}">
 <meta http-equiv="refresh" content="0; url=https://tinygo.org/">
 </head>
 <body>

--- a/static/x/drivers/microphone/index.html
+++ b/static/x/drivers/microphone/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 <meta name="go-import" content="tinygo.org/x/drivers git https://github.com/tinygo-org/drivers">
-<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/master{/dir} https://github.com/tinygo-org/drivers/blob/master{/dir}/{file}#L{line}">
+<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/release{/dir} https://github.com/tinygo-org/drivers/blob/release{/dir}/{file}#L{line}">
 <meta http-equiv="refresh" content="0; url=https://tinygo.org/">
 </head>
 <body>

--- a/static/x/drivers/mma8653/index.html
+++ b/static/x/drivers/mma8653/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 <meta name="go-import" content="tinygo.org/x/drivers git https://github.com/tinygo-org/drivers">
-<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/master{/dir} https://github.com/tinygo-org/drivers/blob/master{/dir}/{file}#L{line}">
+<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/release{/dir} https://github.com/tinygo-org/drivers/blob/release{/dir}/{file}#L{line}">
 <meta http-equiv="refresh" content="0; url=https://tinygo.org/">
 </head>
 <body>

--- a/static/x/drivers/mpu6050/index.html
+++ b/static/x/drivers/mpu6050/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 <meta name="go-import" content="tinygo.org/x/drivers git https://github.com/tinygo-org/drivers">
-<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/master{/dir} https://github.com/tinygo-org/drivers/blob/master{/dir}/{file}#L{line}">
+<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/release{/dir} https://github.com/tinygo-org/drivers/blob/release{/dir}/{file}#L{line}">
 <meta http-equiv="refresh" content="0; url=https://tinygo.org/">
 </head>
 <body>

--- a/static/x/drivers/net/index.html
+++ b/static/x/drivers/net/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 <meta name="go-import" content="tinygo.org/x/drivers git https://github.com/tinygo-org/drivers">
-<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/master{/dir} https://github.com/tinygo-org/drivers/blob/master{/dir}/{file}#L{line}">
+<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/release{/dir} https://github.com/tinygo-org/drivers/blob/release{/dir}/{file}#L{line}">
 <meta http-equiv="refresh" content="0; url=https://tinygo.org/">
 </head>
 <body>

--- a/static/x/drivers/net/mqtt/index.html
+++ b/static/x/drivers/net/mqtt/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 <meta name="go-import" content="tinygo.org/x/drivers git https://github.com/tinygo-org/drivers">
-<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/master{/dir} https://github.com/tinygo-org/drivers/blob/master{/dir}/{file}#L{line}">
+<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/release{/dir} https://github.com/tinygo-org/drivers/blob/release{/dir}/{file}#L{line}">
 <meta http-equiv="refresh" content="0; url=https://tinygo.org/">
 </head>
 <body>

--- a/static/x/drivers/net/tls/index.html
+++ b/static/x/drivers/net/tls/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 <meta name="go-import" content="tinygo.org/x/drivers git https://github.com/tinygo-org/drivers">
-<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/master{/dir} https://github.com/tinygo-org/drivers/blob/master{/dir}/{file}#L{line}">
+<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/release{/dir} https://github.com/tinygo-org/drivers/blob/release{/dir}/{file}#L{line}">
 <meta http-equiv="refresh" content="0; url=https://tinygo.org/">
 </head>
 <body>

--- a/static/x/drivers/pcd8544/index.html
+++ b/static/x/drivers/pcd8544/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 <meta name="go-import" content="tinygo.org/x/drivers git https://github.com/tinygo-org/drivers">
-<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/master{/dir} https://github.com/tinygo-org/drivers/blob/master{/dir}/{file}#L{line}">
+<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/release{/dir} https://github.com/tinygo-org/drivers/blob/release{/dir}/{file}#L{line}">
 <meta http-equiv="refresh" content="0; url=https://tinygo.org/">
 </head>
 <body>

--- a/static/x/drivers/semihosting/index.html
+++ b/static/x/drivers/semihosting/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 <meta name="go-import" content="tinygo.org/x/drivers git https://github.com/tinygo-org/drivers">
-<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/master{/dir} https://github.com/tinygo-org/drivers/blob/master{/dir}/{file}#L{line}">
+<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/release{/dir} https://github.com/tinygo-org/drivers/blob/release{/dir}/{file}#L{line}">
 <meta http-equiv="refresh" content="0; url=https://tinygo.org/">
 </head>
 <body>

--- a/static/x/drivers/shifter/index.html
+++ b/static/x/drivers/shifter/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 <meta name="go-import" content="tinygo.org/x/drivers git https://github.com/tinygo-org/drivers">
-<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/master{/dir} https://github.com/tinygo-org/drivers/blob/master{/dir}/{file}#L{line}">
+<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/release{/dir} https://github.com/tinygo-org/drivers/blob/release{/dir}/{file}#L{line}">
 <meta http-equiv="refresh" content="0; url=https://tinygo.org/">
 </head>
 <body>

--- a/static/x/drivers/sht3x/index.html
+++ b/static/x/drivers/sht3x/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 <meta name="go-import" content="tinygo.org/x/drivers git https://github.com/tinygo-org/drivers">
-<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/master{/dir} https://github.com/tinygo-org/drivers/blob/master{/dir}/{file}#L{line}">
+<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/release{/dir} https://github.com/tinygo-org/drivers/blob/release{/dir}/{file}#L{line}">
 <meta http-equiv="refresh" content="0; url=https://tinygo.org/">
 </head>
 <body>

--- a/static/x/drivers/ssd1306/index.html
+++ b/static/x/drivers/ssd1306/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 <meta name="go-import" content="tinygo.org/x/drivers git https://github.com/tinygo-org/drivers">
-<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/master{/dir} https://github.com/tinygo-org/drivers/blob/master{/dir}/{file}#L{line}">
+<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/release{/dir} https://github.com/tinygo-org/drivers/blob/release{/dir}/{file}#L{line}">
 <meta http-equiv="refresh" content="0; url=https://tinygo.org/">
 </head>
 <body>

--- a/static/x/drivers/ssd1331/index.html
+++ b/static/x/drivers/ssd1331/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 <meta name="go-import" content="tinygo.org/x/drivers git https://github.com/tinygo-org/drivers">
-<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/master{/dir} https://github.com/tinygo-org/drivers/blob/master{/dir}/{file}#L{line}">
+<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/release{/dir} https://github.com/tinygo-org/drivers/blob/release{/dir}/{file}#L{line}">
 <meta http-equiv="refresh" content="0; url=https://tinygo.org/">
 </head>
 <body>

--- a/static/x/drivers/st7735/index.html
+++ b/static/x/drivers/st7735/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 <meta name="go-import" content="tinygo.org/x/drivers git https://github.com/tinygo-org/drivers">
-<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/master{/dir} https://github.com/tinygo-org/drivers/blob/master{/dir}/{file}#L{line}">
+<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/release{/dir} https://github.com/tinygo-org/drivers/blob/release{/dir}/{file}#L{line}">
 <meta http-equiv="refresh" content="0; url=https://tinygo.org/">
 </head>
 <body>

--- a/static/x/drivers/st7789/index.html
+++ b/static/x/drivers/st7789/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 <meta name="go-import" content="tinygo.org/x/drivers git https://github.com/tinygo-org/drivers">
-<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/master{/dir} https://github.com/tinygo-org/drivers/blob/master{/dir}/{file}#L{line}">
+<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/release{/dir} https://github.com/tinygo-org/drivers/blob/release{/dir}/{file}#L{line}">
 <meta http-equiv="refresh" content="0; url=https://tinygo.org/">
 </head>
 <body>

--- a/static/x/drivers/thermistor/index.html
+++ b/static/x/drivers/thermistor/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 <meta name="go-import" content="tinygo.org/x/drivers git https://github.com/tinygo-org/drivers">
-<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/master{/dir} https://github.com/tinygo-org/drivers/blob/master{/dir}/{file}#L{line}">
+<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/release{/dir} https://github.com/tinygo-org/drivers/blob/release{/dir}/{file}#L{line}">
 <meta http-equiv="refresh" content="0; url=https://tinygo.org/">
 </head>
 <body>

--- a/static/x/drivers/touch/index.html
+++ b/static/x/drivers/touch/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 <meta name="go-import" content="tinygo.org/x/drivers git https://github.com/tinygo-org/drivers">
-<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/master{/dir} https://github.com/tinygo-org/drivers/blob/master{/dir}/{file}#L{line}">
+<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/release{/dir} https://github.com/tinygo-org/drivers/blob/release{/dir}/{file}#L{line}">
 <meta http-equiv="refresh" content="0; url=https://tinygo.org/">
 </head>
 <body>

--- a/static/x/drivers/touch/resistive/index.html
+++ b/static/x/drivers/touch/resistive/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 <meta name="go-import" content="tinygo.org/x/drivers git https://github.com/tinygo-org/drivers">
-<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/master{/dir} https://github.com/tinygo-org/drivers/blob/master{/dir}/{file}#L{line}">
+<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/release{/dir} https://github.com/tinygo-org/drivers/blob/release{/dir}/{file}#L{line}">
 <meta http-equiv="refresh" content="0; url=https://tinygo.org/">
 </head>
 <body>

--- a/static/x/drivers/veml6070/index.html
+++ b/static/x/drivers/veml6070/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 <meta name="go-import" content="tinygo.org/x/drivers git https://github.com/tinygo-org/drivers">
-<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/master{/dir} https://github.com/tinygo-org/drivers/blob/master{/dir}/{file}#L{line}">
+<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/release{/dir} https://github.com/tinygo-org/drivers/blob/release{/dir}/{file}#L{line}">
 <meta http-equiv="refresh" content="0; url=https://tinygo.org/">
 </head>
 <body>

--- a/static/x/drivers/vl53l1x/index.html
+++ b/static/x/drivers/vl53l1x/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 <meta name="go-import" content="tinygo.org/x/drivers git https://github.com/tinygo-org/drivers">
-<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/master{/dir} https://github.com/tinygo-org/drivers/blob/master{/dir}/{file}#L{line}">
+<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/release{/dir} https://github.com/tinygo-org/drivers/blob/release{/dir}/{file}#L{line}">
 <meta http-equiv="refresh" content="0; url=https://tinygo.org/">
 </head>
 <body>

--- a/static/x/drivers/waveshare-epd/epd2in13/index.html
+++ b/static/x/drivers/waveshare-epd/epd2in13/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 <meta name="go-import" content="tinygo.org/x/drivers git https://github.com/tinygo-org/drivers">
-<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/master{/dir} https://github.com/tinygo-org/drivers/blob/master{/dir}/{file}#L{line}">
+<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/release{/dir} https://github.com/tinygo-org/drivers/blob/release{/dir}/{file}#L{line}">
 <meta http-equiv="refresh" content="0; url=https://tinygo.org/">
 </head>
 <body>

--- a/static/x/drivers/waveshare-epd/epd2in13x/index.html
+++ b/static/x/drivers/waveshare-epd/epd2in13x/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 <meta name="go-import" content="tinygo.org/x/drivers git https://github.com/tinygo-org/drivers">
-<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/master{/dir} https://github.com/tinygo-org/drivers/blob/master{/dir}/{file}#L{line}">
+<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/release{/dir} https://github.com/tinygo-org/drivers/blob/release{/dir}/{file}#L{line}">
 <meta http-equiv="refresh" content="0; url=https://tinygo.org/">
 </head>
 <body>

--- a/static/x/drivers/wifinina/index.html
+++ b/static/x/drivers/wifinina/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 <meta name="go-import" content="tinygo.org/x/drivers git https://github.com/tinygo-org/drivers">
-<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/master{/dir} https://github.com/tinygo-org/drivers/blob/master{/dir}/{file}#L{line}">
+<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/release{/dir} https://github.com/tinygo-org/drivers/blob/release{/dir}/{file}#L{line}">
 <meta http-equiv="refresh" content="0; url=https://tinygo.org/">
 </head>
 <body>

--- a/static/x/drivers/ws2812/index.html
+++ b/static/x/drivers/ws2812/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 <meta name="go-import" content="tinygo.org/x/drivers git https://github.com/tinygo-org/drivers">
-<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/master{/dir} https://github.com/tinygo-org/drivers/blob/master{/dir}/{file}#L{line}">
+<meta name="go-source" content="tinygo.org/x/drivers _ https://github.com/tinygo-org/drivers/tree/release{/dir} https://github.com/tinygo-org/drivers/blob/release{/dir}/{file}#L{line}">
 <meta http-equiv="refresh" content="0; url=https://tinygo.org/">
 </head>
 <body>

--- a/static/x/go-llvm/index.html
+++ b/static/x/go-llvm/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 <meta name="go-import" content="tinygo.org/x/go-llvm git https://github.com/tinygo-org/go-llvm">
-<meta name="go-source" content="tinygo.org/x/go-llvm _ https://github.com/tinygo-org/go-llvm/tree/master{/dir} https://github.com/tinygo-org/go-llvm/blob/master{/dir}/{file}#L{line}">
+<meta name="go-source" content="tinygo.org/x/go-llvm _ https://github.com/tinygo-org/go-llvm/tree/release{/dir} https://github.com/tinygo-org/go-llvm/blob/release{/dir}/{file}#L{line}">
 <meta http-equiv="refresh" content="0; url=https://tinygo.org/">
 </head>
 <body>

--- a/static/x/tinydraw/index.html
+++ b/static/x/tinydraw/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 <meta name="go-import" content="tinygo.org/x/tinydraw git https://github.com/tinygo-org/tinydraw">
-<meta name="go-source" content="tinygo.org/x/tinydraw _ https://github.com/tinygo-org/tinydraw/tree/master{/dir} https://github.com/tinygo-org/tinydraw/blob/master{/dir}/{file}#L{line}">
+<meta name="go-source" content="tinygo.org/x/tinydraw _ https://github.com/tinygo-org/tinydraw/tree/release{/dir} https://github.com/tinygo-org/tinydraw/blob/release{/dir}/{file}#L{line}">
 <meta http-equiv="refresh" content="0; url=https://tinygo.org/">
 </head>
 <body>

--- a/static/x/tinyfont/index.html
+++ b/static/x/tinyfont/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 <meta name="go-import" content="tinygo.org/x/tinyfont git https://github.com/tinygo-org/tinyfont">
-<meta name="go-source" content="tinygo.org/x/tinyfont _ https://github.com/tinygo-org/tinyfont/tree/master{/dir} https://github.com/tinygo-org/tinyfont/blob/master{/dir}/{file}#L{line}">
+<meta name="go-source" content="tinygo.org/x/tinyfont _ https://github.com/tinygo-org/tinyfont/tree/release{/dir} https://github.com/tinygo-org/tinyfont/blob/release{/dir}/{file}#L{line}">
 <meta http-equiv="refresh" content="0; url=https://tinygo.org/">
 </head>
 <body>

--- a/static/x/tinygo/compiler/index.html
+++ b/static/x/tinygo/compiler/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 <meta name="go-import" content="tinygo.org/x/tinygo/compiler git https://github.com/tinygo-org/tinygo">
-<meta name="go-source" content="tinygo.org/x/tinygo/compiler _ https://github.com/tinygo-org/tinygo/tree/master{/dir} https://github.com/tinygo-org/tinygo/blob/master{/dir}/{file}#L{line}">
+<meta name="go-source" content="tinygo.org/x/tinygo/compiler _ https://github.com/tinygo-org/tinygo/tree/release{/dir} https://github.com/tinygo-org/tinygo/blob/release{/dir}/{file}#L{line}">
 <meta http-equiv="refresh" content="0; url=https://tinygo.org/">
 </head>
 <body>

--- a/static/x/tinygo/index.html
+++ b/static/x/tinygo/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 <meta name="go-import" content="tinygo.org/x/tinygo git https://github.com/tinygo-org/tinygo">
-<meta name="go-source" content="tinygo.org/x/tinygo _ https://github.com/tinygo-org/tinygo/tree/master{/dir} https://github.com/tinygo-org/tinygo/blob/master{/dir}/{file}#L{line}">
+<meta name="go-source" content="tinygo.org/x/tinygo _ https://github.com/tinygo-org/tinygo/tree/release{/dir} https://github.com/tinygo-org/tinygo/blob/release{/dir}/{file}#L{line}">
 <meta http-equiv="refresh" content="0; url=https://tinygo.org/">
 </head>
 <body>

--- a/static/x/tinygo/interp/index.html
+++ b/static/x/tinygo/interp/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 <meta name="go-import" content="tinygo.org/x/tinygo/interp git https://github.com/tinygo-org/tinygo">
-<meta name="go-source" content="tinygo.org/x/tinygo/interp _ https://github.com/tinygo-org/tinygo/tree/master{/dir} https://github.com/tinygo-org/tinygo/blob/master{/dir}/{file}#L{line}">
+<meta name="go-source" content="tinygo.org/x/tinygo/interp _ https://github.com/tinygo-org/tinygo/tree/release{/dir} https://github.com/tinygo-org/tinygo/blob/release{/dir}/{file}#L{line}">
 <meta http-equiv="refresh" content="0; url=https://tinygo.org/">
 </head>
 <body>

--- a/static/x/tinygo/ir/index.html
+++ b/static/x/tinygo/ir/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 <meta name="go-import" content="tinygo.org/x/tinygo/ir git https://github.com/tinygo-org/tinygo">
-<meta name="go-source" content="tinygo.org/x/tinygo/ir _ https://github.com/tinygo-org/tinygo/tree/master{/dir} https://github.com/tinygo-org/tinygo/blob/master{/dir}/{file}#L{line}">
+<meta name="go-source" content="tinygo.org/x/tinygo/ir _ https://github.com/tinygo-org/tinygo/tree/release{/dir} https://github.com/tinygo-org/tinygo/blob/release{/dir}/{file}#L{line}">
 <meta http-equiv="refresh" content="0; url=https://tinygo.org/">
 </head>
 <body>

--- a/static/x/tinygo/loader/index.html
+++ b/static/x/tinygo/loader/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 <meta name="go-import" content="tinygo.org/x/tinygo/loader git https://github.com/tinygo-org/tinygo">
-<meta name="go-source" content="tinygo.org/x/tinygo/loader _ https://github.com/tinygo-org/tinygo/tree/master{/dir} https://github.com/tinygo-org/tinygo/blob/master{/dir}/{file}#L{line}">
+<meta name="go-source" content="tinygo.org/x/tinygo/loader _ https://github.com/tinygo-org/tinygo/tree/release{/dir} https://github.com/tinygo-org/tinygo/blob/release{/dir}/{file}#L{line}">
 <meta http-equiv="refresh" content="0; url=https://tinygo.org/">
 </head>
 <body>


### PR DESCRIPTION
This PR is part of the changeover to eliminate all direct use of master/slave terminology.

Also see https://github.com/tinygo-org/tinygo/pull/1216