### PR TITLE
microcontrollers: start adding new boards arduino zero, esp32, esp826…

### DIFF
--- a/content/faq/what-about-esp8266-esp32.md
+++ b/content/faq/what-about-esp8266-esp32.md
@@ -3,10 +3,6 @@ title: "What about the ESP8266/ESP32?"
 weight: 5
 ---
 
-As of February 2019 there is now an official project from Espressif to add the Xtensa chip architecture to LLVM.
+As of September 2020, we now have support for the ESP32 and ESP8266 in TinyGo!
 
-For the discussion of this see [this forum thread](https://www.esp32.com/viewtopic.php?t=9226).
-
-The repository that contains the Xtensa fork of LLVM is located at [https://github.com/espressif/llvm-project](https://github.com/espressif/llvm-project)
-
-It is not yet in a usable state, but once it is we will start the process of supporting it in TinyGo.
+Please see https://tinygo.org/microcontrollers/esp32 and https://tinygo.org/microcontrollers/esp8266 for more information.

--- a/content/getting-started/linux.md
+++ b/content/getting-started/linux.md
@@ -28,15 +28,15 @@ You must have Go already installed on your machine in order to install TinyGo. W
 If you are using Ubuntu or another Debian based Linux on an Intel processor, download the DEB file from Github and install it using the following commands:
 
 ```shell
-wget https://github.com/tinygo-org/tinygo/releases/download/v0.14.1/tinygo_0.14.1_amd64.deb
-sudo dpkg -i tinygo_0.14.1_amd64.deb
+wget https://github.com/tinygo-org/tinygo/releases/download/v0.15.0/tinygo_0.15.0_amd64.deb
+sudo dpkg -i tinygo_0.15.0_amd64.deb
 ```
 
 If you are on a Raspberry Pi or other ARM-based Linux computer, you should use this command instead:
 
 ```shell
-wget https://github.com/tinygo-org/tinygo/releases/download/v0.14.1/tinygo_0.14.1_arm.deb
-sudo dpkg -i tinygo_0.14.1_arm.deb
+wget https://github.com/tinygo-org/tinygo/releases/download/v0.15.0/tinygo_0.15.0_arm.deb
+sudo dpkg -i tinygo_0.15.0_arm.deb
 ```
 
 You will need to ensure that the path to the `tinygo` executable file is in your `PATH` variable.
@@ -49,7 +49,7 @@ You can test that the installation is working properly by running this code whic
 
 ```shell
 $ tinygo version
-tinygo version 0.14.1 linux/amd64 (using go version go1.15 and LLVM version 10.0.1)
+tinygo version 0.15.0 linux/amd64 (using go version go1.15 and LLVM version 10.0.1)
 ```
 
 If you are only interested in compiling TinyGo code for WebAssembly then you are now done with the installation.
@@ -212,7 +212,7 @@ This results in a `tinygo` binary in the `build` directory:
 
 ```shell
 $ ./build/tinygo version
-tinygo version 0.14.1 linux/amd64 (using go version go1.15 and LLVM version 10.0.1)
+tinygo version 0.15.0 linux/amd64 (using go version go1.15 and LLVM version 10.0.1)
 ```
 
 ### Additional Requirements for Microcontrollers

--- a/content/getting-started/macos.md
+++ b/content/getting-started/macos.md
@@ -28,7 +28,7 @@ You can test that the installation is working properly by running this code whic
 
 ```shell
 $ tinygo version
-tinygo version 0.14.1 darwin/amd64 (using go version go1.15 and LLVM version 10.0.1)
+tinygo version 0.15.0 darwin/amd64 (using go version go1.15 and LLVM version 10.0.1)
 ```
 
 If you are only interested in compiling TinyGo code for WebAssembly then you are done with the installation.
@@ -120,7 +120,7 @@ This results in a `tinygo` binary in the `build` directory:
 
 ```shell
 $ ./build/tinygo version
-tinygo version 0.14.1 darwin/amd64 (using go version go1.15 and LLVM version 10.0.1)
+tinygo version 0.15.0 darwin/amd64 (using go version go1.15 and LLVM version 10.0.1)
 ```
 
 ### Additional Requirements for Microcontrollers

--- a/content/getting-started/using-docker.md
+++ b/content/getting-started/using-docker.md
@@ -7,7 +7,7 @@ You can use our Docker image to be able to run the TinyGo compiler on your compu
 
 ## Installing
 
-    docker pull tinygo/tinygo:0.14.1
+    docker pull tinygo/tinygo:0.15.0
 
 ## Using
 
@@ -16,24 +16,24 @@ For your own code, you will probably want to use absolute paths.
 
 A docker container exists for easy access to the TinyGo CLI. For example, to compile `wasm.wasm` for the WebAssembly export example:
 
-    docker run --rm -v $(pwd):/src tinygo/tinygo:0.14.1 tinygo build -o wasm.wasm -target=wasm examples/wasm/export
+    docker run --rm -v $(pwd):/src tinygo/tinygo:0.15.0 tinygo build -o wasm.wasm -target=wasm examples/wasm/export
 
 See the [WebAssembly page](../../webassembly) for more information on executing the compiled
 WebAssembly.
 
 To compile `blinky1.hex` targeting an ARM microcontroller, such as the PCA10040:
 
-    docker run --rm -v $(pwd):/src tinygo/tinygo:0.14.1 tinygo build -o /src/blinky1.hex -size=short -target=pca10040 examples/blinky1
+    docker run --rm -v $(pwd):/src tinygo/tinygo:0.15.0 tinygo build -o /src/blinky1.hex -size=short -target=pca10040 examples/blinky1
 
 To compile `blinky1.hex` targeting an AVR microcontroller such as the Arduino:
 
-    docker run --rm -v $(pwd):/src tinygo/tinygo:0.14.1 tinygo build -o /src/blinky1.hex -size=short -target=arduino examples/blinky1
+    docker run --rm -v $(pwd):/src tinygo/tinygo:0.15.0 tinygo build -o /src/blinky1.hex -size=short -target=arduino examples/blinky1
 
 For projects that have remote dependencies outside of the standard library and
 go code within your own project, you will need to map your entire `$GOPATH`
 into the docker image for those dependencies to be found:
 
-    docker run -v $GOPATH:/go -e "GOPATH=/go" tinygo/tinygo:0.14.1 tinygo build -o /go/src/github.com/myuser/myrepo/wasm.wasm -target wasm --no-debug /go/src/github.com/myuser/myrepo/wasm-main.go
+    docker run -v $GOPATH:/go -e "GOPATH=/go" tinygo/tinygo:0.15.0 tinygo build -o /go/src/github.com/myuser/myrepo/wasm.wasm -target wasm --no-debug /go/src/github.com/myuser/myrepo/wasm-main.go
 
 **note: At this time, tinygo does not resolve dependencies from the /vendor/ folder within your project.**
 

--- a/content/getting-started/windows.md
+++ b/content/getting-started/windows.md
@@ -38,7 +38,7 @@ You can test that the installation was successful by running the `version` comma
 
 ```shell
 > tinygo version
-tinygo version 0.14.1 windows/amd64 (using go version go1.15 and LLVM version 10.0.1)
+tinygo version 0.15.0 windows/amd64 (using go version go1.15 and LLVM version 10.0.1)
 ```
 
 Upgrading to the latest TinyGo version can be done via scoop with:
@@ -55,7 +55,7 @@ Upgrading to the latest TinyGo version can be done via scoop with:
 
     - Choose the download link for Microsoft Windows, Windows 7 or later, Intel 64-bit processor.
 
-- Download the TinyGo binary for Windows file from https://github.com/tinygo-org/tinygo/releases/download/v0.14.1/tinygo0.14.1.windows-amd64.zip
+- Download the TinyGo binary for Windows file from https://github.com/tinygo-org/tinygo/releases/download/v0.15.0/tinygo0.15.0.windows-amd64.zip
 
 - Decompress the file like this:
 
@@ -75,7 +75,7 @@ Upgrading to the latest TinyGo version can be done via scoop with:
 
     ```
     > tinygo version
-    tinygo version 0.14.1 windows/amd64 (using go version go1.15 and LLVM version 10.0.1)
+    tinygo version 0.15.0 windows/amd64 (using go version go1.15 and LLVM version 10.0.1)
     ```
 
 ### Flashing boards
@@ -189,7 +189,7 @@ This results in a `tinygo.exe` binary in the `build` directory:
 
 ```text
 $ ./build/tinygo version
-tinygo version 0.14.1 windows/amd64 (using go version go1.15 and LLVM version 10.0.1)
+tinygo version 0.15.0 windows/amd64 (using go version go1.15 and LLVM version 10.0.1)
 ```
 
 ### Additional Requirements for Microcontrollers

--- a/content/microcontrollers/_index.md
+++ b/content/microcontrollers/_index.md
@@ -8,7 +8,7 @@ weight: 3
 
 TinyGo lets you run Go directly on microcontrollers.
 
-TinyGo has support for 39 different boards and devices such as the Arduino Nano33 IoT, Adafruit Circuit Playground Express, BBC micro:bit and more. Click on a board name found in the left menu to see the what features are supported for the given hardware.
+TinyGo has support for 44 different boards and devices such as the Arduino Nano33 IoT, Adafruit Circuit Playground Express, BBC micro:bit and more. Click on a board name found in the left menu to see the what features are supported for the given hardware.
 
 We also give you the ability to add new boards. If your target isn't listed here, please raise an issue in the [issue tracker](https://github.com/tinygo-org/tinygo/issues).
 

--- a/content/microcontrollers/arduino-nano33-iot.md
+++ b/content/microcontrollers/arduino-nano33-iot.md
@@ -126,4 +126,6 @@ Once you have updated your Arduino Nano33 IoT board the first time, after that y
 
 You can use the USB port to the Arduino Nano33 IoT as a serial port. `UART0` refers to this connection.
 
-For information on how to use the built-in NINA-W102 wireless chip, please see the "espat" driver in the TinyGo drivers repository located at [https://github.com/tinygo-org/drivers/tree/release/espat](https://github.com/tinygo-org/drivers/tree/release/espat).
+For information on how to use the built-in NINA-W102 wireless chip with the default firmware, please see the "wifinina" driver in the TinyGo drivers repository located at [https://github.com/tinygo-org/drivers/tree/release/wifinina](https://github.com/tinygo-org/drivers/tree/release/wifinina).
+
+You can also use the Espressif ESP-AT firmware, although you will need to flash it yourself. Please see the "espat" driver in the TinyGo drivers repository located at [https://github.com/tinygo-org/drivers/tree/release/espat](https://github.com/tinygo-org/drivers/tree/release/espat).

--- a/content/microcontrollers/arduino-zero.md
+++ b/content/microcontrollers/arduino-zero.md
@@ -1,0 +1,121 @@
+---
+title: "Arduino Zero"
+weight: 3
+---
+
+The [Arduino Zero](https://store.arduino.cc/arduino-zero) is a very small ARM development board based on the Atmel [SAMD21](https://www.microchip.com/wwwproducts/en/ATSAMD21G18) family of processors.
+
+## Interfaces
+
+| Interface | Hardware Supported | TinyGo Support |
+| --------- | ------------- | ----- |
+| GPIO      | YES | YES |
+| UART      | YES | YES |
+| SPI      | YES | YES |
+| I2C      | YES | YES |
+| ADC      | YES | YES |
+| PWM      | YES | YES |
+
+## Machine Package Docs
+
+[Documentation for the machine package for the Arduino Zero](../machine/arduino-zero)
+
+## Installing BOSSA
+
+In order to flash your TinyGo programs onto the Arduino Zero board, you will need to install the "bossac" command line utility which is part of the [BOSSA command line utilities](https://github.com/shumatech/BOSSA).
+
+### macOS
+
+You can use Homebrew to install the BOSSA command line interface by using the following command:
+
+```shell
+brew cask install bossa
+```
+
+Or if you  prefer, you can also download the installer from https://github.com/shumatech/BOSSA/releases/download/1.9.1/bossa-1.9.1.dmg
+
+Once you have downloaded it, double click on the .dmg file to perform the installation.
+
+### Linux
+
+On Linux, install from source:
+
+```shell
+sudo apt install libreadline-dev libwxgtk3.0-* 
+git clone https://github.com/shumatech/BOSSA.git
+cd BOSSA
+make
+sudo cp bin/bossac /usr/local/bin
+```
+
+### Windows
+
+You can download BOSSA from https://github.com/shumatech/BOSSA/releases/download/1.9.1/bossa-x64-1.9.1.msi
+
+*VERY IMPORTANT*: During the installation, you much choose to install into `c:\Program Files`. The installer might have the wrong path, so edit it to match  `c:\Program Files`.
+
+After the installation, you must add BOSSA to your PATH:
+
+```shell
+set PATH=%PATH%;"c:\Program Files\BOSSA";
+```
+
+Test that you have installed "BOSSA" correctly by running this command:
+
+```shell
+bossac --help
+```
+
+## Flashing
+
+Once you have installed the needed BOSSA command line utility, as in the previous section, you are ready to build and flash code to your Arduino Zero board.
+
+### CLI Flashing on Linux
+
+- Plug your Arduino Zero board into your computer's USB port.
+- Build and flash your TinyGo code using the `tinygo flash` command. This command flashes the Arduino Zero with the blinky1 example:
+
+    ```
+    tinygo flash -target=arduino-zero examples/blinky1
+    ```
+
+- The Arduino Zero board should restart and then begin running your program.
+
+### CLI Flashing on macOS
+
+- Plug your Arduino Zero board into your computer's USB port.
+- Build and flash your TinyGo code using the `tinygo flash` command. This command flashes the Arduino Zero with the blinky1 example:
+
+    ```
+    tinygo flash -target=arduino-zero examples/blinky1
+    ```
+
+- The Arduino Zero board should restart and then begin running your program.
+
+### CLI Flashing on Windows
+
+- Plug your Arduino Zero board into your computer's USB port.
+- Build and flash your TinyGo code using the `tinygo flash` command. This command flashes the Arduino Zero with the blinky1 example:
+
+    ```
+    tinygo flash -target=arduino-zero examples/blinky1
+    ```
+
+- The Arduino Zero board should restart and then begin running your program.
+
+### Troubleshooting
+
+If you have troubles getting your Arduino Zero board to receive code, try this:
+
+- Press the "RESET" button on the board two times to get the Arduino Zero board ready to receive code.
+- Now try running the `tinygo flash` command as above:
+
+    ```shell
+    tinygo flash -target=arduino-zero [PATH TO YOUR PROGRAM]
+    ```
+
+Once you have updated your Arduino Zero board the first time, after that you should be able to flash it entirely from the command line.
+
+## Notes
+
+You can use the USB port to the Arduino Zero as a serial port. `UART0` refers to this connection.

--- a/content/microcontrollers/bbc-microbit.md
+++ b/content/microcontrollers/bbc-microbit.md
@@ -15,6 +15,7 @@ The BBC [micro:bit](https://microbit.org) is a tiny programmable computer design
 | I2C      | YES | YES |
 | ADC      | YES | Not yet |
 | PWM      | Software support | Not yet |
+| Bluetooth      | YES | YES |
 
 ## Machine Package Docs
 
@@ -68,3 +69,5 @@ machine.SPI1.Configure(machine.SPIConfig{
 // use I2C0 as normally do
 machine.I2C0.Configure(machine.I2CConfig{})
 ```
+
+Bluetooth support is now available for the BBC micro:bit board. See https://github.com/tinygo-org/bluetooth for more information.

--- a/content/microcontrollers/circuit-playground-bluefruit.md
+++ b/content/microcontrollers/circuit-playground-bluefruit.md
@@ -3,7 +3,7 @@ title: "Adafruit Circuit Playground Bluefruit"
 weight: 3
 ---
 
-The [Adafruit Circuit Playground Bluefruit](https://www.adafruit.com/product/4333) is small ARM development board based on the Nordic Semiconductor [nrf52840](https://www.nordicsemi.com/eng/Products/nRF52840)  processor. It has several built-in devices such as WS2812 "NeoPixel" LEDs, buttons, an accelerometer, and some other sensors.
+The [Adafruit Circuit Playground Bluefruit](https://www.adafruit.com/product/4333) is small ARM development board based on the Nordic Semiconductor [nrf52840](https://www.nordicsemi.com/eng/Products/nRF52840) processor. It has several built-in devices such as WS2812 "NeoPixel" LEDs, buttons, an accelerometer, and some other sensors.
 
 ## Interfaces
 
@@ -15,6 +15,7 @@ The [Adafruit Circuit Playground Bluefruit](https://www.adafruit.com/product/433
 | I2C      | YES | YES |
 | ADC      | YES | YES |
 | PWM      | YES | YES |
+| Bluetooth      | YES | YES |
 
 ## Machine Package Docs
 
@@ -79,4 +80,5 @@ You can use the USB port to the Circuit Playground Bluefruit as a serial port. `
 
 For an example that uses the built-in Neopixel LEDs, take a look at the TinyGo drivers repository located at [https://github.com/tinygo-org/drivers/tree/release/examples](https://github.com/tinygo-org/drivers)
 
-Bluetooth support is also in development but not yet completed.
+Bluetooth support is now available for the Circuit Playground Bluefruit board. See https://github.com/tinygo-org/bluetooth for more information.
+

--- a/content/microcontrollers/clue-alpha.md
+++ b/content/microcontrollers/clue-alpha.md
@@ -15,6 +15,7 @@ The [Adafruit CLUE](https://www.adafruit.com/product/4500) is small ARM developm
 | I2C      | YES | YES |
 | ADC      | YES | YES |
 | PWM      | YES | YES |
+| Bluetooth      | YES | YES |
 
 ## Machine Package Docs
 
@@ -79,4 +80,4 @@ You can use the USB port to the CLUE as a serial port. `UART0` refers to this co
 
 For an example that uses the built-in Neopixel LEDs, take a look at the TinyGo drivers repository located at [https://github.com/tinygo-org/drivers/tree/release/examples](https://github.com/tinygo-org/drivers)
 
-Bluetooth support is in development but not yet completed.
+Bluetooth support is now available for the Adafruit CLUE board. See https://github.com/tinygo-org/bluetooth for more information.

--- a/content/microcontrollers/drivers/_index.md
+++ b/content/microcontrollers/drivers/_index.md
@@ -6,11 +6,11 @@ weight: 90
 
 # Drivers
 
-TinyGo has driver support for 44 different sensors and devices such as digital accelerometers and multicolor LEDs.
+TinyGo has driver support for 53 different sensors and devices such as digital accelerometers and multicolor LEDs.
 
 All of the drivers code is in the TinyGo Drivers repository located at [https://github.com/tinygo-org/drivers/](https://github.com/tinygo-org/drivers/).
 
-The following 51 devices are supported.
+The following 53 devices are supported.
 
 | Device Name | Interface Type |
 |----------|-------------|
@@ -38,6 +38,7 @@ The following 51 devices are supported.
 | [ILI9341 TFT color display](https://cdn-shop.adafruit.com/datasheets/ILI9341.pdf) | SPI |
 | [L293x motor driver](https://www.ti.com/lit/ds/symlink/l293d.pdf) | GPIO/PWM |
 | [L9110x motor driver](https://www.elecrow.com/download/datasheet-l9110.pdf) | GPIO/PWM |
+| [LIS2MDL magnetometer](https://www.st.com/resource/en/datasheet/lis2mdl.pdf) | I2C |
 | [LIS3DH accelerometer](https://www.st.com/resource/en/datasheet/lis3dh.pdf) | I2C |
 | [LSM6DS3 accelerometer](https://www.st.com/resource/en/datasheet/lsm6ds3.pdf) | I2C |
 | [MAG3110 magnetometer](https://www.nxp.com/docs/en/data-sheet/MAG3110.pdf) | I2C |
@@ -64,6 +65,7 @@ The following 51 devices are supported.
 | [VL53L1X time-of-flight distance sensor](https://www.st.com/resource/en/datasheet/vl53l1x.pdf) | I2C |
 | [Waveshare 2.13" (B & C) e-paper display](https://www.waveshare.com/w/upload/d/d3/2.13inch-e-paper-b-Specification.pdf) | SPI |
 | [Waveshare 2.13" e-paper display](https://www.waveshare.com/w/upload/e/e6/2.13inch_e-Paper_Datasheet.pdf) | SPI |
+| [Waveshare 4.2" e-paper B/W display](https://www.waveshare.com/w/upload/6/6a/4.2inch-e-paper-specification.pdf) | SPI |
 | [WS2812 RGB LED](https://cdn-shop.adafruit.com/datasheets/WS2812.pdf) | GPIO |
 
 We also give you the ability to add new drivers. If your device isn't listed here, please raise an issue in the [issue tracker](https://github.com/tinygo-org/drivers/issues).

--- a/content/microcontrollers/esp32.md
+++ b/content/microcontrollers/esp32.md
@@ -24,15 +24,66 @@ The [Espressif ESP32]() is a tiny development board based on the Xtensa [ESP32](
 
 ### CLI Flashing on Linux
 
-Goes here
+You need to install the Espressif toolchain for Linux to use TinyGo with the ESP32: 
+
+https://docs.espressif.com/projects/esp-idf/en/release-v3.0/get-started/linux-setup.html#standard-setup-of-toolchain-for-linux
+
+In addition, you must install the `esptool` flashing tool:
+
+https://github.com/espressif/esptool#easy-installation
+
+Now you should be able to flash your board as follows:
+
+- Plug your ESP32 board into your computer's USB port.
+- Build and flash your TinyGo code using the `tinygo flash` command. This command flashes the ESP32 with the blinky1 example:
+
+    ```
+    tinygo flash -target=esp32-wroom-32 examples/blinky1
+    ```
+
+- The ESP32 board should restart and then begin running your program.
 
 ### CLI Flashing on macOS
 
-Goes here
+You need to install the Espressif toolchain for macOS to use TinyGo with the ESP32: 
+
+https://docs.espressif.com/projects/esp-idf/en/release-v3.0/get-started/macos-setup.html
+
+In addition, you must install the `esptool` flashing tool:
+
+https://github.com/espressif/esptool#easy-installation
+
+Now you should be able to flash your board as follows:
+
+- Plug your ESP32 board into your computer's USB port.
+- Build and flash your TinyGo code using the `tinygo flash` command. This command flashes the ESP32 with the blinky1 example:
+
+    ```
+    tinygo flash -target=esp32-wroom-32 examples/blinky1
+    ```
+
+- The ESP32 board should restart and then begin running your program.
 
 ### CLI Flashing on Windows
 
-Goes here
+You need to install the Espressif toolchain for Windows to use TinyGo with the ESP32: 
+
+https://docs.espressif.com/projects/esp-idf/en/release-v3.0/get-started/windows-setup.html
+
+In addition, you must install the `esptool` flashing tool:
+
+https://github.com/espressif/esptool#easy-installation
+
+Now you should be able to flash your board as follows:
+
+- Plug your ESP32 board into your computer's USB port.
+- Build and flash your TinyGo code using the `tinygo flash` command. This command flashes the ESP32 with the blinky1 example:
+
+    ```
+    tinygo flash -target=esp32-wroom-32 examples/blinky1
+    ```
+
+- The ESP32 board should restart and then begin running your program.
 
 ### Troubleshooting
 

--- a/content/microcontrollers/esp32.md
+++ b/content/microcontrollers/esp32.md
@@ -3,7 +3,7 @@ title: "ESP32"
 weight: 3
 ---
 
-The [Espressif ESP32]() is a tiny development board based on the Xtensa [ESP32]() family of SoC.
+The [Espressif ESP32](https://www.espressif.com/en/products/socs/esp32) is a powerful chip that is used on many different development boards. It includes a built-in radio that can be used for WiFi or Bluetooth wireless connections.
 
 ## Interfaces
 
@@ -15,6 +15,8 @@ The [Espressif ESP32]() is a tiny development board based on the Xtensa [ESP32](
 | I2C      | YES | Not Yet |
 | ADC      | YES | Not Yet |
 | PWM      | YES | Not Yet |
+| WiFi      | YES | Not Yet |
+| Bluetooth      | YES | Not Yet |
 
 ## Machine Package Docs
 
@@ -38,7 +40,7 @@ Now you should be able to flash your board as follows:
 - Build and flash your TinyGo code using the `tinygo flash` command. This command flashes the ESP32 with the blinky1 example:
 
     ```
-    tinygo flash -target=esp32-wroom-32 examples/blinky1
+    tinygo flash -target=esp32-wroom-32 -port=/dev/ttyUSB0 examples/blinky1
     ```
 
 - The ESP32 board should restart and then begin running your program.

--- a/content/microcontrollers/esp32.md
+++ b/content/microcontrollers/esp32.md
@@ -1,0 +1,43 @@
+---
+title: "ESP32"
+weight: 3
+---
+
+The [Espressif ESP32]() is a tiny development board based on the Xtensa [ESP32]() family of SoC.
+
+## Interfaces
+
+| Interface | Hardware Supported | TinyGo Support |
+| --------- | ------------- | ----- |
+| GPIO      | YES | YES |
+| UART      | YES | YES |
+| SPI      | YES | YES |
+| I2C      | YES | Not Yet |
+| ADC      | YES | Not Yet |
+| PWM      | YES | Not Yet |
+
+## Machine Package Docs
+
+[Documentation for the machine package for the ESP32](../machine/esp32)
+
+## Flashing
+
+### CLI Flashing on Linux
+
+Goes here
+
+### CLI Flashing on macOS
+
+Goes here
+
+### CLI Flashing on Windows
+
+Goes here
+
+### Troubleshooting
+
+Goes here
+
+## Notes
+
+Goes here

--- a/content/microcontrollers/esp8266.md
+++ b/content/microcontrollers/esp8266.md
@@ -24,15 +24,66 @@ The [Espressif ESP8266]() is a tiny development board based on the Xtensa [ESP82
 
 ### CLI Flashing on Linux
 
-Goes here
+You need to install the Espressif toolchain for Linux to use TinyGo with the ESP8266. Note that it is the same download as for the ESP32: 
+
+https://docs.espressif.com/projects/esp-idf/en/release-v3.0/get-started/linux-setup.html#standard-setup-of-toolchain-for-linux
+
+In addition, you must install the `esptool` flashing tool:
+
+https://github.com/espressif/esptool#easy-installation
+
+Now you should be able to flash your board as follows:
+
+- Plug your ESP8266 board into your computer's USB port.
+- Build and flash your TinyGo code using the `tinygo flash` command. This command flashes the ESP8266 with the blinky1 example:
+
+    ```
+    tinygo flash -target=esp8266 examples/blinky1
+    ```
+
+- The ESP8266 board should restart and then begin running your program.
 
 ### CLI Flashing on macOS
 
-Goes here
+You need to install the Espressif toolchain for macOS to use TinyGo with the ESP8266. Note that it is the same download as for the ESP32: 
+
+https://docs.espressif.com/projects/esp-idf/en/release-v3.0/get-started/macos-setup.html
+
+In addition, you must install the `esptool` flashing tool:
+
+https://github.com/espressif/esptool#easy-installation
+
+Now you should be able to flash your board as follows:
+
+- Plug your ESP8266 board into your computer's USB port.
+- Build and flash your TinyGo code using the `tinygo flash` command. This command flashes the ESP8266 with the blinky1 example:
+
+    ```
+    tinygo flash -target=esp8266 examples/blinky1
+    ```
+
+- The ESP826 board should restart and then begin running your program.
 
 ### CLI Flashing on Windows
 
-Goes here
+You need to install the Espressif toolchain for Windows to use TinyGo with the ESP826. Note that it is the same download as for the ESP32: 
+
+https://docs.espressif.com/projects/esp-idf/en/release-v3.0/get-started/windows-setup.html
+
+In addition, you must install the `esptool` flashing tool:
+
+https://github.com/espressif/esptool#easy-installation
+
+Now you should be able to flash your board as follows:
+
+- Plug your ESP826 board into your computer's USB port.
+- Build and flash your TinyGo code using the `tinygo flash` command. This command flashes the ESP826 with the blinky1 example:
+
+    ```
+    tinygo flash -target=esp8266 examples/blinky1
+    ```
+
+- The ESP826 board should restart and then begin running your program.
 
 ### Troubleshooting
 

--- a/content/microcontrollers/esp8266.md
+++ b/content/microcontrollers/esp8266.md
@@ -1,0 +1,43 @@
+---
+title: "ESP8266"
+weight: 3
+---
+
+The [Espressif ESP8266]() is a tiny development board based on the Xtensa [ESP8266]() family of SoC.
+
+## Interfaces
+
+| Interface | Hardware Supported | TinyGo Support |
+| --------- | ------------- | ----- |
+| GPIO      | YES | YES |
+| UART      | YES | YES |
+| SPI      | YES | Not Yet |
+| I2C      | YES | Not Yet |
+| ADC      | YES | Not Yet |
+| PWM      | YES | Not Yet |
+
+## Machine Package Docs
+
+[Documentation for the machine package for the ESP8266](../machine/esp8266)
+
+## Flashing
+
+### CLI Flashing on Linux
+
+Goes here
+
+### CLI Flashing on macOS
+
+Goes here
+
+### CLI Flashing on Windows
+
+Goes here
+
+### Troubleshooting
+
+Goes here
+
+## Notes
+
+Goes here

--- a/content/microcontrollers/esp8266.md
+++ b/content/microcontrollers/esp8266.md
@@ -3,7 +3,7 @@ title: "ESP8266"
 weight: 3
 ---
 
-The [Espressif ESP8266]() is a tiny development board based on the Xtensa [ESP8266]() family of SoC.
+The [Espressif ESP8266](https://www.espressif.com/en/products/socs/esp8266) is small yet powerful SoC that is usually used for WiFi applications thanks to its built-in radio.
 
 ## Interfaces
 
@@ -15,6 +15,7 @@ The [Espressif ESP8266]() is a tiny development board based on the Xtensa [ESP82
 | I2C      | YES | Not Yet |
 | ADC      | YES | Not Yet |
 | PWM      | YES | Not Yet |
+| WiFi      | YES | Not Yet |
 
 ## Machine Package Docs
 
@@ -24,7 +25,7 @@ The [Espressif ESP8266]() is a tiny development board based on the Xtensa [ESP82
 
 ### CLI Flashing on Linux
 
-You need to install the Espressif toolchain for Linux to use TinyGo with the ESP8266. Note that it is the same download as for the ESP32: 
+You need to install the same toolchain for the ESP8266 as is used for the ESP32 to use the ESP8266 with TinyGo: 
 
 https://docs.espressif.com/projects/esp-idf/en/release-v3.0/get-started/linux-setup.html#standard-setup-of-toolchain-for-linux
 
@@ -38,14 +39,14 @@ Now you should be able to flash your board as follows:
 - Build and flash your TinyGo code using the `tinygo flash` command. This command flashes the ESP8266 with the blinky1 example:
 
     ```
-    tinygo flash -target=esp8266 examples/blinky1
+    tinygo flash -target=esp8266 -port=/dev/ttyUSB examples/blinky1
     ```
 
 - The ESP8266 board should restart and then begin running your program.
 
 ### CLI Flashing on macOS
 
-You need to install the Espressif toolchain for macOS to use TinyGo with the ESP8266. Note that it is the same download as for the ESP32: 
+You need to install the same toolchain for the ESP8266 as is used for the ESP32 to use the ESP8266 with TinyGo:
 
 https://docs.espressif.com/projects/esp-idf/en/release-v3.0/get-started/macos-setup.html
 
@@ -66,7 +67,7 @@ Now you should be able to flash your board as follows:
 
 ### CLI Flashing on Windows
 
-You need to install the Espressif toolchain for Windows to use TinyGo with the ESP826. Note that it is the same download as for the ESP32: 
+You need to install the same toolchain for the ESP8266 as is used for the ESP32 to use the ESP8266 with TinyGo:
 
 https://docs.espressif.com/projects/esp-idf/en/release-v3.0/get-started/windows-setup.html
 

--- a/content/microcontrollers/feather-nrf52840.md
+++ b/content/microcontrollers/feather-nrf52840.md
@@ -3,7 +3,7 @@ title: "Adafruit Feather nRF52840"
 weight: 3
 ---
 
-The [Adafruit Feather nRF52840](https://www.adafruit.com/product/4500) is small ARM development board based on the Nordic Semiconductor [nrf52840](https://www.nordicsemi.com/eng/Products/nRF52840) processor.
+The [Adafruit Feather nRF52840](https://www.adafruit.com/product/4500) is a small ARM development board based on the Nordic Semiconductor [nrf52840](https://www.nordicsemi.com/eng/Products/nRF52840) processor.
 
 ## Interfaces
 
@@ -15,6 +15,7 @@ The [Adafruit Feather nRF52840](https://www.adafruit.com/product/4500) is small 
 | I2C      | YES | YES |
 | ADC      | YES | YES |
 | PWM      | YES | YES |
+| Bluetooth      | YES | YES |
 
 ## Machine Package Docs
 
@@ -77,4 +78,4 @@ Once you have updated your Adafruit Feather nRF52840 board the first time, after
 
 You can use the USB port to the Adafruit Feather nRF52840 as a serial port. `UART0` refers to this connection.
 
-Bluetooth support is in development but not yet completed.
+Bluetooth support is now available for the Adafruit Feather nRF52840 board. See https://github.com/tinygo-org/bluetooth for more information.

--- a/content/microcontrollers/feather-stm32f405.md
+++ b/content/microcontrollers/feather-stm32f405.md
@@ -22,21 +22,35 @@ The [Adafruit Feather STM32F405](https://www.adafruit.com/product/4382) is a tin
 
 ## Flashing
 
+Flashing this board using its DFU bootloader can be a bit cumbersome (see Adafruit docs at https://learn.adafruit.com/adafruit-stm32f405-feather-express/dfu-bootloader-details), but it is possible - without requiring an external programmer - by pulling the B0 pin high (you can use the board's 3.3V output pin) at bootup when connected to host PC via USB. This puts the device in bootloader mode.
+
+Once in bootloader mode, the device can be programmed using the open-source tool `dfu-util`.
+
 ### CLI Flashing on Linux
 
-Goes here
+You must first install the `dfu-util` program in order to flash the Adafruit Feather STM32F405 board.
+
+    sudo apt update 
+    sudo apt install dfu-util
 
 ### CLI Flashing on macOS
 
-Goes here
+You must first install the `dfu-util` program in order to flash the Adafruit Feather STM32F405 board. You can do this using Homebrew on macOS:
+
+    brew install dfu-util
 
 ### CLI Flashing on Windows
 
-Goes here
+You must first install the `dfu-util` program in order to flash the Adafruit Feather STM32F405 board.
+
+- Download dfu-util from the website here: http://dfu-util.sourceforge.net/releases/dfu-util-0.9-win64.zip
+- Decompress the files to a directory such as `C:\dfu-util`
+- Add `C:\dfu-util` to your `PATH`.
 
 ### Troubleshooting
 
-Goes here
+If you run into trouble getting dfu-util installed and working on Windows, see the blog post at https://www.hanselman.com/blog/HowToFixDfuutilSTMWinUSBZadigBootloadersAndOtherFirmwareFlashingIssuesOnWindows.aspx
+
 
 ## Notes
 

--- a/content/microcontrollers/feather-stm32f405.md
+++ b/content/microcontrollers/feather-stm32f405.md
@@ -1,0 +1,43 @@
+---
+title: "Adafruit Feather STM32F405"
+weight: 3
+---
+
+The [Adafruit Feather STM32F405](https://www.adafruit.com/product/4382) is a tiny ARM development board based on the ST Micro [STM32F405](https://www.st.com/resource/en/datasheet/dm00037051.pdf) family of microcontrollers.
+
+## Interfaces
+
+| Interface | Hardware Supported | TinyGo Support |
+| --------- | ------------- | ----- |
+| GPIO      | YES | YES |
+| UART      | YES | YES |
+| SPI      | YES | YES |
+| I2C      | YES | YES |
+| ADC      | YES | Not yet |
+| PWM      | YES | Not yet |
+
+## Machine Package Docs
+
+[Documentation for the machine package for the Adafruit Feather STM32F405](../machine/feather-stm32f405)
+
+## Flashing
+
+### CLI Flashing on Linux
+
+Goes here
+
+### CLI Flashing on macOS
+
+Goes here
+
+### CLI Flashing on Windows
+
+Goes here
+
+### Troubleshooting
+
+Goes here
+
+## Notes
+
+Goes here

--- a/content/microcontrollers/feather-stm32f405.md
+++ b/content/microcontrollers/feather-stm32f405.md
@@ -51,7 +51,6 @@ You must first install the `dfu-util` program in order to flash the Adafruit Fea
 
 If you run into trouble getting dfu-util installed and working on Windows, see the blog post at https://www.hanselman.com/blog/HowToFixDfuutilSTMWinUSBZadigBootloadersAndOtherFirmwareFlashingIssuesOnWindows.aspx
 
-
 ## Notes
 
 Goes here

--- a/content/microcontrollers/itsybitsy-nrf52840.md
+++ b/content/microcontrollers/itsybitsy-nrf52840.md
@@ -1,0 +1,83 @@
+---
+title: "Adafruit ItsyBitsy-nRF52840"
+weight: 3
+---
+
+The [Adafruit ItsyBitsy-nRF52840](https://www.adafruit.com/product/4333) is a small ARM development board based on the Nordic Semiconductor [nrf52840](https://www.nordicsemi.com/eng/Products/nRF52840)  processor.
+
+## Interfaces
+
+| Interface | Hardware Supported | TinyGo Support |
+| --------- | ------------- | ----- |
+| GPIO      | YES | YES |
+| UART      | YES | YES |
+| SPI      | YES | YES |
+| I2C      | YES | YES |
+| ADC      | YES | YES |
+| PWM      | YES | YES |
+| Bluetooth      | YES | YES |
+
+## Machine Package Docs
+
+[Documentation for the machine package for the ItsyBitsy-nRF52840](../machine/itsybitsy-nrf52840)
+
+## Flashing
+
+### UF2
+
+The ItsyBitsy-nRF52840 comes with the [UF2 bootloader](https://github.com/Microsoft/uf2) already installed.
+
+### CLI Flashing on Linux
+
+- Plug your ItsyBitsy-nRF52840 into your computer's USB port.
+- Flash your TinyGo program to the board using this command:
+
+    ```shell
+    tinygo flash -target=itsybitsy-nrf52840 [PATH TO YOUR PROGRAM]
+    ```
+
+- The ItsyBitsy-nRF52840 board should restart and then begin running your program.
+
+### CLI Flashing on macOS
+
+- Plug your ItsyBitsy-nRF52840 into your computer's USB port.
+- Flash your TinyGo program to the board using this command:
+
+    ```shell
+    tinygo flash -target=itsybitsy-nrf52840 [PATH TO YOUR PROGRAM]
+    ```
+
+- The ItsyBitsy-nRF52840 board should restart and then begin running your program.
+
+### CLI Flashing on Windows
+
+- Plug your ItsyBitsy-nRF52840 into your computer's USB port.
+- Flash your TinyGo program to the board using this command:
+
+    ```shell
+    tinygo flash -target=itsybitsy-nrf52840 [PATH TO YOUR PROGRAM]
+    ```
+
+- The ItsyBitsy-nRF52840 board should restart and then begin running your program.
+
+### Troubleshooting
+
+If you have troubles getting your ItsyBitsy-nRF52840 board to receive code, try this:
+
+- Press the "RESET" button on the board two times to get the ItsyBitsy-nRF52840 board ready to receive code.
+- The ItsyBitsy-nRF52840 board will appear to your computer like a USB drive.
+- Now try running the command:
+
+    ```shell
+    tinygo flash -target=itsybitsy-nrf52840 [PATH TO YOUR PROGRAM]
+    ```
+
+Once you have updated your ItsyBitsy-nRF52840 board the first time, after that you should be able to flash it entirely from the command line.
+
+## Notes
+
+You can use the USB port to the ItsyBitsy-nRF52840 as a serial port. `UART0` refers to this connection.
+
+For an example that uses the built-in Neopixel LEDs, take a look at the TinyGo drivers repository located at [https://github.com/tinygo-org/drivers/tree/release/examples](https://github.com/tinygo-org/drivers)
+
+Bluetooth support is now available for the ItsyBitsy-nRF52840 board. See https://github.com/tinygo-org/bluetooth for more information.

--- a/content/microcontrollers/nrf52840-mdk.md
+++ b/content/microcontrollers/nrf52840-mdk.md
@@ -15,6 +15,7 @@ The [nRF52840-MDK](https://wiki.makerdiary.com/nrf52840-mdk/) is an open-source,
 | I2C      | YES | YES |
 | ADC      | YES | Not yet |
 | PWM      | YES | Not yet |
+| Bluetooth      | YES | YES |
 
 ## Machine Package Docs
 
@@ -28,3 +29,7 @@ Programs are loaded onto the nRF52840-MDK board using the `openocd` command line
 
 - Plug your nRF52840-MDK into your computer's USB port.
 - Build and flash your TinyGo program using `tinygo flash -target=nrf52840-mdk`
+
+## Notes
+
+Bluetooth support is now available for nRF52840 boards. See https://github.com/tinygo-org/bluetooth for more information.

--- a/content/microcontrollers/particle-argon.md
+++ b/content/microcontrollers/particle-argon.md
@@ -15,6 +15,7 @@ weight: 3
 | I2C      | YES | YES |
 | ADC      | YES | YES |
 | PWM      | YES | YES |
+| Bluetooth      | YES | Not yet |
 
 ## Machine Package Docs
 

--- a/content/microcontrollers/particle-boron.md
+++ b/content/microcontrollers/particle-boron.md
@@ -15,6 +15,7 @@ weight: 3
 | I2C      | YES | YES |
 | ADC      | YES | YES |
 | PWM      | YES | YES |
+| Bluetooth      | YES | Not yet |
 
 ## Machine Package Docs
 

--- a/content/microcontrollers/particle-xenon.md
+++ b/content/microcontrollers/particle-xenon.md
@@ -15,6 +15,7 @@ weight: 3
 | I2C      | YES | YES |
 | ADC      | YES | YES |
 | PWM      | YES | YES |
+| Bluetooth      | YES | Not yet |
 
 ## Machine Package Docs
 

--- a/content/microcontrollers/pca10031.md
+++ b/content/microcontrollers/pca10031.md
@@ -15,6 +15,7 @@ The [Nordic Semiconductor PCA10031](https://www.nordicsemi.com/eng/Products/nRF5
 | I2C      | YES | Not yet |
 | ADC      | YES | Not yet |
 | PWM      | YES | Not yet |
+| Bluetooth      | YES | YES |
 
 ## Machine Package Docs
 

--- a/content/microcontrollers/pca10040.md
+++ b/content/microcontrollers/pca10040.md
@@ -15,6 +15,7 @@ The [Nordic Semiconductor PCA10040](https://www.nordicsemi.com/eng/Products/Blue
 | I2C      | YES | YES |
 | ADC      | YES | YES |
 | PWM      | YES | YES |
+| Bluetooth      | YES | YES |
 
 ## Machine Package Docs
 

--- a/content/microcontrollers/pca10056.md
+++ b/content/microcontrollers/pca10056.md
@@ -15,6 +15,7 @@ The [Nordic Semiconductor PCA10056](https://www.nordicsemi.com/Software-and-Tool
 | I2C      | YES | YES |
 | ADC      | YES | Not yet |
 | PWM      | YES | Not yet |
+| Bluetooth      | YES | YES |
 
 ## Machine Package Docs
 

--- a/content/microcontrollers/reelboard.md
+++ b/content/microcontrollers/reelboard.md
@@ -17,6 +17,7 @@ It is equipped with an Electrophoretic (electronic ink) Display (EPD), along wit
 | I2C      | YES | YES |
 | ADC      | YES | Not yet |
 | PWM      | YES | Not yet |
+| Bluetooth      | YES | YES |
 
 ## Machine Package Docs
 
@@ -44,3 +45,5 @@ Programs can also be loaded onto the reelboard using the `openocd` command line 
 
 - Plug your reelboard into your computer's USB port.
 - Build and flash your TinyGo program using `tinygo flash -target=reelboard`
+
+Bluetooth support is now available for reelboard. See https://github.com/tinygo-org/bluetooth for more information.

--- a/content/microcontrollers/stm32f4discovery.md
+++ b/content/microcontrollers/stm32f4discovery.md
@@ -14,7 +14,7 @@ CS43L22 audio DAC, 2 user buttons, and 4 user LEDs.
 | --------- | ------------- | ----- |
 | GPIO      | YES | YES |
 | UART      | YES | YES |
-| SPI      | YES | Not yet |
+| SPI      | YES | YES |
 | I2C      | YES | Not yet |
 | ADC      | YES | Not yet |
 | PWM      | YES | Not yet |

--- a/content/webassembly/webassembly.md
+++ b/content/webassembly/webassembly.md
@@ -57,13 +57,13 @@ Note the `--no-debug` flag, which reduces the size of the final binary by removi
 debug symbols from the output. Also note that you must change the path to your Wasm file from `/go/src/github.com/myuser/myrepo/wasm-main.go` to whatever the actual path to your file is:
 
 ```
-docker run -v $GOPATH:/go -e "GOPATH=/go" tinygo/tinygo:0.14.1 tinygo build -o /go/src/github.com/myuser/myrepo/wasm.wasm -target wasm --no-debug /go/src/github.com/myuser/myrepo/wasm-main.go
+docker run -v $GOPATH:/go -e "GOPATH=/go" tinygo/tinygo:0.15.0 tinygo build -o /go/src/github.com/myuser/myrepo/wasm.wasm -target wasm --no-debug /go/src/github.com/myuser/myrepo/wasm-main.go
 ```
 
 Make sure you copy `wasm_exec.js` to your runtime environment:
 
 ```
-docker run -v $GOPATH:/go -e "GOPATH=/go" tinygo/tinygo:0.14.1 /bin/bash -c "cp /usr/local/tinygo/targets/wasm_exec.js /go/src/github.com/myuser/myrepo/
+docker run -v $GOPATH:/go -e "GOPATH=/go" tinygo/tinygo:0.15.0 /bin/bash -c "cp /usr/local/tinygo/targets/wasm_exec.js /go/src/github.com/myuser/myrepo/
 ```
 
 More complete examples are provided in the [wasm examples](https://github.com/tinygo-org/tinygo/tree/master/src/examples/wasm).


### PR DESCRIPTION
This PR starts the process for the docs matching the next release of TinyGo.

It starts by adding new boards arduino zero, esp32, esp8266, itsybitsy-nrf52840, and feather-stm32f405.

The docs pages themselves for each of these platforms will need more work before release, but this gives us something to work from.