### PR TITLE
config: fix GitHub repo URL

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -28,7 +28,7 @@ copyright = "The TinyGo Authors"
 
 
 # Repository configuration (URLs for in-page links to opening issues and suggesting changes)
-github_repo = "https://github.com/google/tinygo-site"
+github_repo = "https://github.com/tinygo-org/tinygo-site"
 # An optional link to a related project repo. For example, the sibling repository where your product code lives.
 github_project_repo = "https://github.com/tinygo-org/tinygo"
 github_branch= "release"


### PR DESCRIPTION
This makes most links in the right sidebar work.