### PR TITLE
overview: fix link to install doc

### DIFF
--- a/content/getting-started/overview/overview.md
+++ b/content/getting-started/overview/overview.md
@@ -60,4 +60,4 @@ By using TinyGo you can actually compile and run a binary on a variety of bare m
 
 Many different boards from vendors such as [Adafruit](https://www.adafruit.com/) and [Arduino](https://www.arduino.cc/) and many other companies are supported. For a complete list, see [this list](../../../docs/reference/microcontrollers).
 
-Interested? Play around a bit with it on our [playground](https://play.tinygo.org/) or continue with [installing TinyGo](install).
+Interested? Play around a bit with it on our [playground](https://play.tinygo.org/) or continue with [installing TinyGo](../../install).


### PR DESCRIPTION
The https://tinygo.org/getting-started/overview/overview/ page links to https://tinygo.org/getting-started/overview/overview/install which is a 404.  

I confess to authoring this PR on a phone, so I did not rebuild the site to confirm, but think this correctly updates the relative URL.

As an aside, I wonder if renaming `overview.md` to `_index.md` would remove the extra nesting of the overview URL.