### PR TITLE
Update WebAssembly documentation

### DIFF
--- a/content/webassembly/webassembly.md
+++ b/content/webassembly/webassembly.md
@@ -84,6 +84,9 @@ loading it into JavaScript with `WebAssembly.instantiateStreaming`, or
 const go = new Go(); // Defined in wasm_exec.js
 const WASM_URL = 'wasm.wasm';
 
+// Define functions that we left undefined
+go.importObject.env["main.add"] = (a, b) => a + b;
+
 var wasm;
 
 if ('instantiateStreaming' in WebAssembly) {


### PR DESCRIPTION
The WebAssembly example page declares a function called `add` and mentions that it needs to get added to `env` in the imports object.

The instantiation code further down, however, doesn’t do so. This PR fixes that, but I am not entirely sure if this is the style you want to advocate for. 