### PR TITLE
microcontrollers: add micros added in tinygo 0.18.0

### DIFF
--- a/content/docs/reference/microcontrollers/arduino-mega1280.md
+++ b/content/docs/reference/microcontrollers/arduino-mega1280.md
@@ -1,0 +1,50 @@
+---
+title: "Arduino Mega 1280"
+weight: 3
+---
+
+The [Arduino Mega 1280](https://www.arduino.cc/en/Main/arduinoBoardMega/) is based on the AVR [ATmega1280](https://www.microchip.com/wwwproducts/en/ATMEGA1280) microcontroller.
+
+Note: the AVR backend of LLVM is still experimental so you may encounter bugs.
+
+## Interfaces
+
+| Interface | Hardware Supported | TinyGo Support |
+| --------- | ------------- | ----- |
+| GPIO      | YES | YES |
+| UART      | YES | YES |
+| SPI      | YES | YES |
+| I2C      | YES | YES |
+| ADC      | YES | YES |
+| PWM      | YES | YES |
+
+## Machine Package Docs
+
+[Documentation for the machine package for the Arduino Mega 1280](../machine/arduino-mega1280)
+
+## Installing dependencies
+
+The Arduino Mega 1280 needs a few extra dependencies to work, for example, if you get an error like this:
+
+```text
+/usr/lib/gcc/avr/5.4.0/../../../avr/bin/ld: cannot find -lm
+/usr/lib/gcc/avr/5.4.0/../../../avr/bin/ld: cannot find -lc
+collect2: error: ld returned 1 exit status
+```
+
+Or like this:
+
+```text
+/bin/sh: 1: avrdude: not found
+```
+
+To fix this, see the installation guide for [Linux](../../getting-started/linux/#avr-arduino) and for [macOS](../../getting-started/macos/#avr-arduino).
+
+## Flashing
+
+### AVRDude
+
+Programs are loaded onto the Arduino Mega 1280 using the `avrdude` command line utility program. You must install this program before you will be able to flash the Arduino Uno board with your TinyGo code.
+
+- Plug your Arduino Uno into your computer's USB port.
+- Build and flash your TinyGo program using `tinygo flash -target arduino-mega1280 /path/to/code`

--- a/content/docs/reference/microcontrollers/atsame54-xpro.md
+++ b/content/docs/reference/microcontrollers/atsame54-xpro.md
@@ -1,0 +1,34 @@
+---
+title: "Microchip SAM E54 Xplained Pro"
+weight: 3
+---
+
+The [Microchip SAM E54 Xplained Pro](https://www.microchip.com/developmenttools/productdetails/atsame54-xpro) is a tiny ARM development board based on the Atmel [ATSAME54P20](https://www.microchip.com/wwwproducts/en/ATSAME54P20A) family of SoC.
+
+## Interfaces
+
+| Interface | Hardware Supported | TinyGo Support |
+| --------- | ------------- | ----- |
+| GPIO      | YES | YES |
+| UART      | YES | YES |
+| SPI      | YES | YES |
+| I2C      | YES | YES |
+| ADC      | YES | YES |
+| PWM      | YES | YES |
+
+## Machine Package Docs
+
+[Documentation for the machine package for the Adafruit SAM E54 Xplained Pro](../machine/atsame54-xpro)
+
+## Flashing
+
+### OpenOCD
+
+Programs are loaded onto the SAM E54 Xplained Pro with the onboard [Atmel EDBG](http://ww1.microchip.com/downloads/en/devicedoc/atmel-42096-microcontrollers-embedded-debugger_user-guide.pdf) hardware programmer, using the `openocd` command line utility program to perform the board flashing. You must install [OpenOCD](http://openocd.org/) before you will be able to flash the SAM E54 Xplained Pro board with your TinyGo code.
+
+- Plug your SAM E54 Xplained Pro into your computer's USB port.
+- Build and flash your TinyGo program using `tinygo flash -target=atsame54-xpro [PATH TO YOUR PROGRAM]`
+
+## Notes
+
+You can use the USB port to the SAM E54 Xplained Pro as a serial port. `UART0` refers to this connection.

--- a/content/docs/reference/microcontrollers/feather-m4-can.md
+++ b/content/docs/reference/microcontrollers/feather-m4-can.md
@@ -1,0 +1,58 @@
+---
+title: "Adafruit Feather M4 CAN"
+weight: 3
+---
+
+The [Adafruit Feather M4 CAN](https://www.adafruit.com/product/4759) is a tiny ARM development board based on the Atmel [ATSAME51J19](https://www.microchip.com/wwwproducts/en/ATSAME51J19A) family of SoC.
+
+## Interfaces
+
+| Interface | Hardware Supported | TinyGo Support |
+| --------- | ------------- | ----- |
+| GPIO      | YES | YES |
+| UART      | YES | YES |
+| SPI      | YES | YES |
+| I2C      | YES | YES |
+| ADC      | YES | YES |
+| PWM      | YES | YES |
+
+## Machine Package Docs
+
+[Documentation for the machine package for the Adafruit Feather M4 CAN](../machine/feather-m4-can)
+
+## Flashing
+
+### UF2
+
+The Feather M4 CAN comes with the [UF2 bootloader](https://github.com/Microsoft/uf2) already installed.
+
+### CLI Flashing
+
+- Plug your Feather M4 CAN into your computer's USB port.
+- Flash your TinyGo program to the board using this command:
+
+    ```shell
+    tinygo flash -target=feather-m4-can [PATH TO YOUR PROGRAM]
+    ```
+
+- The Feather M4 CAN board should restart and then begin running your program.
+
+
+### Troubleshooting
+
+If you have troubles getting your Feather M4 CAN board to receive code, try this:
+
+- Press the "RESET" button on the board two times to get the Feather M4 CAN board ready to receive code.
+- The Feather M4 CAN board will appear to your computer like a USB drive.
+- Now try running the command as above:
+
+
+```shell
+tinygo flash -target=feather-m4-can [PATH TO YOUR PROGRAM]
+```
+
+Once you have updated your Feather M4 CAN board the first time, after that you should be able to flash it entirely from the command line.
+
+## Notes
+
+You can use the USB port to the Feather M4 CAN as a serial port. `UART0` refers to this connection.

--- a/content/docs/reference/microcontrollers/grandcentral-m4.md
+++ b/content/docs/reference/microcontrollers/grandcentral-m4.md
@@ -1,0 +1,58 @@
+---
+title: "Adafruit Grand Central M4"
+weight: 3
+---
+
+The [Adafruit Grand Central M4](https://www.adafruit.com/product/4064) is a tiny ARM development board based on the Atmel [ATSAMD51P20](https://www.microchip.com/wwwproducts/en/ATSAMD51P20A) family of SoC.
+
+## Interfaces
+
+| Interface | Hardware Supported | TinyGo Support |
+| --------- | ------------- | ----- |
+| GPIO      | YES | YES |
+| UART      | YES | YES |
+| SPI      | YES | YES |
+| I2C      | YES | YES |
+| ADC      | YES | YES |
+| PWM      | YES | YES |
+
+## Machine Package Docs
+
+[Documentation for the machine package for the Adafruit Grand Central M4](../machine/grandcentral-m4)
+
+## Flashing
+
+### UF2
+
+The Grand Central M4 comes with the [UF2 bootloader](https://github.com/Microsoft/uf2) already installed.
+
+### CLI Flashing
+
+- Plug your Grand Central M4 into your computer's USB port.
+- Flash your TinyGo program to the board using this command:
+
+    ```shell
+    tinygo flash -target=grandcentral-m4 [PATH TO YOUR PROGRAM]
+    ```
+
+- The Grand Central M4 board should restart and then begin running your program.
+
+
+### Troubleshooting
+
+If you have troubles getting your Grand Central M4 board to receive code, try this:
+
+- Press the "RESET" button on the board two times to get the Grand Central M4 board ready to receive code.
+- The Grand Central M4 board will appear to your computer like a USB drive.
+- Now try running the command as above:
+
+
+```shell
+tinygo flash -target=grandcentral-m4 [PATH TO YOUR PROGRAM]
+```
+
+Once you have updated your Grand Central M4 board the first time, after that you should be able to flash it entirely from the command line.
+
+## Notes
+
+You can use the USB port to the Grand Central M4 as a serial port. `UART0` refers to this connection.

--- a/content/docs/reference/microcontrollers/nucleo-l031k6.md
+++ b/content/docs/reference/microcontrollers/nucleo-l031k6.md
@@ -1,0 +1,32 @@
+---
+title: "STM32 Nucleo L031K6"
+weight: 3
+---
+
+The [STM32 Nucleo L031K6](https://www.st.com/en/evaluation-tools/nucleo-l031k6.html) is an ARM development board based on the ST Micro [STM32L031K6](https://www.st.com/en/microcontrollers-microprocessors/stm32l031k6.html) SoC.
+
+It has 2 user buttons, and 3 user LEDs.
+
+## Interfaces
+
+| Interface | Hardware Supported | TinyGo Support |
+| --------- | ------------- | ----- |
+| GPIO      | YES | YES |
+| UART      | YES | YES |
+| SPI      | YES | YES |
+| I2C      | YES | YES |
+| ADC      | YES | Not yet |
+| PWM      | YES | Not yet |
+
+## Machine Package Docs
+
+[Documentation for the machine package for the STM32 Nucleo L031K6](../machine/nucleo-l031k6)
+
+## Flashing
+
+### OpenOCD
+
+Programs are loaded onto the STM32 Nucleo L031K6 with the onboard [STLink v2](https://www.st.com/en/development-tools/st-link-v2.html) hardware programmer, using the `openocd` command line utility program to perform the board flashing. You must install [OpenOCD](http://openocd.org/) before you will be able to flash the STM32 Nucleo L031K6 board with your TinyGo code.
+
+- Plug your STM32 Nucleo L031K6 into your computer's USB port.
+- Build and flash your TinyGo program using `tinygo flash -target=nucleo-l031k6`

--- a/content/docs/reference/microcontrollers/nucleo-l432kc.md
+++ b/content/docs/reference/microcontrollers/nucleo-l432kc.md
@@ -1,0 +1,32 @@
+---
+title: "STM32 Nucleo L432KC"
+weight: 3
+---
+
+The [STM32 Nucleo L432KC](https://www.st.com/en/evaluation-tools/nucleo-l432kc.html) is an ARM development board based on the ST Micro [STM32L432KC](https://www.st.com/en/microcontrollers-microprocessors/stm32l432kc.html) SoC.
+
+It has 2 user buttons, and 3 user LEDs.
+
+## Interfaces
+
+| Interface | Hardware Supported | TinyGo Support |
+| --------- | ------------- | ----- |
+| GPIO      | YES | YES |
+| UART      | YES | YES |
+| SPI      | YES | YES |
+| I2C      | YES | YES |
+| ADC      | YES | Not yet |
+| PWM      | YES | Not yet |
+
+## Machine Package Docs
+
+[Documentation for the machine package for the STM32 Nucleo L432KC](../machine/nucleo-l432kc)
+
+## Flashing
+
+### OpenOCD
+
+Programs are loaded onto the STM32 Nucleo L432KC with the onboard [STLink v2](https://www.st.com/en/development-tools/st-link-v2.html) hardware programmer, using the `openocd` command line utility program to perform the board flashing. You must install [OpenOCD](http://openocd.org/) before you will be able to flash the STM32 Nucleo L432KC board with your TinyGo code.
+
+- Plug your STM32 Nucleo L432KC into your computer's USB port.
+- Build and flash your TinyGo program using `tinygo flash -target=nucleo-l432kc`

--- a/content/docs/reference/microcontrollers/pca10059.md
+++ b/content/docs/reference/microcontrollers/pca10059.md
@@ -1,0 +1,50 @@
+---
+title: "PCA10059"
+weight: 3
+---
+
+The [Nordic Semiconductor PCA10059](https://www.nordicsemi.com/Software-and-tools/Development-Kits/nRF52840-Dongle) is a single-board development kit for wireless applications based on the Nordic Semiconductor [nRF52840](https://www.nordicsemi.com/eng/Products/nRF52840) SoC.
+
+## Interfaces
+
+| Interface | Hardware Supported | TinyGo Support |
+| --------- | ------------- | ----- |
+| GPIO      | YES | YES |
+| UART      | YES | YES |
+| SPI      | YES | YES |
+| I2C      | YES | YES |
+| ADC      | YES | YES |
+| PWM      | YES | YES |
+| Bluetooth      | YES | YES |
+
+## Machine Package Docs
+
+[Documentation for the machine package for the PCA10059](../machine/pca10059)
+
+## Flashing
+
+There are two options to flash the PCA10059 board.
+
+### nrfutil
+
+Programs can be loaded onto the PCA10059 board using the `nrfutil` command line utility program.
+
+Install the nrfutil Command-Line Tools: [NordicSemiconductor/pc-nrfutil](https://github.com/NordicSemiconductor/pc-nrfutil)
+
+Once you have installed nrfutil correctly, you will be able to flash the PCA10059 board with your TinyGo code.
+
+- Plug your PCA10059 into your computer's USB port.
+- Press SW2 to go to bootloader.
+- Build and flash your TinyGo program using `tinygo flash -target=pca10059 [PATH TO YOUR PROGRAM]`
+
+## Notes
+
+As of TinyGo v0.18.0, it is not writable on Windows.
+
+If you are using Windows, please do the following to flash.
+
+```
+tinygo build -o pca10059-blinky1.hex -target=pca10059 examples/blinky1
+nrfutil pkg generate --hw-version 52 --sd-req 0x0 --application pca10059-blinky1.hex --application-version 1 pca10059-blinky1.zip
+nrfutil dfu usb-serial -pkg pca10059-blinky1.zip -p COM33 -b 115200
+```


### PR DESCRIPTION
I have added the boards that were added in 0.18.0.

I don't have the Arduino Mega 1280 and STM boards so I don't know if this is correct.
I would like to ask someone if the Flash method and Interfaces are correct.

```
A       content/docs/reference/microcontrollers/arduino-mega1280.md
A       content/docs/reference/microcontrollers/atsame54-xpro.md
A       content/docs/reference/microcontrollers/feather-m4-can.md
A       content/docs/reference/microcontrollers/grandcentral-m4.md
A       content/docs/reference/microcontrollers/nucleo-l031k6.md
A       content/docs/reference/microcontrollers/nucleo-l432kc.md
A       content/docs/reference/microcontrollers/pca10059.md
```

At the moment, `issues/1757` is not merged, so pca10059 cannot be tinygo flashed on Windows.
https://github.com/tinygo-org/tinygo/issues/1757

In addition, I haven't doc-gen'd it.
When I run it, almost every file has a diff.
Is this as intended?