### PR TITLE
microcontrollers: remove I2C from ESP8266

### DIFF
--- a/content/microcontrollers/arduino-nano33-iot.md
+++ b/content/microcontrollers/arduino-nano33-iot.md
@@ -76,29 +76,7 @@ bossac --help
 
 Once you have installed the needed BOSSA command line utility, as in the previous section, you are ready to build and flash code to your Arduino Nano33 IoT board.
 
-### CLI Flashing on Linux
-
-- Plug your Arduino Nano33 IoT board into your computer's USB port.
-- Build and flash your TinyGo code using the `tinygo flash` command. This command flashes the Arduino Nano33 IoT with the blinky1 example:
-
-    ```
-    tinygo flash -target=arduino-nano33 examples/blinky1
-    ```
-
-- The Arduino Nano33 IoT board should restart and then begin running your program.
-
-### CLI Flashing on macOS
-
-- Plug your Arduino Nano33 IoT board into your computer's USB port.
-- Build and flash your TinyGo code using the `tinygo flash` command. This command flashes the Arduino Nano33 IoT with the blinky1 example:
-
-    ```
-    tinygo flash -target=arduino-nano33 examples/blinky1
-    ```
-
-- The Arduino Nano33 IoT board should restart and then begin running your program.
-
-### CLI Flashing on Windows
+### CLI Flashing
 
 - Plug your Arduino Nano33 IoT board into your computer's USB port.
 - Build and flash your TinyGo code using the `tinygo flash` command. This command flashes the Arduino Nano33 IoT with the blinky1 example:

--- a/content/microcontrollers/arduino-zero.md
+++ b/content/microcontrollers/arduino-zero.md
@@ -70,7 +70,7 @@ bossac --help
 
 Once you have installed the needed BOSSA command line utility, as in the previous section, you are ready to build and flash code to your Arduino Zero board.
 
-### CLI Flashing on Linux
+### CLI Flashing
 
 - Plug your Arduino Zero board into your computer's USB port.
 - Build and flash your TinyGo code using the `tinygo flash` command. This command flashes the Arduino Zero with the blinky1 example:
@@ -81,27 +81,6 @@ Once you have installed the needed BOSSA command line utility, as in the previou
 
 - The Arduino Zero board should restart and then begin running your program.
 
-### CLI Flashing on macOS
-
-- Plug your Arduino Zero board into your computer's USB port.
-- Build and flash your TinyGo code using the `tinygo flash` command. This command flashes the Arduino Zero with the blinky1 example:
-
-    ```
-    tinygo flash -target=arduino-zero examples/blinky1
-    ```
-
-- The Arduino Zero board should restart and then begin running your program.
-
-### CLI Flashing on Windows
-
-- Plug your Arduino Zero board into your computer's USB port.
-- Build and flash your TinyGo code using the `tinygo flash` command. This command flashes the Arduino Zero with the blinky1 example:
-
-    ```
-    tinygo flash -target=arduino-zero examples/blinky1
-    ```
-
-- The Arduino Zero board should restart and then begin running your program.
 
 ### Troubleshooting
 

--- a/content/microcontrollers/circuit-playground-bluefruit.md
+++ b/content/microcontrollers/circuit-playground-bluefruit.md
@@ -27,29 +27,7 @@ The [Adafruit Circuit Playground Bluefruit](https://www.adafruit.com/product/433
 
 The Circuit Playground Bluefruit comes with the [UF2 bootloader](https://github.com/Microsoft/uf2) already installed.
 
-### CLI Flashing on Linux
-
-- Plug your Circuit Playground Bluefruit into your computer's USB port.
-- Flash your TinyGo program to the board using this command:
-
-    ```shell
-    tinygo flash -target=circuitplay-bluefruit [PATH TO YOUR PROGRAM]
-    ```
-
-- The Circuit Playground Bluefruit board should restart and then begin running your program.
-
-### CLI Flashing on macOS
-
-- Plug your Circuit Playground Bluefruit into your computer's USB port.
-- Flash your TinyGo program to the board using this command:
-
-    ```shell
-    tinygo flash -target=circuitplay-bluefruit [PATH TO YOUR PROGRAM]
-    ```
-
-- The Circuit Playground Bluefruit board should restart and then begin running your program.
-
-### CLI Flashing on Windows
+### CLI Flashing
 
 - Plug your Circuit Playground Bluefruit into your computer's USB port.
 - Flash your TinyGo program to the board using this command:

--- a/content/microcontrollers/circuit-playground-express.md
+++ b/content/microcontrollers/circuit-playground-express.md
@@ -26,29 +26,7 @@ The [Adafruit Circuit Playground Express](https://www.adafruit.com/product/3333)
 
 The Circuit Playground Express comes with the [UF2 bootloader](https://github.com/Microsoft/uf2) already installed.
 
-### CLI Flashing on Linux
-
-- Plug your Circuit Playground Express into your computer's USB port.
-- Flash your TinyGo program to the board using this command:
-
-    ```shell
-    tinygo flash -target=circuitplay-express [PATH TO YOUR PROGRAM]
-    ```
-
-- The Circuit Playground Express board should restart and then begin running your program.
-
-### CLI Flashing on macOS
-
-- Plug your Circuit Playground Express into your computer's USB port.
-- Flash your TinyGo program to the board using this command:
-
-    ```shell
-    tinygo flash -target=circuitplay-express [PATH TO YOUR PROGRAM]
-    ```
-
-- The Circuit Playground Express board should restart and then begin running your program.
-
-### CLI Flashing on Windows
+### CLI Flashing
 
 - Plug your Circuit Playground Express into your computer's USB port.
 - Flash your TinyGo program to the board using this command:

--- a/content/microcontrollers/clue-alpha.md
+++ b/content/microcontrollers/clue-alpha.md
@@ -27,29 +27,7 @@ The [Adafruit CLUE](https://www.adafruit.com/product/4500) is small ARM developm
 
 The CLUE comes with the [UF2 bootloader](https://github.com/Microsoft/uf2) already installed.
 
-### CLI Flashing on Linux
-
-- Plug your CLUE into your computer's USB port.
-- Flash your TinyGo program to the board using this command:
-
-    ```shell
-    tinygo flash -target=clue-alpha [PATH TO YOUR PROGRAM]
-    ```
-
-- The CLUE board should restart and then begin running your program.
-
-### CLI Flashing on macOS
-
-- Plug your CLUE into your computer's USB port.
-- Flash your TinyGo program to the board using this command:
-
-    ```shell
-    tinygo flash -target=clue-alpha [PATH TO YOUR PROGRAM]
-    ```
-
-- The CLUE board should restart and then begin running your program.
-
-### CLI Flashing on Windows
+### CLI Flashing
 
 - Plug your CLUE into your computer's USB port.
 - Flash your TinyGo program to the board using this command:

--- a/content/microcontrollers/esp8266.md
+++ b/content/microcontrollers/esp8266.md
@@ -12,9 +12,7 @@ The [Espressif ESP8266](https://www.espressif.com/en/products/socs/esp8266) is s
 | GPIO      | YES | YES |
 | UART      | YES | YES |
 | SPI      | YES | Not Yet |
-| I2C      | YES | Not Yet |
 | ADC      | YES | Not Yet |
-| PWM      | YES | Not Yet |
 | WiFi      | YES | Not Yet |
 
 ## Machine Package Docs

--- a/content/microcontrollers/feather-m0.md
+++ b/content/microcontrollers/feather-m0.md
@@ -26,29 +26,7 @@ The [Adafruit Feather M0](https://www.adafruit.com/product/3403) is a tiny ARM d
 
 The Feather M0 comes with the [UF2 bootloader](https://github.com/Microsoft/uf2) already installed.
 
-### CLI Flashing on Linux
-
-- Plug your Feather M0 into your computer's USB port.
-- Flash your TinyGo program to the board using this command:
-
-    ```shell
-    tinygo flash -target=feather-m0 [PATH TO YOUR PROGRAM]
-    ```
-
-- The Feather M0 board should restart and then begin running your program.
-
-### CLI Flashing on macOS
-
-- Plug your Feather M0 into your computer's USB port.
-- Flash your TinyGo program to the board using this command:
-
-    ```shell
-    tinygo flash -target=feather-m0 [PATH TO YOUR PROGRAM]
-    ```
-
-- The Feather M0 board should restart and then begin running your program.
-
-### CLI Flashing on Windows
+### CLI Flashing
 
 - Plug your Feather M0 into your computer's USB port.
 - Flash your TinyGo program to the board using this command:

--- a/content/microcontrollers/feather-m4.md
+++ b/content/microcontrollers/feather-m4.md
@@ -26,7 +26,7 @@ The [Adafruit Feather M4](https://www.adafruit.com/product/3857) is a tiny ARM d
 
 The Feather M4 comes with the [UF2 bootloader](https://github.com/Microsoft/uf2) already installed.
 
-### CLI Flashing on Linux
+### CLI Flashing
 
 - Plug your Feather M4 into your computer's USB port.
 - Flash your TinyGo program to the board using this command:
@@ -37,27 +37,6 @@ The Feather M4 comes with the [UF2 bootloader](https://github.com/Microsoft/uf2)
 
 - The Feather M4 board should restart and then begin running your program.
 
-### CLI Flashing on macOS
-
-- Plug your Feather M4 into your computer's USB port.
-- Flash your TinyGo program to the board using this command:
-
-    ```shell
-    tinygo flash -target=feather-m4 [PATH TO YOUR PROGRAM]
-    ```
-
-- The Feather M4 board should restart and then begin running your program.
-
-### CLI Flashing on Windows
-
-- Plug your Feather M4 into your computer's USB port.
-- Flash your TinyGo program to the board using this command:
-
-    ```shell
-    tinygo flash -target=feather-m4 [PATH TO YOUR PROGRAM]
-    ```
-
-- The Feather M4 board should restart and then begin running your program.
 
 ### Troubleshooting
 

--- a/content/microcontrollers/feather-nrf52840.md
+++ b/content/microcontrollers/feather-nrf52840.md
@@ -27,29 +27,7 @@ The [Adafruit Feather nRF52840](https://www.adafruit.com/product/4500) is a smal
 
 The Adafruit Feather nRF52840 comes with the [UF2 bootloader](https://github.com/Microsoft/uf2) already installed.
 
-### CLI Flashing on Linux
-
-- Plug your Adafruit Feather nRF52840 into your computer's USB port.
-- Flash your TinyGo program to the board using this command:
-
-    ```shell
-    tinygo flash -target=feather-nrf52840 [PATH TO YOUR PROGRAM]
-    ```
-
-- The Adafruit Feather nRF52840 board should restart and then begin running your program.
-
-### CLI Flashing on macOS
-
-- Plug your Adafruit Feather nRF52840 into your computer's USB port.
-- Flash your TinyGo program to the board using this command:
-
-    ```shell
-    tinygo flash -target=feather-nrf52840 [PATH TO YOUR PROGRAM]
-    ```
-
-- The Adafruit Feather nRF52840 board should restart and then begin running your program.
-
-### CLI Flashing on Windows
+### CLI Flashing
 
 - Plug your Adafruit Feather nRF52840 into your computer's USB port.
 - Flash your TinyGo program to the board using this command:

--- a/content/microcontrollers/itsybitsy-m0.md
+++ b/content/microcontrollers/itsybitsy-m0.md
@@ -26,29 +26,7 @@ The [Adafruit ItsyBitsy M0](https://www.adafruit.com/product/3727) is very compa
 
 The ItsyBitsy M0 comes with the [UF2 bootloader](https://github.com/Microsoft/uf2) already installed.
 
-### CLI Flashing on Linux
-
-- Plug your ItsyBitsy M0 into your computer's USB port.
-- Flash your TinyGo program to the board using this command:
-
-    ```shell
-    tinygo flash -target=itsybitsy-m0 [PATH TO YOUR PROGRAM]
-    ```
-
-- The ItsyBitsy M0 board should restart and then begin running your program.
-
-### CLI Flashing on macOS
-
-- Plug your ItsyBitsy M0 into your computer's USB port.
-- Flash your TinyGo program to the board using this command:
-
-    ```shell
-    tinygo flash -target=itsybitsy-m0 [PATH TO YOUR PROGRAM]
-    ```
-
-- The ItsyBitsy M0 board should restart and then begin running your program.
-
-### CLI Flashing on Windows
+### CLI Flashing
 
 - Plug your ItsyBitsy M0 into your computer's USB port.
 - Flash your TinyGo program to the board using this command:

--- a/content/microcontrollers/itsybitsy-m4.md
+++ b/content/microcontrollers/itsybitsy-m4.md
@@ -26,29 +26,7 @@ The [Adafruit ItsyBitsy M4](https://www.adafruit.com/product/3800) is very compa
 
 The ItsyBitsy M4 comes with the [UF2 bootloader](https://github.com/Microsoft/uf2) already installed.
 
-### CLI Flashing on Linux
-
-- Plug your ItsyBitsy M4 into your computer's USB port.
-- Flash your TinyGo program to the board using this command:
-
-    ```shell
-    tinygo flash -target=itsybitsy-m4 [PATH TO YOUR PROGRAM]
-    ```
-
-- The ItsyBitsy M4 board should restart and then begin running your program.
-
-### CLI Flashing on macOS
-
-- Plug your ItsyBitsy M4 into your computer's USB port.
-- Flash your TinyGo program to the board using this command:
-
-    ```shell
-    tinygo flash -target=itsybitsy-m4 [PATH TO YOUR PROGRAM]
-    ```
-
-- The ItsyBitsy M4 board should restart and then begin running your program.
-
-### CLI Flashing on Windows
+### CLI Flashing
 
 - Plug your ItsyBitsy M4 into your computer's USB port.
 - Flash your TinyGo program to the board using this command:

--- a/content/microcontrollers/itsybitsy-nrf52840.md
+++ b/content/microcontrollers/itsybitsy-nrf52840.md
@@ -27,29 +27,7 @@ The [Adafruit ItsyBitsy-nRF52840](https://www.adafruit.com/product/4333) is a sm
 
 The ItsyBitsy-nRF52840 comes with the [UF2 bootloader](https://github.com/Microsoft/uf2) already installed.
 
-### CLI Flashing on Linux
-
-- Plug your ItsyBitsy-nRF52840 into your computer's USB port.
-- Flash your TinyGo program to the board using this command:
-
-    ```shell
-    tinygo flash -target=itsybitsy-nrf52840 [PATH TO YOUR PROGRAM]
-    ```
-
-- The ItsyBitsy-nRF52840 board should restart and then begin running your program.
-
-### CLI Flashing on macOS
-
-- Plug your ItsyBitsy-nRF52840 into your computer's USB port.
-- Flash your TinyGo program to the board using this command:
-
-    ```shell
-    tinygo flash -target=itsybitsy-nrf52840 [PATH TO YOUR PROGRAM]
-    ```
-
-- The ItsyBitsy-nRF52840 board should restart and then begin running your program.
-
-### CLI Flashing on Windows
+### CLI Flashing
 
 - Plug your ItsyBitsy-nRF52840 into your computer's USB port.
 - Flash your TinyGo program to the board using this command:

--- a/content/microcontrollers/metro-m4-airlift.md
+++ b/content/microcontrollers/metro-m4-airlift.md
@@ -26,29 +26,7 @@ The [Adafruit Metro M4 Express AirLift](https://www.adafruit.com/product/4000) i
 
 The Metro M4 Express comes with the [UF2 bootloader](https://github.com/Microsoft/uf2) already installed.
 
-### CLI Flashing on Linux
-
-- Plug your Metro M4 Express into your computer's USB port.
-- Flash your TinyGo program to the board using this command:
-
-    ```shell
-    tinygo flash -target=metro-m4-airlift [PATH TO YOUR PROGRAM]
-    ```
-
-- The Metro M4 Express board should restart and then begin running your program.
-
-### CLI Flashing on macOS
-
-- Plug your Metro M4 Express into your computer's USB port.
-- Flash your TinyGo program to the board using this command:
-
-    ```shell
-    tinygo flash -target=metro-m4-airlift [PATH TO YOUR PROGRAM]
-    ```
-
-- The Metro M4 Express board should restart and then begin running your program.
-
-### CLI Flashing on Windows
+### CLI Flashing
 
 - Plug your Metro M4 Express into your computer's USB port.
 - Flash your TinyGo program to the board using this command:

--- a/content/microcontrollers/pybadge.md
+++ b/content/microcontrollers/pybadge.md
@@ -28,29 +28,7 @@ It has many built-in devices, such as a 1.8" 160x128 Color TFT Display, 8 x butt
 
 The PyBadge comes with the [UF2 bootloader](https://github.com/Microsoft/uf2) already installed.
 
-### CLI Flashing on Linux
-
-- Plug your PyBadge into your computer's USB port.
-- Flash your TinyGo program to the board using this command:
-
-    ```shell
-    tinygo flash -target=pybadge [PATH TO YOUR PROGRAM]
-    ```
-
-- The PyBadge board should restart and then begin running your program.
-
-### CLI Flashing on macOS
-
-- Plug your PyBadge into your computer's USB port.
-- Flash your TinyGo program to the board using this command:
-
-    ```shell
-    tinygo flash -target=pybadge [PATH TO YOUR PROGRAM]
-    ```
-
-- The PyBadge board should restart and then begin running your program.
-
-### CLI Flashing on Windows
+### CLI Flashing
 
 - Plug your PyBadge into your computer's USB port.
 - Flash your TinyGo program to the board using this command:

--- a/content/microcontrollers/pygamer.md
+++ b/content/microcontrollers/pygamer.md
@@ -28,29 +28,7 @@ It has many built-in devices, such as a 1.8" 160x128 Color TFT Display, a dual-p
 
 The PyGamer comes with the [UF2 bootloader](https://github.com/Microsoft/uf2) already installed.
 
-### CLI Flashing on Linux
-
-- Plug your PyGamer into your computer's USB port.
-- Flash your TinyGo program to the board using this command:
-
-    ```shell
-    tinygo flash -target=pygamer [PATH TO YOUR PROGRAM]
-    ```
-
-- The PyGamer board should restart and then begin running your program.
-
-### CLI Flashing on macOS
-
-- Plug your PyGamer into your computer's USB port.
-- Flash your TinyGo program to the board using this command:
-
-    ```shell
-    tinygo flash -target=pygamer [PATH TO YOUR PROGRAM]
-    ```
-
-- The PyGamer board should restart and then begin running your program.
-
-### CLI Flashing on Windows
+### CLI Flashing
 
 - Plug your PyGamer into your computer's USB port.
 - Flash your TinyGo program to the board using this command:

--- a/content/microcontrollers/pyportal.md
+++ b/content/microcontrollers/pyportal.md
@@ -28,29 +28,7 @@ The PyPortal also has an Espressif ESP32 Wi-Fi coprocessor with TLS/SSL support 
 
 The PyPortal comes with the [UF2 bootloader](https://github.com/Microsoft/uf2) already installed.
 
-### CLI Flashing on Linux
-
-- Plug your PyPortal into your computer's USB port.
-- Flash your TinyGo program to the board using this command:
-
-    ```shell
-    tinygo flash -target=pyportal [PATH TO YOUR PROGRAM]
-    ```
-
-- The PyPortal board should restart and then begin running your program.
-
-### CLI Flashing on macOS
-
-- Plug your PyPortal into your computer's USB port.
-- Flash your TinyGo program to the board using this command:
-
-    ```shell
-    tinygo flash -target=pyportal [PATH TO YOUR PROGRAM]
-    ```
-
-- The PyPortal board should restart and then begin running your program.
-
-### CLI Flashing on Windows
+### CLI Flashing
 
 - Plug your PyPortal into your computer's USB port.
 - Flash your TinyGo program to the board using this command:

--- a/content/microcontrollers/teensy36.md
+++ b/content/microcontrollers/teensy36.md
@@ -26,29 +26,7 @@ The [PJRC Teensy 3.6](https://www.pjrc.com/store/teensy36.html) is a small ARM d
 
 In order to flash your TinyGo programs onto the Teensy 3.6 board, you will need to install the `teensy_loader_cli` (https://github.com/PaulStoffregen/teensy_loader_cli) on your machine.
 
-### CLI Flashing on Linux
-
-- Plug your Teensy 3.6 into your computer's USB port.
-- Flash your TinyGo program to the board using this command:
-
-    ```shell
-    tinygo flash -target=teensy36 [PATH TO YOUR PROGRAM]
-    ```
-
-- The Teensy 3.6 board should restart and then begin running your program.
-
-### CLI Flashing on macOS
-
-- Plug your Teensy 3.6 into your computer's USB port.
-- Flash your TinyGo program to the board using this command:
-
-    ```shell
-    tinygo flash -target=teensy36 [PATH TO YOUR PROGRAM]
-    ```
-
-- The Teensy 3.6 board should restart and then begin running your program.
-
-### CLI Flashing on Windows
+### CLI Flashing
 
 - Plug your Teensy 3.6 into your computer's USB port.
 - Flash your TinyGo program to the board using this command:

--- a/content/microcontrollers/trinket-m0.md
+++ b/content/microcontrollers/trinket-m0.md
@@ -26,29 +26,7 @@ The [Adafruit Trinket M0](https://www.adafruit.com/product/3500) is a tiny ARM d
 
 The Trinket M0 comes with the [UF2 bootloader](https://github.com/Microsoft/uf2) already installed.
 
-### CLI Flashing on Linux
-
-- Plug your Trinket M0 into your computer's USB port.
-- Flash your TinyGo program to the board using this command:
-
-    ```shell
-    tinygo flash -target=trinket-m0 [PATH TO YOUR PROGRAM]
-    ```
-
-- The Trinket M0 board should restart and then begin running your program.
-
-### CLI Flashing on macOS
-
-- Plug your Trinket M0 into your computer's USB port.
-- Flash your TinyGo program to the board using this command:
-
-    ```shell
-    tinygo flash -target=trinket-m0 [PATH TO YOUR PROGRAM]
-    ```
-
-- The Trinket M0 board should restart and then begin running your program.
-
-### CLI Flashing on Windows
+### CLI Flashing
 
 - Plug your Trinket M0 into your computer's USB port.
 - Flash your TinyGo program to the board using this command:

--- a/content/microcontrollers/wioterminal.md
+++ b/content/microcontrollers/wioterminal.md
@@ -26,29 +26,7 @@ The [Seeed Wio Terminal](https://www.seeedstudio.com/Wio-Terminal-p-4509.html) i
 
 The Wio Terminal comes with the [UF2 bootloader](https://github.com/Microsoft/uf2) already installed.
 
-### CLI Flashing on Linux
-
-- Plug your Wio Terminal into your computer's USB port.
-- Flash your TinyGo program to the board using this command:
-
-    ```shell
-    tinygo flash -target=wioterminal [PATH TO YOUR PROGRAM]
-    ```
-
-- The Wio Terminal board should restart and then begin running your program.
-
-### CLI Flashing on macOS
-
-- Plug your Wio Terminal into your computer's USB port.
-- Flash your TinyGo program to the board using this command:
-
-    ```shell
-    tinygo flash -target=wioterminal [PATH TO YOUR PROGRAM]
-    ```
-
-- The Wio Terminal board should restart and then begin running your program.
-
-### CLI Flashing on Windows
+### CLI Flashing
 
 - Plug your Wio Terminal into your computer's USB port.
 - Flash your TinyGo program to the board using this command:

--- a/content/microcontrollers/xiao.md
+++ b/content/microcontrollers/xiao.md
@@ -26,29 +26,7 @@ The [Seeed Seeeduino XIAO](https://www.seeedstudio.com/Seeeduino-XIAO-Arduino-Mi
 
 The XIAO comes with the [UF2 bootloader](https://github.com/Microsoft/uf2) already installed.
 
-### CLI Flashing on Linux
-
-- Plug your XIAO into your computer's USB port.
-- Flash your TinyGo program to the board using this command:
-
-    ```shell
-    tinygo flash -target=xiao [PATH TO YOUR PROGRAM]
-    ```
-
-- The XIAO board should restart and then begin running your program.
-
-### CLI Flashing on macOS
-
-- Plug your XIAO into your computer's USB port.
-- Flash your TinyGo program to the board using this command:
-
-    ```shell
-    tinygo flash -target=xiao [PATH TO YOUR PROGRAM]
-    ```
-
-- The XIAO board should restart and then begin running your program.
-
-### CLI Flashing on Windows
+### CLI Flashing
 
 - Plug your XIAO into your computer's USB port.
 - Flash your TinyGo program to the board using this command:


### PR DESCRIPTION
The ESP8266 does not have hardware support for I2C or PWM, this will need software emulation.

Many people may think the ESP8266 does have hardware support for I2C or PWM as it's available in all the other ports, but it does not. All of it is basically software bitbanging and using timers to simulate PWM behavior. But because it is in software, it is never as reliable as real hardware support.

The ESP32 has all these things, however.