### PR TITLE
microcontrollers: new boards added as part of 0.17 release

### DIFF
--- a/content/microcontrollers/_index.md
+++ b/content/microcontrollers/_index.md
@@ -8,7 +8,7 @@ weight: 3
 
 TinyGo lets you run Go directly on microcontrollers.
 
-TinyGo has support for 48 different boards and devices such as the Arduino Nano33 IoT, Adafruit Circuit Playground Express, BBC micro:bit and more. Click on a board name found in the left menu to see the what features are supported for the given hardware.
+TinyGo has support for 53 different boards and devices such as the Arduino Nano33 IoT, Adafruit Circuit Playground Express, BBC micro:bit and more. Click on a board name found in the left menu to see the what features are supported for the given hardware.
 
 We also give you the ability to add new boards. If your target isn't listed here, please raise an issue in the [issue tracker](https://github.com/tinygo-org/tinygo/issues).
 

--- a/content/microcontrollers/adafruit-clue.md
+++ b/content/microcontrollers/adafruit-clue.md
@@ -19,7 +19,7 @@ The [Adafruit CLUE](https://www.adafruit.com/product/4500) is small ARM developm
 
 ## Machine Package Docs
 
-[Documentation for the machine package for the Adafruit CLUE](../machine/clue-alpha)
+[Documentation for the machine package for the Adafruit CLUE](../machine/adafruit-clue)
 
 ## Flashing
 
@@ -35,7 +35,7 @@ The CLUE comes with the [UF2 bootloader](https://github.com/Microsoft/uf2) alrea
 - Flash your TinyGo program to the board using this command:
 
     ```shell
-    tinygo flash -target=clue-alpha [PATH TO YOUR PROGRAM]
+    tinygo flash -target=clue [PATH TO YOUR PROGRAM]
     ```
 
 - The CLUE board should restart and then begin running your program.
@@ -49,7 +49,7 @@ If you have troubles getting your CLUE board to receive code, try this:
 - Now try running the command:
 
     ```shell
-    tinygo flash -target=clue-alpha [PATH TO YOUR PROGRAM]
+    tinygo flash -target=clue [PATH TO YOUR PROGRAM]
     ```
 
 Once you have updated your CLUE board the first time, after that you should be able to flash it entirely from the command line.

--- a/content/microcontrollers/arduino-mkr1000.md
+++ b/content/microcontrollers/arduino-mkr1000.md
@@ -1,0 +1,103 @@
+---
+title: "Arduino MKR1000"
+weight: 3
+---
+
+The [Arduino MKR1000](https://store.arduino.cc/arduino-mkr1000-wifi) is a very small ARM development board based on the Microchip [SAMD21](https://www.microchip.com/wwwproducts/en/ATSAMD21G18) family of processors. It also has a NINA-W102 chip onboard which provides an wireless communication abilities based on the popular ESP32 family of wireless chips from Espressif.
+
+## Interfaces
+
+| Interface | Hardware Supported | TinyGo Support |
+| --------- | ------------- | ----- |
+| GPIO      | YES | YES |
+| UART      | YES | YES |
+| SPI      | YES | YES |
+| I2C      | YES | YES |
+| ADC      | YES | YES |
+| PWM      | YES | YES |
+
+## Machine Package Docs
+
+[Documentation for the machine package for the Arduino MKR1000](../machine/arduino-mkr1000)
+
+## Installing BOSSA
+
+In order to flash your TinyGo programs onto the Arduino MKR1000 board, you will need to install the "bossac" command line utility which is part of the [BOSSA command line utilities](https://github.com/shumatech/BOSSA).
+
+### macOS
+
+You can use Homebrew to install the BOSSA command line interface by using the following command:
+
+```shell
+brew cask install bossa
+```
+
+Or if you  prefer, you can also download the installer from https://github.com/shumatech/BOSSA/releases/download/1.9.1/bossa-1.9.1.dmg
+
+Once you have downloaded it, double click on the .dmg file to perform the installation.
+
+### Linux
+
+On Linux, install from source:
+
+```shell
+sudo apt install libreadline-dev libwxgtk3.0-gtk3-dev
+git clone https://github.com/shumatech/BOSSA.git
+cd BOSSA
+make
+sudo cp bin/bossac /usr/local/bin
+```
+
+### Windows
+
+You can download BOSSA from https://github.com/shumatech/BOSSA/releases/download/1.9.1/bossa-x64-1.9.1.msi
+
+*VERY IMPORTANT*: During the installation, you must choose to install into `c:\Program Files`. The installer might have the wrong path, so edit it to match  `c:\Program Files`.
+
+After the installation, you must add BOSSA to your PATH:
+
+```shell
+set PATH=%PATH%;"c:\Program Files\BOSSA";
+```
+
+Test that you have installed "BOSSA" correctly by running this command:
+
+```shell
+bossac --help
+```
+
+## Flashing
+
+Once you have installed the needed BOSSA command line utility, as in the previous section, you are ready to build and flash code to your Arduino MKR1000 board.
+
+### CLI Flashing
+
+- Plug your Arduino MKR1000 board into your computer's USB port.
+- Build and flash your TinyGo code using the `tinygo flash` command. This command flashes the Arduino MKR1000 with the blinky1 example:
+
+    ```shell
+    tinygo flash -target=arduino-mkr1000 examples/blinky1
+    ```
+
+- The Arduino MKR1000 board should restart and then begin running your program.
+
+### Troubleshooting
+
+If you have troubles getting your Arduino MKR1000 board to receive code, try this:
+
+- Press the "RESET" button on the board two times to get the Arduino MKR1000 board ready to receive code.
+- Now try running the `tinygo flash` command as above:
+
+    ```shell
+    tinygo flash -target=arduino-mkr1000 [PATH TO YOUR PROGRAM]
+    ```
+
+Once you have updated your Arduino MKR1000 board the first time, after that you should be able to flash it entirely from the command line.
+
+## Notes
+
+You can use the USB port to the Arduino MKR1000 as a serial port. `UART0` refers to this connection.
+
+For information on how to use the built-in NINA-W102 wireless chip with the default firmware, please see the "wifinina" driver in the TinyGo drivers repository located at [https://github.com/tinygo-org/drivers/tree/release/wifinina](https://github.com/tinygo-org/drivers/tree/release/wifinina).
+
+You can also use the Espressif ESP-AT firmware, although you will need to flash it yourself. Please see the "espat" driver in the TinyGo drivers repository located at [https://github.com/tinygo-org/drivers/tree/release/espat](https://github.com/tinygo-org/drivers/tree/release/espat).

--- a/content/microcontrollers/dragino-lgt92.md
+++ b/content/microcontrollers/dragino-lgt92.md
@@ -1,0 +1,31 @@
+---
+title: "Dragino LGT-92"
+weight: 3
+---
+
+The [Dragino LGT-92](https://www.dragino.com/products/lora-lorawan-end-node/item/142-lgt-92.html) includes a low power GPS module L76-L and 9-axis accelerometer for motion and attitude detection. It is based on the ST Micro [STM32L072CZT6](https://www.st.com/en/microcontrollers-microprocessors/stm32l072cz.html) SoC.
+
+## Interfaces
+
+| Interface | Hardware Supported | TinyGo Support |
+| --------- | ------------- | ----- |
+| GPIO      | YES | YES |
+| UART      | YES | YES |
+| SPI      | YES | YES |
+| I2C      | YES | YES |
+| ADC      | YES | Not yet |
+| PWM      | YES | Not yet |
+
+## Machine Package Docs
+
+[Documentation for the machine package for the Dragino LGT-92](../machine/lgt-92)
+
+## Flashing
+
+### OpenOCD
+
+Programs are loaded onto the Dragino LGT-92 with a separate hardware programmer such as the [STLink v2](https://www.st.com/en/development-tools/st-link-v2.html) board, using the `openocd` command line utility program to perform the board flashing. You must install [OpenOCD](http://openocd.org/) before you will be able to flash the Dragino LGT-92 board with your TinyGo code.
+
+- Plug your STLink v2 programmer into your computer's USB port.
+- Plug your Dragino LGT-92 into the STLink v2 programmer using the Dragino LGT-92 `SWIO`, `SWCLK`, `3V3` and `GND` pins.
+- Build and flash your TinyGo program using `tinygo flash -target=lgt92`

--- a/content/microcontrollers/drivers/_index.md
+++ b/content/microcontrollers/drivers/_index.md
@@ -6,11 +6,11 @@ weight: 90
 
 # Drivers
 
-TinyGo has driver support for 53 different sensors and devices such as digital accelerometers and multicolor LEDs.
+TinyGo has driver support for many different sensors and devices such as digital accelerometers and multicolor LEDs.
 
 All of the drivers code is in the TinyGo Drivers repository located at [https://github.com/tinygo-org/drivers/](https://github.com/tinygo-org/drivers/).
 
-The following 53 devices are supported.
+The following 56 devices are supported.
 
 | Device Name | Interface Type |
 |----------|-------------|
@@ -26,7 +26,9 @@ The following 53 devices are supported.
 | [BMI160 accelerometer/gyroscope](https://www.bosch-sensortec.com/media/boschsensortec/downloads/datasheets/bst-bmi160-ds000.pdf) | SPI |
 | [BMP180 barometer](https://cdn-shop.adafruit.com/datasheets/BST-BMP180-DS000-09.pdf) | I2C |
 | [BMP280 temperature/barometer](https://www.bosch-sensortec.com/media/boschsensortec/downloads/datasheets/bst-bmp280-ds001.pdf) | I2C |
+| [BMP388 pressure sensor](https://www.bosch-sensortec.com/media/boschsensortec/downloads/datasheets/bst-bmp388-ds001.pdf) | I2C |
 | [Buzzer](https://en.wikipedia.org/wiki/Buzzer#Piezoelectric) | GPIO |
+| [DHTXX thermometer and humidity sensor](https://cdn-shop.adafruit.com/datasheets/Digital+humidity+and+temperature+sensor+AM2302.pdf) | GPIO |
 | [DS1307 real time clock](https://datasheets.maximintegrated.com/en/ds/DS1307.pdf) | I2C |
 | [DS3231 real time clock](https://datasheets.maximintegrated.com/en/ds/DS3231.pdf) | I2C |
 | [ESP32 as WiFi Coprocessor with Arduino nina-fw](https://github.com/arduino/nina-fw) | SPI |
@@ -42,6 +44,7 @@ The following 53 devices are supported.
 | [LIS3DH accelerometer](https://www.st.com/resource/en/datasheet/lis3dh.pdf) | I2C |
 | [LSM6DS3 accelerometer](https://www.st.com/resource/en/datasheet/lsm6ds3.pdf) | I2C |
 | [MAG3110 magnetometer](https://www.nxp.com/docs/en/data-sheet/MAG3110.pdf) | I2C |
+| [MCP23017 port expander](https://ww1.microchip.com/downloads/en/DeviceDoc/20001952C.pdf) | I2C |
 | [MCP3008 analog to digital converter (ADC)](http://ww1.microchip.com/downloads/en/DeviceDoc/21295d.pdf) | SPI |
 | [Microphone - PDM](https://cdn-learn.adafruit.com/assets/assets/000/049/977/original/MP34DT01-M.pdf) | I2S/PDM |
 | [MMA8653 accelerometer](https://www.nxp.com/docs/en/data-sheet/MMA8653FC.pdf) | I2C |

--- a/content/microcontrollers/matrix-portal-m4.md
+++ b/content/microcontrollers/matrix-portal-m4.md
@@ -1,0 +1,56 @@
+---
+title: "Adafruit Matrix Portal M4"
+weight: 3
+---
+
+The [Adafruit Matrix Portal M4](https://www.adafruit.com/product/4745) is an ARM development system based on the [ATSAMD51J19 Cortex M4 processor](https://www.microchip.com/wwwproducts/en/ATSAMD51J19). The Adafruit Matrix Portal M4 is designed to plugin easily to any HUB-75 LED display. In addition it has a built-in ESP32 Wi-Fi coprocessor, along with a LIS3DH accelerometer.
+
+## Interfaces
+
+| Interface | Hardware Supported | TinyGo Support |
+| --------- | ------------- | ----- |
+| GPIO      | YES | YES |
+| UART      | YES | YES |
+| SPI      | YES | YES |
+| I2C      | YES | YES |
+| ADC      | YES | YES |
+| PWM      | YES | YES |
+
+## Machine Package Docs
+
+[Documentation for the machine package for the Adafruit Matrix Portal M4](../machine/matrix-portal-m4)
+
+## Flashing
+
+### UF2
+
+The Adafruit Matrix Portal M4 comes with the [UF2 bootloader](https://github.com/Microsoft/uf2) already installed.
+
+### CLI Flashing
+
+- Plug your Matrix Portal M4 into your computer's USB port.
+- Flash your TinyGo program to the board using this command:
+
+    ```shell
+    tinygo flash -target=matrixportal-m4 [PATH TO YOUR PROGRAM]
+    ```
+
+- The Matrix Portal M4 board should restart and then begin running your program.
+
+### Troubleshooting
+
+If you have troubles getting your Matrix Portal M4 board to receive code, try this:
+
+- Press the "RESET" button on the board two times to get the Matrix Portal M4 board ready to receive code.
+- The Matrix Portal M4 board will appear to your computer like a USB drive.
+- Now try running the command as above:
+
+    ```shell
+    tinygo flash -target=matrixportal-m4 [PATH TO YOUR PROGRAM]
+    ```
+
+Once you have updated your Matrix Portal M4 board the first time, after that you should be able to flash it entirely from the command line.
+
+## Notes
+
+You can use the USB port to the Matrix Portal M4 as a serial port. `UART0` refers to this connection.

--- a/content/microcontrollers/nicenano.md
+++ b/content/microcontrollers/nicenano.md
@@ -1,0 +1,100 @@
+---
+title: "nice!nano v1.0"
+weight: 3
+---
+
+The [nice!nano](https://nicekeyboards.com/products/nice-nano-v1-0) is a wireless, BLE enabled replacement for the Pro Micro powered by the Nordic Semiconductor [nrf52840](https://www.nordicsemi.com/eng/Products/nRF52840) processor.
+
+## Interfaces
+
+| Interface | Hardware Supported | TinyGo Support |
+| --------- | ------------- | ----- |
+| GPIO      | YES | YES |
+| UART      | YES | YES |
+| SPI      | YES | YES |
+| I2C      | YES | YES |
+| ADC      | YES | YES |
+| PWM      | YES | YES |
+| Bluetooth      | YES | YES |
+
+## Machine Package Docs
+
+[Documentation for the machine package for the nice!nano](../machine/nicenano)
+
+## Flashing
+
+### UF2
+
+The nice!nano comes with the [UF2 bootloader](https://github.com/Microsoft/uf2) already installed.
+
+**PLEASE NOTE** that for a good experience using TinyGo on your board you must be running version 0.4.1 or above of the UF2 bootloader on the board. For more information, [see below](#updating-the-uf2-bootloader)
+
+### CLI Flashing
+
+- Plug your nice!nano into your computer's USB port.
+- Flash your TinyGo program to the board using this command:
+
+    ```shell
+    tinygo flash -target=nicenano [PATH TO YOUR PROGRAM]
+    ```
+
+- The nice!nano board should restart and then begin running your program.
+
+### Troubleshooting
+
+If you have troubles getting your nice!nano board to receive code, try this:
+
+- Press the "RESET" button on the board two times to get the nice!nano board ready to receive code.
+- The nicenano board will appear to your computer like a USB drive.
+- Now try running the command:
+
+    ```shell
+    tinygo flash -target=nicenano [PATH TO YOUR PROGRAM]
+    ```
+
+Once you have updated your nice!nano board the first time, after that you should be able to flash it entirely from the command line.
+
+## Notes
+
+You can use the USB port to the nice!nano as a serial port. `UART0` refers to this connection.
+
+Bluetooth support is available for the nice!nano board. See https://github.com/tinygo-org/bluetooth for more information.
+
+## Updating the UF2 bootloader
+
+This board uses a UF2 bootloader created by Adafruit: https://github.com/adafruit/Adafruit_nRF52_Bootloader
+
+We recommend bootloader version 0.4.1 or above. You can check what version is installed on your board by double-clicking the button on the board to launch the bootloader. When you do this, a USB volume that should automatically be mounted on your computer. Check the file named "INFO_UF2.TXT" on that drive. The bootloader firmware version should be listed in that file, for example:
+
+```
+UF2 Bootloader 0.4.1 lib/nrfx (v2.0.0) lib/tinyusb (0.6.0-272-g4e6aa0d8) lib/uf2 (remotes/origin/configupdate-9-gadbb8c7)
+Model: Adafruit ItsyBitsy nRF52840 Express
+Board-ID: nRF52840-ItsyBitsy-revA
+SoftDevice: S140 version 6.1.1
+Date: Jan 19 2021
+```
+
+To update the bootloader, you will need to install the `adafruit-nrfutil` program. 
+
+You can install it by running:
+
+```shell
+pip3 install --user adafruit-nrfutil
+```
+
+Once you have installed the `adafruit-nrfutil` program, download the firmware here: 
+https://github.com/adafruit/Adafruit_nRF52_Bootloader/releases/download/0.4.1/nice_nano_bootloader-0.4.1.zip
+
+Unzip the files in this zip file and save them to a convenient location. 
+
+Plug in your board to your computer's USB port.
+
+Now we are ready to update the firmware. Run a command something like the following, adjusting for any difference based on where you have saved the files, and what your serial port is named:
+
+```shell
+ adafruit-nrfutil --verbose dfu serial --package nice_nano_bootloader-0.4.1_s140_6.1.1.zip -p /dev/ttyACM0 -b 115200 --singlebank --touch 1200
+```
+
+Note that you should be flashing the board using the zip file that was contained within the zip file that you downloaded, NOT the file that you downloaded.
+
+Once you have flashed the board with the `adafruit-nrfutil` it should restart the board with the new bootloader. You only need to do this update once, and then from that point on the new bootloader will be active.

--- a/content/microcontrollers/nrf52840-mdk-usb-dongle.md
+++ b/content/microcontrollers/nrf52840-mdk-usb-dongle.md
@@ -39,6 +39,7 @@ To install the S140 v6 SoftDevice, please follow the SoftDevice part of the ["Ru
 
 - Enter DFU mode by holding the dongle's RESET/USR button while plugging it into your computer's USB port. A flash drive with the name MDK-DONGLE will appear.
 - Flash your TinyGo program to the board using this command:
+
     ```shell
     tinygo flash -target=nrf52840-mdk-usb-dongle [PATH TO YOUR PROGRAM]
     ```

--- a/content/microcontrollers/p1am-100.md
+++ b/content/microcontrollers/p1am-100.md
@@ -1,0 +1,103 @@
+---
+title: "ProductivityOpen P1AM-100"
+weight: 3
+---
+
+The [ProductivityOpen P1AM-100](https://facts-engineering.github.io/modules/P1AM-100/P1AM-100.html) automation platform compatible with Productivity1000 Series I/O modules, P1AM Series shields, and Arduino MKR format shields. It is based on the Microchip [SAMD21G18](https://www.microchip.com/wwwproducts/en/ATSAMD21G18) family of processors. It also has a NINA-W102 chip onboard which provides an wireless communication abilities based on the popular ESP32 family of wireless chips from Espressif.
+
+## Interfaces
+
+| Interface | Hardware Supported | TinyGo Support |
+| --------- | ------------- | ----- |
+| GPIO      | YES | YES |
+| UART      | YES | YES |
+| SPI      | YES | YES |
+| I2C      | YES | YES |
+| ADC      | YES | YES |
+| PWM      | YES | YES |
+
+## Machine Package Docs
+
+[Documentation for the machine package for the ProductivityOpen P1AM-100](../machine/p1am-100)
+
+## Installing BOSSA
+
+In order to flash your TinyGo programs onto the ProductivityOpen P1AM-100 board, you will need to install the "bossac" command line utility which is part of the [BOSSA command line utilities](https://github.com/shumatech/BOSSA).
+
+### macOS
+
+You can use Homebrew to install the BOSSA command line interface by using the following command:
+
+```shell
+brew cask install bossa
+```
+
+Or if you  prefer, you can also download the installer from https://github.com/shumatech/BOSSA/releases/download/1.9.1/bossa-1.9.1.dmg
+
+Once you have downloaded it, double click on the .dmg file to perform the installation.
+
+### Linux
+
+On Linux, install from source:
+
+```shell
+sudo apt install libreadline-dev libwxgtk3.0-gtk3-dev
+git clone https://github.com/shumatech/BOSSA.git
+cd BOSSA
+make
+sudo cp bin/bossac /usr/local/bin
+```
+
+### Windows
+
+You can download BOSSA from https://github.com/shumatech/BOSSA/releases/download/1.9.1/bossa-x64-1.9.1.msi
+
+*VERY IMPORTANT*: During the installation, you must choose to install into `c:\Program Files`. The installer might have the wrong path, so edit it to match  `c:\Program Files`.
+
+After the installation, you must add BOSSA to your PATH:
+
+```shell
+set PATH=%PATH%;"c:\Program Files\BOSSA";
+```
+
+Test that you have installed "BOSSA" correctly by running this command:
+
+```shell
+bossac --help
+```
+
+## Flashing
+
+Once you have installed the needed BOSSA command line utility, as in the previous section, you are ready to build and flash code to your ProductivityOpen P1AM-100 board.
+
+### CLI Flashing
+
+- Plug your ProductivityOpen P1AM-100 board into your computer's USB port.
+- Build and flash your TinyGo code using the `tinygo flash` command. This command flashes the ProductivityOpen P1AM-100 with the blinky1 example:
+
+    ```shell
+    tinygo flash -target=p1am-100 examples/blinky1
+    ```
+
+- The ProductivityOpen P1AM-100 board should restart and then begin running your program.
+
+### Troubleshooting
+
+If you have troubles getting your ProductivityOpen P1AM-100 board to receive code, try this:
+
+- Press the "RESET" button on the board two times to get the ProductivityOpen P1AM-100 board ready to receive code.
+- Now try running the `tinygo flash` command as above:
+
+    ```shell
+    tinygo flash -target=p1am-100 [PATH TO YOUR PROGRAM]
+    ```
+
+Once you have updated your ProductivityOpen P1AM-100 board the first time, after that you should be able to flash it entirely from the command line.
+
+## Notes
+
+You can use the USB port to the ProductivityOpen P1AM-100 as a serial port. `UART0` refers to this connection.
+
+For information on how to use the built-in NINA-W102 wireless chip with the default firmware, please see the "wifinina" driver in the TinyGo drivers repository located at [https://github.com/tinygo-org/drivers/tree/release/wifinina](https://github.com/tinygo-org/drivers/tree/release/wifinina).
+
+You can also use the Espressif ESP-AT firmware, although you will need to flash it yourself. Please see the "espat" driver in the TinyGo drivers repository located at [https://github.com/tinygo-org/drivers/tree/release/espat](https://github.com/tinygo-org/drivers/tree/release/espat).

--- a/content/microcontrollers/stm32-nucleo-f722ze.md
+++ b/content/microcontrollers/stm32-nucleo-f722ze.md
@@ -1,0 +1,32 @@
+---
+title: "STM32 Nucleo F722ZE"
+weight: 3
+---
+
+The [STM32 Nucleo F722ZE](https://www.st.com/en/evaluation-tools/nucleo-f722ze.html) is an ARM development board based on the ST Micro [STM32F722ZE](https://www.st.com/en/microcontrollers-microprocessors/stm32f722ze.html) SoC.
+
+It has onboard ethernet, 2 user buttons, and 3 user LEDs.
+
+## Interfaces
+
+| Interface | Hardware Supported | TinyGo Support |
+| --------- | ------------- | ----- |
+| GPIO      | YES | YES |
+| UART      | YES | YES |
+| SPI      | YES | YES |
+| I2C      | YES | YES |
+| ADC      | YES | Not yet |
+| PWM      | YES | Not yet |
+
+## Machine Package Docs
+
+[Documentation for the machine package for the STM32 Nucleo F722ZE](../machine/stm32nucleof722ze)
+
+## Flashing
+
+### OpenOCD
+
+Programs are loaded onto the STM32 Nucleo F722ZE with the onboard [STLink v2](https://www.st.com/en/development-tools/st-link-v2.html) hardware programmer, using the `openocd` command line utility program to perform the board flashing. You must install [OpenOCD](http://openocd.org/) before you will be able to flash the STM32 Nucleo F722ZE board with your TinyGo code.
+
+- Plug your STM32 Nucleo F722ZE into your computer's USB port.
+- Build and flash your TinyGo program using `tinygo flash -target=nucleo-f722ze`

--- a/content/microcontrollers/stm32-nucleo-l552ze.md
+++ b/content/microcontrollers/stm32-nucleo-l552ze.md
@@ -1,0 +1,32 @@
+---
+title: "STM32 Nucleo L552ZE"
+weight: 3
+---
+
+The [STM32 Nucleo L552ZE](https://www.st.com/en/evaluation-tools/nucleo-l552ze-q.html) is an ARM development board based on the ST Micro [STM32L552ZE](https://www.st.com/en/microcontrollers-microprocessors/stm32l552ze.html) SoC.
+
+It has onboard ethernet, 2 user buttons, and 3 user LEDs.
+
+## Interfaces
+
+| Interface | Hardware Supported | TinyGo Support |
+| --------- | ------------- | ----- |
+| GPIO      | YES | YES |
+| UART      | YES | YES |
+| SPI      | YES | YES |
+| I2C      | YES | YES |
+| ADC      | YES | Not yet |
+| PWM      | YES | Not yet |
+
+## Machine Package Docs
+
+[Documentation for the machine package for the STM32 Nucleo l552ze](../machine/stm32nucleol552ze)
+
+## Flashing
+
+### OpenOCD
+
+Programs are loaded onto the STM32 Nucleo L552ZE with the onboard [STLink v2](https://www.st.com/en/development-tools/st-link-v2.html) hardware programmer, using the `openocd` command line utility program to perform the board flashing. You must install [OpenOCD](http://openocd.org/) before you will be able to flash the STM32 Nucleo L552ZE board with your TinyGo code.
+
+- Plug your STM32 Nucleo L552ZE into your computer's USB port.
+- Build and flash your TinyGo program using `tinygo flash -target=nucleo-l552ze`

--- a/content/microcontrollers/stm32f4discovery.md
+++ b/content/microcontrollers/stm32f4discovery.md
@@ -15,7 +15,7 @@ CS43L22 audio DAC, 2 user buttons, and 4 user LEDs.
 | GPIO      | YES | YES |
 | UART      | YES | YES |
 | SPI      | YES | YES |
-| I2C      | YES | Not yet |
+| I2C      | YES | YES |
 | ADC      | YES | Not yet |
 | PWM      | YES | Not yet |
 


### PR DESCRIPTION
This PR adds new boards that are part of 0.17 release.

I was not able to run the `make-gen` script. It failed on `bluepill-clone`. I remember having this problem on a previous occasion, but I do not recall exactly why. Something to do with modules?