### PR TITLE
microcontrollers: remove PWM support from the Mega 2560

### DIFF
--- a/content/docs/reference/microcontrollers/arduino-mega2560.md
+++ b/content/docs/reference/microcontrollers/arduino-mega2560.md
@@ -16,7 +16,7 @@ Note: the AVR backend of LLVM is still experimental so you may encounter bugs.
 | SPI      | YES | YES |
 | I2C      | YES | YES |
 | ADC      | YES | YES |
-| PWM      | YES | YES |
+| PWM      | YES | Not yet |
 
 ## Machine Package Docs
 


### PR DESCRIPTION
The Arduino Mega 1280 has PWM support, but the Mega 2560 does not.