### PR TITLE
fix path of wasm page

### DIFF
--- a/content/getting-started/using-docker.md
+++ b/content/getting-started/using-docker.md
@@ -18,7 +18,7 @@ A docker container exists for easy access to the TinyGo CLI. For example, to com
 
     docker run --rm -v $(pwd):/src tinygo/tinygo:0.14.1 tinygo build -o wasm.wasm -target=wasm examples/wasm/export
 
-See the [WebAssembly page](../webassembly) for more information on executing the compiled
+See the [WebAssembly page](../../webassembly) for more information on executing the compiled
 WebAssembly.
 
 To compile `blinky1.hex` targeting an ARM microcontroller, such as the PCA10040:


### PR DESCRIPTION
This fixes the "Webassembly page" link in https://tinygo.org/getting-started/using-docker/ 