### PR TITLE
Change to use `tinygo targets`

### DIFF
--- a/doc-gen/Makefile
+++ b/doc-gen/Makefile
@@ -1,52 +1,5 @@
-
-DEVICES = \
-    arduino \
-    arduino-mega2560 \
-    arduino-nano \
-    arduino-nano33 \
-    arduino-zero \
-    bluepill \
-    circuitplay-bluefruit \
-    circuitplay-express \
-    clue_alpha \
-    digispark \
-    esp32 \
-    esp8266 \
-    feather-m0 \
-    feather-m4 \
-    feather-nrf52840 \
-    feather-stm32f405 \
-    gameboy-advance \
-    hifive1b \
-    itsybitsy-m0 \
-    itsybitsy-m4 \
-    itsybitsy-nrf52840 \
-    maixbit \
-    metro-m4-airlift \
-    microbit \
-    nintendoswitch \
-    nrf52840-mdk \
-    nucleo-f103rb \
-    particle-argon \
-    particle-boron \
-    particle-xenon \
-    pca10031 \
-    pca10040 \
-    pca10056 \
-    pinetime-devkit0 \
-    pybadge \
-    pygamer \
-    pyportal \
-    reelboard \
-    stm32f4disco \
-    teensy36 \
-    trinket-m0 \
-    wioterminal \
-    x9pro \
-    xiao
-
 all:
-	go run . $(DEVICES)
+	go run . `tinygo targets`
 
 
 #all:


### PR DESCRIPTION
Using tinygo-targets, we will see some targets that we may not need, but we won't forget to update them.

![Screenshot from 2020-11-19 21-09-08](https://user-images.githubusercontent.com/9251039/99664431-812e4700-2aab-11eb-9c47-fe6eac474132.png)

Currently, document generation for teensy40 is not possible. (#134)
Otherwise, we are able to generate it.

```
$ go run . teensy40
Generating documentation for: teensy40
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x65bded]

goroutine 1 [running]:
main.writeDoc(0x744ca0, 0xc0000b6078, 0x7ffdc4f22023, 0x8, 0xc0000f60b0, 0xb, 0xb, 0xc000182038, 0x5, 0xc000182051, ...)
        /home/sago35/dev/src/github.com/tinygo-org/tinygo-site/doc-gen/main.go:223 +0xe3d
main.writeTargetDoc(0x7ffdc4f22023, 0x8, 0xc0000b00f0, 0x2f)
        /home/sago35/dev/src/github.com/tinygo-org/tinygo-site/doc-gen/main.go:128 +0x569
main.main()
        /home/sago35/dev/src/github.com/tinygo-org/tinygo-site/doc-gen/main.go:87 +0x249
exit status 2
```