### PR TITLE
Update Digispark's interfaces table

### DIFF
--- a/content/microcontrollers/digispark.md
+++ b/content/microcontrollers/digispark.md
@@ -18,7 +18,7 @@ Note: the AVR backend of LLVM is still experimental so you may encounter bugs.
 | SPI      |  Requires software | Not yet |
 | I2C      | Requires software | Not yet |
 | ADC      | YES | Not yet |
-| PWM      | ? | Not yet |
+| PWM      | YES | Not yet |
 
 ## Machine Package Docs
 


### PR DESCRIPTION
According to the Digispark documentation, the Digispark board supports PWM, so this commit updates the interfaces table to reflect that.