### PR TITLE
docs: add page descriptions to various pages

### DIFF
--- a/content/docs/guides/build.md
+++ b/content/docs/guides/build.md
@@ -1,6 +1,8 @@
 ---
 title: "Build from source"
 weight: 2
+description: |
+  Build a development version of TinyGo from source if you want to help improve TinyGo or want to try the latest features.
 ---
 
 This page details how to build TinyGo from source. If you would like to install a pre-build release, please see our [quick install guide](../../getting-started/install).

--- a/content/docs/guides/ide-integration/_index.md
+++ b/content/docs/guides/ide-integration/_index.md
@@ -1,6 +1,8 @@
 ---
 title: "IDE Integration"
 weight: 8
+description: |
+  TinyGo has some IDE support. This is how you can configure your IDE to recognize the machine package.
 ---
 
 IDEs need to have certain environment variables set before they work with TinyGo: `GOROOT` and `GOFLAGS`. You can determine the correct values from the `tinygo info` command (starting with TinyGo 0.15).

--- a/content/docs/guides/linux.md
+++ b/content/docs/guides/linux.md
@@ -1,6 +1,8 @@
 ---
 title: "Linux support"
 weight: 4
+description: |
+  How to use TinyGo to create normal Linux executables.
 ---
 
 TinyGo also lets you compile programs for Linux systems, both 32-bit and 64-bit, on both x86 and ARM architectures.

--- a/content/docs/guides/webassembly.md
+++ b/content/docs/guides/webassembly.md
@@ -1,6 +1,8 @@
 ---
 title: "Using WebAssembly"
 weight: 3
+description: |
+  How to call WebAssembly from JavaScript in a browser.
 ---
 
 You can call a JavaScript function from Go and call a Go function from WebAssembly:

--- a/content/docs/reference/lang-support/_index.md
+++ b/content/docs/reference/lang-support/_index.md
@@ -1,6 +1,8 @@
 ---
 title: "Go language features"
 weight: 6
+description: |
+  Which Go language features are supported by TinyGo and which are still a work in progress.
 ---
 
 While TinyGo supports a big subset of the Go language, not everything is supported yet.

--- a/content/docs/reference/microcontrollers/_index.md
+++ b/content/docs/reference/microcontrollers/_index.md
@@ -2,12 +2,14 @@
 title: "Microcontrollers"
 chapter: true
 weight: 3
+description: |
+  Documentation for each microcontroller board supported by TinyGo.
 ---
 
 TinyGo lets you run Go directly on microcontrollers.
 
-TinyGo has support for 53 different boards and devices such as the Arduino Nano33 IoT, Adafruit Circuit Playground Express, BBC micro:bit and more. Click on a board name found in the left menu to see the what features are supported for the given hardware.
+TinyGo has support for 53 different boards and devices such as the Arduino Nano33 IoT, Adafruit Circuit Playground Express, BBC micro:bit and more. Click on a board name below to see the what features are supported for the given hardware.
 
 We also give you the ability to add new boards. If your target isn't listed here, please raise an issue in the [issue tracker](https://github.com/tinygo-org/tinygo/issues).
 
-Want to know the details about how it is possible to compile Go for microcontrollers? Check out the [microcontrollers](../compiler-internals/microcontrollers/) page in our "Compiler Internals" section.
+Want to know the details about how it is possible to compile Go for microcontrollers? Check out the [microcontrollers](../../concepts/compiler-internals/microcontrollers/) page in our "Compiler Internals" section.

--- a/content/docs/reference/usage/_index.md
+++ b/content/docs/reference/usage/_index.md
@@ -2,6 +2,8 @@
 title: "Using TinyGo"
 chapter: true
 weight: 2
+description: |
+  How to use the `tinygo` command.
 ---
 
 These pages assume you already have TinyGo installed, either using Docker or by installing it manually.

--- a/content/docs/reference/usage/basic.md
+++ b/content/docs/reference/usage/basic.md
@@ -1,9 +1,10 @@
 ---
 title: "Basic command examples"
 weight: 1
+description: |
+  Here are some basic examples of using TinyGo in the most common scenarios.
 ---
 
-Here will go some basic examples of using TinyGo in the most common scenarios.
 
 ### Building "Hello, World" program for WebAssembly
 

--- a/content/docs/reference/usage/important-options.md
+++ b/content/docs/reference/usage/important-options.md
@@ -1,6 +1,8 @@
 ---
 title: "Important Build Options"
 weight: 3
+description: |
+  Command line flags you will commonly use with TinyGo that often control how the binary is built or flashed to the device.
 ---
 
 There are a few flags to control how binaries are built:

--- a/content/docs/reference/usage/misc-options.md
+++ b/content/docs/reference/usage/misc-options.md
@@ -1,6 +1,8 @@
 ---
 title: "Misc. Build Options"
 weight: 4
+description: |
+  Command line flags that are less commonly used and don't usually impact the build.
 ---
 
 - `-no-debug`

--- a/content/docs/reference/usage/subcommands.md
+++ b/content/docs/reference/usage/subcommands.md
@@ -1,6 +1,8 @@
 ---
 title: "Subcommands"
 weight: 2
+description: |
+  Subcommands like `tinygo flash` and `tinygo version`.
 ---
 
 TinyGo tries to be similar to the main `go` command in usage. It consists of the following main subcommands:


### PR DESCRIPTION
This is helpful in lists of pages to know what the page is about (apart from just the title).