### PR TITLE
add scheduler options

### DIFF
--- a/content/usage/important-options.md
+++ b/content/usage/important-options.md
@@ -11,16 +11,16 @@ Output filename, see the ``build`` command.
 - `-target`
 Select the target you want to use. Leave it empty to compile for the host. This switch also configures the emulator, flash tool and debugger to use so you don't have to fiddle with those options. Read [supported targets](../../microcontrollers/) for a list of supported targets. Example targets:
 
- - wasm
+  - wasm
 WebAssembly target. Creates .wasm files that can be run in a web browser.
 
- - arduino
+  - arduino
 Compile using the experimental AVR backend to run Go programs on an Arduino Uno.
 
- - microbit
+  - microbit
 Compile programs for the `BBC micro:bit <https://microbit.org/>`_.
 
- - qemu
+  - qemu
 Run on a Stellaris LM3S as emulated by QEMU.
 
 - `-port`
@@ -29,19 +29,19 @@ Specify the serial port used for flashing. This is used for the Arduino Uno, whi
 - `-opt`
 Which optimization level to use. Optimization levels roughly follow standard `-O` level options like ``-O2``, ``-Os``, etc. Available optimization levels:
 
- - `-opt=0`
+  - `-opt=0`
 Disable as much optimizations as possible. There are still a few optimization passes that run to make sure the program executes correctly, but all LLVM passes that can be disabled are disabled.
 
- - `-opt=1`
+  - `-opt=1`
 Enable only a few optimization passes. In particular, this keeps the inliner disabled. It can be useful when you want to look at the generated IR but want to avoid the noise that is common in non-optimized code.
 
- - `-opt=2`
+  - `-opt=2`
 A good optimization level for use cases not strongly limited by code size. Provided here for completeness. It enables most optimizations and will likely result in the fastest code.
 
- - `-opt=s`
+  - `-opt=s`
 Like `-opt=2`, but while being more careful about code size. It provides a balance between performance and code size.
 
- - `-opt=z` (default)
+  - `-opt=z` (default)
 Like ``-opt=s``, but more aggressive about code size. This pass also reduces the inliner threshold by a large margin. Use this pass if you care a lot about code size.
 
 - `-ocd-output`
@@ -50,13 +50,13 @@ Print output of the on-chip debugger tool (like OpenOCD) while in a `tinygo gdb`
 - `-gc`
 Use the specified memory manager:
 
- - `-gc=none`
+  - `-gc=none`
 Do not use a memory manager at all. This will cause a link error at every place in the program that tries to allocate memory. The primary use case for this is finding such locations.
 
- - `-gc=dumb`
+  - `-gc=dumb`
 Only allocate memory, never free it. This is the simplest allocator possible and uses very few resources while being very portable. Also, allocation is very fast. Larger programs will likely need a real garbage collector.
 
- - `-gc=marksweep`
+  - `-gc=marksweep`
 Simple conservative mark/sweep garbage collector. This collector does not yet work on all platforms. Also, the performance of the collector is highly unpredictable as any allocation may trigger a garbage collection cycle.
 
 - `-panic`
@@ -67,3 +67,10 @@ Use the specified panic strategy. That is, what the compiled program should do w
 
   - `-panic=trap`
     Do not print the panic message but instead of printing anything, it directly hits a trap instruction. This instruction varies by platform but it will result in the immediate termination of the program. It could either exit with `SIGILL` or cause a call to the `HardFault_Handler`. It can be used to reduce the size of the compiled program while keeping standard Go safety rules intact at the cost of debuggability.
+
+- `-scheduler`
+Use the specified scheduler. Without a scheduler goroutines won't work.
+
+  - `scheduler=coroutines` Use the coroutines scheduler.
+  - `scheduler=tasks` Use the tasks scheduler.
+  - `scheduler=none` None is the default value. No scheduler is being used.

--- a/content/usage/important-options.md
+++ b/content/usage/important-options.md
@@ -69,8 +69,8 @@ Use the specified panic strategy. That is, what the compiled program should do w
     Do not print the panic message but instead of printing anything, it directly hits a trap instruction. This instruction varies by platform but it will result in the immediate termination of the program. It could either exit with `SIGILL` or cause a call to the `HardFault_Handler`. It can be used to reduce the size of the compiled program while keeping standard Go safety rules intact at the cost of debuggability.
 
 - `-scheduler`
-Use the specified scheduler. Without a scheduler goroutines won't work.
+Use the specified scheduler. The default scheduler varies by platform. For example, `AVR` currently defaults to `none` because it has such limited memory while `coroutines` and `tasks` is used for other platforms. Normally you do not need to override the default except on AVR where you can optionally select the tasks scheduler if you want concurrency.
 
-  - `scheduler=coroutines` Use the coroutines scheduler.
-  - `scheduler=tasks` Use the tasks scheduler.
-  - `scheduler=none` None is the default value. No scheduler is being used.
+  - `scheduler=coroutines` UThe coroutines scheduler is a portable scheduler based on C++ coroutines that works almost everywhere and is therefore used whenever the tasks scheduler is not available or impossible to implement such as on WebAssembly.
+  - `scheduler=tasks` The tasks scheduler is a scheduler much like an RTOS available for a limited number of platforms. It currently works on AVR, baremetal ARM (Cortex-M), the ESP8266, and the ESP32. This is usually the preferred scheduler if it is available.
+  - `scheduler=none` The none scheduler disables scheduler support, which means that goroutines and channels are not available. It can be used to reduce firmware size and RAM consumption if goroutines and channels are not needed.

--- a/content/usage/important-options.md
+++ b/content/usage/important-options.md
@@ -71,6 +71,6 @@ Use the specified panic strategy. That is, what the compiled program should do w
 - `-scheduler`
 Use the specified scheduler. The default scheduler varies by platform. For example, `AVR` currently defaults to `none` because it has such limited memory while `coroutines` and `tasks` is used for other platforms. Normally you do not need to override the default except on AVR where you can optionally select the tasks scheduler if you want concurrency.
 
-  - `scheduler=coroutines` UThe coroutines scheduler is a portable scheduler based on C++ coroutines that works almost everywhere and is therefore used whenever the tasks scheduler is not available or impossible to implement such as on WebAssembly.
+  - `scheduler=coroutines` The coroutines scheduler is a portable scheduler based on C++ coroutines that works almost everywhere and is therefore used whenever the tasks scheduler is not available or impossible to implement such as on WebAssembly.
   - `scheduler=tasks` The tasks scheduler is a scheduler much like an RTOS available for a limited number of platforms. It currently works on AVR, baremetal ARM (Cortex-M), the ESP8266, and the ESP32. This is usually the preferred scheduler if it is available.
   - `scheduler=none` The none scheduler disables scheduler support, which means that goroutines and channels are not available. It can be used to reduce firmware size and RAM consumption if goroutines and channels are not needed.


### PR DESCRIPTION
Fixed some markdown lint warnings in the file. 
Also added the possible scheduler parameter. 
Some day in the future, someone who is able to explain the difference between the coroutines and task scheduler could add some more explanations there :) 