### PR TITLE
microcontrollers/adafruit-nrf: add info on how to update UF2 bootload…

### DIFF
--- a/content/microcontrollers/circuit-playground-bluefruit.md
+++ b/content/microcontrollers/circuit-playground-bluefruit.md
@@ -27,6 +27,8 @@ The [Adafruit Circuit Playground Bluefruit](https://www.adafruit.com/product/433
 
 The Circuit Playground Bluefruit comes with the [UF2 bootloader](https://github.com/Microsoft/uf2) already installed.
 
+**PLEASE NOTE** that for a good experience using TinyGo on your board you must be running version 0.4.1 or above of the UF2 bootloader on the board. For more information, [see below](#updating-the-uf2-bootloader)
+
 ### CLI Flashing
 
 - Plug your Circuit Playground Bluefruit into your computer's USB port.
@@ -60,3 +62,41 @@ For an example that uses the built-in Neopixel LEDs, take a look at the TinyGo d
 
 Bluetooth support is now available for the Circuit Playground Bluefruit board. See https://github.com/tinygo-org/bluetooth for more information.
 
+## Updating the UF2 bootloader
+
+This board uses a UF2 bootloader created by Adafruit: https://github.com/adafruit/Adafruit_nRF52_Bootloader
+
+We recommend bootloader version 0.4.1 or above. You can check what version is installed on your board by double-clicking the button on the board to launch the bootloader. When you do this, a USB volume that should automatically be mounted on your computer. Check the file named "INFO_UF2.TXT" on that drive. The bootloader firmware version should be listed in that file, for example:
+
+```
+UF2 Bootloader 0.4.1 lib/nrfx (v2.0.0) lib/tinyusb (0.6.0-272-g4e6aa0d8) lib/uf2 (remotes/origin/configupdate-9-gadbb8c7)
+Model: Adafruit Circuit Playground nRF52840
+Board-ID: nRF52840-CircuitPlayground-revD
+SoftDevice: S140 version 6.1.1
+Date: Jan 19 2021
+```
+
+To update the bootloader, you will need to install the `adafruit-nrfutil` program. 
+
+You can install it by running:
+
+```shell
+pip3 install --user adafruit-nrfutil
+```
+
+Once you have installed the `adafruit-nrfutil` program, download the firmware here: 
+https://github.com/adafruit/Adafruit_nRF52_Bootloader/releases/download/0.4.1/circuitplayground_nrf52840_bootloader-0.4.1.zip
+
+Unzip the files in this zip file and save them to a convenient location. 
+
+Plug in your Circuit Playground Bluefruit board to your computer's USB port.
+
+Now we are ready to update the firmware. Run a command something like the following, adjusting for any difference based on where you have saved the files, and what your serial port is named:
+
+```shell
+ adafruit-nrfutil --verbose dfu serial --package circuitplayground_nrf52840_bootloader-0.4.1_s140_6.1.1.zip -p /dev/ttyACM0 -b 115200 --singlebank --touch 1200
+```
+
+Note that you should be flashing the board using the zip file that was contained within the zip file that you downloaded, NOT the file that you downloaded.
+
+Once you have flashed the board with the `adafruit-nrfutil` it should restart the board with the new bootloader. You only need to do this update once, and then from that point on the new bootloader will be active.

--- a/content/microcontrollers/clue-alpha.md
+++ b/content/microcontrollers/clue-alpha.md
@@ -27,6 +27,8 @@ The [Adafruit CLUE](https://www.adafruit.com/product/4500) is small ARM developm
 
 The CLUE comes with the [UF2 bootloader](https://github.com/Microsoft/uf2) already installed.
 
+**PLEASE NOTE** that for a good experience using TinyGo on your board you must be running version 0.4.1 or above of the UF2 bootloader on the board. For more information, [see below](#updating-the-uf2-bootloader)
+
 ### CLI Flashing
 
 - Plug your CLUE into your computer's USB port.
@@ -59,3 +61,42 @@ You can use the USB port to the CLUE as a serial port. `UART0` refers to this co
 For an example that uses the built-in Neopixel LEDs, take a look at the TinyGo drivers repository located at [https://github.com/tinygo-org/drivers/tree/release/examples](https://github.com/tinygo-org/drivers)
 
 Bluetooth support is now available for the Adafruit CLUE board. See https://github.com/tinygo-org/bluetooth for more information.
+
+## Updating the UF2 bootloader
+
+This board uses a UF2 bootloader created by Adafruit: https://github.com/adafruit/Adafruit_nRF52_Bootloader
+
+We recommend bootloader version 0.4.1 or above. You can check what version is installed on your board by double-clicking the button on the board to launch the bootloader. When you do this, a USB volume that should automatically be mounted on your computer. Check the file named "INFO_UF2.TXT" on that drive. The bootloader firmware version should be listed in that file, for example:
+
+```
+UF2 Bootloader 0.4.1 lib/nrfx (v2.0.0) lib/tinyusb (0.6.0-272-g4e6aa0d8) lib/uf2 (remotes/origin/configupdate-9-gadbb8c7)
+Model: Adafruit CLUE nRF52840
+Board-ID: nRF52840-CLUE-revA
+SoftDevice: S140 version 6.1.1
+Date: Jan 19 2021
+```
+
+To update the bootloader, you will need to install the `adafruit-nrfutil` program. 
+
+You can install it by running:
+
+```shell
+pip3 install --user adafruit-nrfutil
+```
+
+Once you have installed the `adafruit-nrfutil` program, download the firmware here: 
+https://github.com/adafruit/Adafruit_nRF52_Bootloader/releases/download/0.4.1/clue_nrf52840_bootloader-0.4.1.zip
+
+Unzip the files in this zip file and save them to a convenient location. 
+
+Plug in your board to your computer's USB port.
+
+Now we are ready to update the firmware. Run a command something like the following, adjusting for any difference based on where you have saved the files, and what your serial port is named:
+
+```shell
+ adafruit-nrfutil --verbose dfu serial --package clue_nrf52840_bootloader-0.4.1_s140_6.1.1.zip -p /dev/ttyACM0 -b 115200 --singlebank --touch 1200
+```
+
+Note that you should be flashing the board using the zip file that was contained within the zip file that you downloaded, NOT the file that you downloaded.
+
+Once you have flashed the board with the `adafruit-nrfutil` it should restart the board with the new bootloader. You only need to do this update once, and then from that point on the new bootloader will be active.

--- a/content/microcontrollers/feather-nrf52840.md
+++ b/content/microcontrollers/feather-nrf52840.md
@@ -27,6 +27,8 @@ The [Adafruit Feather nRF52840](https://www.adafruit.com/product/4500) is a smal
 
 The Adafruit Feather nRF52840 comes with the [UF2 bootloader](https://github.com/Microsoft/uf2) already installed.
 
+**PLEASE NOTE** that for a good experience using TinyGo on your board you must be running version 0.4.1 or above of the UF2 bootloader on the board. For more information, [see below](#updating-the-uf2-bootloader)
+
 ### CLI Flashing
 
 - Plug your Adafruit Feather nRF52840 into your computer's USB port.
@@ -57,3 +59,42 @@ Once you have updated your Adafruit Feather nRF52840 board the first time, after
 You can use the USB port to the Adafruit Feather nRF52840 as a serial port. `UART0` refers to this connection.
 
 Bluetooth support is now available for the Adafruit Feather nRF52840 board. See https://github.com/tinygo-org/bluetooth for more information.
+
+## Updating the UF2 bootloader
+
+This board uses a UF2 bootloader created by Adafruit: https://github.com/adafruit/Adafruit_nRF52_Bootloader
+
+We recommend bootloader version 0.4.1 or above. You can check what version is installed on your board by double-clicking the button on the board to launch the bootloader. When you do this, a USB volume that should automatically be mounted on your computer. Check the file named "INFO_UF2.TXT" on that drive. The bootloader firmware version should be listed in that file, for example:
+
+```
+UF2 Bootloader 0.4.1 lib/nrfx (v2.0.0) lib/tinyusb (0.6.0-272-g4e6aa0d8) lib/uf2 (remotes/origin/configupdate-9-gadbb8c7)
+Model: Adafruit CLUE nRF52840
+Board-ID: nRF52840-CLUE-revA
+SoftDevice: S140 version 6.1.1
+Date: Jan 19 2021
+```
+
+To update the bootloader, you will need to install the `adafruit-nrfutil` program. 
+
+You can install it by running:
+
+```shell
+pip3 install --user adafruit-nrfutil
+```
+
+Once you have installed the `adafruit-nrfutil` program, download the firmware here: 
+https://github.com/adafruit/Adafruit_nRF52_Bootloader/releases/download/0.4.1/feather_nrf52832_bootloader-0.4.1.zip
+
+Unzip the files in this zip file and save them to a convenient location. 
+
+Plug in your board to your computer's USB port.
+
+Now we are ready to update the firmware. Run a command something like the following, adjusting for any difference based on where you have saved the files, and what your serial port is named:
+
+```shell
+ adafruit-nrfutil --verbose dfu serial --package feather_nrf52840_bootloader-0.4.1_s140_6.1.1.zip -p /dev/ttyACM0 -b 115200 --singlebank --touch 1200
+```
+
+Note that you should be flashing the board using the zip file that was contained within the zip file that you downloaded, NOT the file that you downloaded.
+
+Once you have flashed the board with the `adafruit-nrfutil` it should restart the board with the new bootloader. You only need to do this update once, and then from that point on the new bootloader will be active.

--- a/content/microcontrollers/itsybitsy-nrf52840.md
+++ b/content/microcontrollers/itsybitsy-nrf52840.md
@@ -27,6 +27,8 @@ The [Adafruit ItsyBitsy-nRF52840](https://www.adafruit.com/product/4333) is a sm
 
 The ItsyBitsy-nRF52840 comes with the [UF2 bootloader](https://github.com/Microsoft/uf2) already installed.
 
+**PLEASE NOTE** that for a good experience using TinyGo on your board you must be running version 0.4.1 or above of the UF2 bootloader on the board. For more information, [see below](#updating-the-uf2-bootloader)
+
 ### CLI Flashing
 
 - Plug your ItsyBitsy-nRF52840 into your computer's USB port.
@@ -59,3 +61,42 @@ You can use the USB port to the ItsyBitsy-nRF52840 as a serial port. `UART0` ref
 For an example that uses the built-in Neopixel LEDs, take a look at the TinyGo drivers repository located at [https://github.com/tinygo-org/drivers/tree/release/examples](https://github.com/tinygo-org/drivers)
 
 Bluetooth support is now available for the ItsyBitsy-nRF52840 board. See https://github.com/tinygo-org/bluetooth for more information.
+
+## Updating the UF2 bootloader
+
+This board uses a UF2 bootloader created by Adafruit: https://github.com/adafruit/Adafruit_nRF52_Bootloader
+
+We recommend bootloader version 0.4.1 or above. You can check what version is installed on your board by double-clicking the button on the board to launch the bootloader. When you do this, a USB volume that should automatically be mounted on your computer. Check the file named "INFO_UF2.TXT" on that drive. The bootloader firmware version should be listed in that file, for example:
+
+```
+UF2 Bootloader 0.4.1 lib/nrfx (v2.0.0) lib/tinyusb (0.6.0-272-g4e6aa0d8) lib/uf2 (remotes/origin/configupdate-9-gadbb8c7)
+Model: Adafruit ItsyBitsy nRF52840 Express
+Board-ID: nRF52840-ItsyBitsy-revA
+SoftDevice: S140 version 6.1.1
+Date: Jan 19 2021
+```
+
+To update the bootloader, you will need to install the `adafruit-nrfutil` program. 
+
+You can install it by running:
+
+```shell
+pip3 install --user adafruit-nrfutil
+```
+
+Once you have installed the `adafruit-nrfutil` program, download the firmware here: 
+https://github.com/adafruit/Adafruit_nRF52_Bootloader/releases/download/0.4.1/itsybitsy_nrf52840_express_bootloader-0.4.1.zip
+
+Unzip the files in this zip file and save them to a convenient location. 
+
+Plug in your board to your computer's USB port.
+
+Now we are ready to update the firmware. Run a command something like the following, adjusting for any difference based on where you have saved the files, and what your serial port is named:
+
+```shell
+ adafruit-nrfutil --verbose dfu serial --package itsybitsy_nrf52840_express_bootloader-0.4.1_s140_6.1.1.zip -p /dev/ttyACM0 -b 115200 --singlebank --touch 1200
+```
+
+Note that you should be flashing the board using the zip file that was contained within the zip file that you downloaded, NOT the file that you downloaded.
+
+Once you have flashed the board with the `adafruit-nrfutil` it should restart the board with the new bootloader. You only need to do this update once, and then from that point on the new bootloader will be active.


### PR DESCRIPTION
This PR add add info on how to update the UF2 bootloader  to version 0.4.0 on Adafruit nrf based boards.

This is needed for the TinyGo flashing process to work smoothly on these boards.