### PR TITLE
macOS bossa install doc fix

### DIFF
--- a/content/docs/reference/microcontrollers/arduino-mkr1000.md
+++ b/content/docs/reference/microcontrollers/arduino-mkr1000.md
@@ -29,7 +29,7 @@ In order to flash your TinyGo programs onto the Arduino MKR1000 board, you will 
 You can use Homebrew to install the BOSSA command line interface by using the following command:
 
 ```shell
-brew cask install bossa
+brew install bossa
 ```
 
 Or if you  prefer, you can also download the installer from https://github.com/shumatech/BOSSA/releases/download/1.9.1/bossa-1.9.1.dmg

--- a/content/docs/reference/microcontrollers/arduino-nano33.md
+++ b/content/docs/reference/microcontrollers/arduino-nano33.md
@@ -35,7 +35,7 @@ In order to flash your TinyGo programs onto the Arduino Nano33 IoT board, you wi
 You can use Homebrew to install the BOSSA command line interface by using the following command:
 
 ```shell
-brew cask install bossa
+brew install bossa
 ```
 
 Or if you  prefer, you can also download the installer from https://github.com/shumatech/BOSSA/releases/download/1.9.1/bossa-1.9.1.dmg

--- a/content/docs/reference/microcontrollers/arduino-zero.md
+++ b/content/docs/reference/microcontrollers/arduino-zero.md
@@ -29,7 +29,7 @@ In order to flash your TinyGo programs onto the Arduino Zero board, you will nee
 You can use Homebrew to install the BOSSA command line interface by using the following command:
 
 ```shell
-brew cask install bossa
+brew install bossa
 ```
 
 Or if you  prefer, you can also download the installer from https://github.com/shumatech/BOSSA/releases/download/1.9.1/bossa-1.9.1.dmg

--- a/content/docs/reference/microcontrollers/p1am-100.md
+++ b/content/docs/reference/microcontrollers/p1am-100.md
@@ -29,7 +29,7 @@ In order to flash your TinyGo programs onto the ProductivityOpen P1AM-100 board,
 You can use Homebrew to install the BOSSA command line interface by using the following command:
 
 ```shell
-brew cask install bossa
+brew install bossa
 ```
 
 Or if you  prefer, you can also download the installer from https://github.com/shumatech/BOSSA/releases/download/1.9.1/bossa-1.9.1.dmg


### PR DESCRIPTION
`brew cask install` command was deprecated and now is completely [disabled](https://github.com/Homebrew/brew/pull/10056/files#diff-6b41cd34991fd4bf2887d97970060cd2c3303f29c13d51480dce512a9ebad369R177) and would not work

Shall use `brew install`

