### PR TITLE
docs: add documentation on how to use GDB

### DIFF
--- a/content/docs/guides/debugging.md
+++ b/content/docs/guides/debugging.md
@@ -1,0 +1,106 @@
+---
+title: "Debugging"
+weight: 10
+description: |
+  Debug TinyGo programs using GDB.
+---
+
+A debugger can show you things that regular print statements cannot show you, especially on microcontrollers. The debugger used by TinyGo is called [GDB](https://www.gnu.org/software/gdb/). Debugging using GDB can sometimes be intimidating, but it is also extremely powerful. For example:
+
+  * A debugger works even when a serial port is not available. This can happen when there is a bug in an interrupt or in initialization code before the serial port is configured.
+  * You can print a stack trace, even in a panic.
+  * Depending on the optimization level and other factors, you may be able to inspect function parameters and local variables.
+  * You can step through the code and see the results on the device as you do so.
+
+By learning just a few commands such as `continue`, `breakpoint`, and `next`, you will be able to start making good use of the GDB command line. See the [GDB tutorial]({{<ref "gdb.md">}}) for an introduction. Here we will show how to get to the GDB prompt in the first place.
+
+## Requirements
+
+For debugging on your own computer (Linux, MacOS) you only really need to have the `gdb` command installed. No other programs are necessary other than the ones you already need for building programs in TinyGo.
+
+For debugging directly on a chip, you need a few more dependencies. Which dependencies you need vary by chip:
+
+  * You need a GDB variant. It depends on the architecture which one you need, but probably you'll need to install `gdb-multiarch` or `arm-none-eabi-gdb`. For other architectures you will need a different debugger (for example, [`riscv64-unknown-elf-gdb`](https://www.sifive.com/software) for RISC-V).
+  * You probably need to install OpenOCD. This program is present in most package managers and it is easiest to install it directly from there.
+  * Some boards require something other than OpenOCD, for example some Nordic Semiconductor boards require `JLinkGDBServer`.
+
+### Debian or Ubuntu
+
+You can install the most common dependencies through the package manager:
+
+    sudo apt-get install gdb-multiarch openocd
+
+### MacOS
+
+You can install the most common dependencies through Homebrew:
+
+    brew install open-ocd
+    brew tap ARMmbed/homebrew-formulae
+    brew install arm-none-eabi-gcc
+
+## Connecting a debug probe
+
+Sometimes you need a separate debug probe. Whether this is necessary depends on the board, some have a debug probe built onto the board already:
+
+  * Evaluation boards from chip vendors (such as STMicroelectronics and Nordic Semiconductors) usually have a debug probe built in.
+  * Boards from vendors such as Arduino and Adafruit usually don't have a debug probe. One notable exception is the BBC micro:bit, which does have a debug probe.
+
+If the board you want to debug already has a debug probe, you don't need any extra hardware and can go to the next step.
+
+There is a variety of choice when it comes to debug probes, but most debug probes are able to work with most boards. However, some are better supported than others.
+
+Here are some debug probes that are known to work in TinyGo for at least some boards:
+
+  * [SEGGER J-Link Edu Mini](https://www.segger.com/products/debug-probes/j-link/models/j-link-edu-mini/): this debugger can debug pretty much all ARM Cortex-M chips and is generally very reliable. However, it comes with some possible issues: it's entirely closed source, it is only allowed to be used for non-commercial purposes and it doesn't support as many chips as the full version.
+  * [Particle Debugger](https://store.particle.io/products/particle-debugger): a [DAPLink](https://armmbed.github.io/DAPLink/) based debugger that can debug practially all ARM Cortex-M chips (like the SEGGER above) and does not have limitations on how it can be used. It is also open source. While this debugger is designed for Particle hardware it can easily handle chips from other vendors.
+  * [ST-Link v2](https://www.st.com/en/development-tools/st-link-v2.html): a debugger often included on boards from STMicroelectronics and also sold separately. It is somewhat less powerful than some other debuggers as it is only intended to be used with ST hardware, even though it works with most microcontrollers that support SWD debugging. Note that many online stores sell counterfeit versions of this debugger that may be unreliable.
+
+Which one you should pick depends on availability and price in your area but if you want to be sure, the SEGGER debugger is a commonly used vendor-neutral debugger that supports almost all chips and is very reliable.
+
+Most ARM Cortex-M chips use a protocol called SWD which uses just two data lines, called SWDIO and SWCLK. Sometimes these are available on separate header pins, but in many cases you'll need to solder some wires to test points on the board. Where they are depends on the board but you can often find them online if you google "&lt;boardname> swd pins" or "&lt;boardname> bootloader programming".
+
+Depending on the debug probe you may need to connect some extra wires:
+
+  * `GND` goes to ground. Not always needed if you're powering the probe from the same USB power source as the board.
+  * `Vref` needs to be connected to the power source of the chip, often 3.3V.
+  * Optionally, some debuggers (such as the Particle debugger) have a built-in UART that can be useful while debugging.
+
+Check the documentation of your debug probe for more information.
+
+## Getting a GDB shell
+
+Now you have all the hardware ready, it's time to actually start the debugger! If you're lucky, TinyGo already supports debugging the board. For example, the following is all you need to debug the BBC micro:bit:
+
+```
+$ tinygo gdb -target=microbit examples/microbit-blink
+[...]
+Reading symbols from /tmp/tinygo158938990/main...done.
+Remote debugging using :3333
+0x00000000 in __isr_vector ()
+target halted due to debug-request, current mode: Thread 
+xPSR: 0x21000000 pc: 0x00003baa msp: 0x200007f0
+Loading section .text, size 0xb84 lma 0x0
+Loading section .tinygo_stacksizes, size 0x4 lma 0xb84
+Loading section .data, size 0x4 lma 0xb88
+Start address 0x71c, load size 2956
+Transfer rate: 4 KB/sec, 985 bytes/write.
+target halted due to debug-request, current mode: Thread 
+xPSR: 0xc1000000 pc: 0x0000071c msp: 0x20000800
+(gdb) 
+```
+
+If you get a result like this without error messages, you have successfully entered the GDB shell! To continue running the program, enter the command `continue`. For more information on using GDB, see the [GDB tutorial]({{<ref "gdb.md">}}).
+
+Otherwise, you may need to specify the programmer:
+
+| Programmer        | Flags                   |
+| ----------------- | ----------------------- |
+| SEGGER J-Link     | `-programmer=jlink`     |
+| Particle Debugger | `-programmer=cmsis-dap` |
+| ST-Link V2        | `-programmer=stlink-v2` |
+
+For example:
+
+```
+$ tinygo gdb -target=arduino-nano33 -programmer=cmsis-dap examples/blinky1
+```

--- a/content/docs/tutorials/gdb.md
+++ b/content/docs/tutorials/gdb.md
@@ -1,0 +1,119 @@
+---
+title: "GDB"
+weight: 10
+description: |
+  Short introduction into debugging with GDB.
+---
+
+The debugger used by TinyGo is called [GDB](https://www.gnu.org/software/gdb/). This tutorial assumes you already have GDB installed and know how to enter the GDB shell, but don't know how to use it yet to actually debug something. For information on how to install and access GDB, see [the debugging guide]({{<ref "debugging.md">}}).
+
+For this tutorial we will assume the following:
+
+  * You have a BBC micro:bit.
+  * You have installed the required software: `openocd` and GDB (either `gdb-multiarch` or `arm-none-eabi-gdb`).
+
+## Enter GDB
+
+Now you can enter the GDB shell using the following command:
+
+```
+$ tinygo gdb -target=microbit examples/microbit-blink
+[...]
+target halted due to debug-request, current mode: Thread 
+xPSR: 0xc1000000 pc: 0x0000071c msp: 0x20000800
+(gdb) 
+```
+
+The following line is important:
+
+```
+target halted due to debug-request, current mode: Thread 
+```
+
+It means the target (in this case, the nrf51822 chip on the BBC micro:bit) is paused right at the start of the program.
+
+## Pause and continue
+
+You can start to run it by running the `c` or `continue` command:
+
+```
+(gdb) continue
+Continuing.
+```
+
+Now you should see that the LED on the BBC micro:bit starts to blink, which indicates that it is running.
+
+Pausing the program is done using Ctrl-C. It doesn't stop like you might expect, it only pauses:
+
+```
+(gdb) continue
+Continuing.
+^C
+Program received signal SIGINT, Interrupt.
+0x0000085c in runtime.waitForEvents () at /home/ayke/src/github.com/tinygo-org/tinygo/src/runtime/runtime_nrf_bare.go:8
+8		arm.Asm("wfe")
+(gdb) 
+```
+
+You can see here that the program pauses at the `wfe` instruction, the "wait for event" instruction that is executed to suspend the microcontroller. This is because the blinking LED example spends the vast majority of its time sleeping, and to reduce power consumption it enters a low power state using this instruction.
+
+You can also see that the LED stopped blinking: the processor was paused by the debug probe.
+
+## Backtrace
+
+One very useful command is `backtrace` or `bt`:
+
+```
+(gdb) bt
+#0  0x0000085c in runtime.waitForEvents () at /home/ayke/src/github.com/tinygo-org/tinygo/src/runtime/runtime_nrf_bare.go:8
+#1  runtime.rtc_sleep (ticks=<optimized out>) at /home/ayke/src/github.com/tinygo-org/tinygo/src/runtime/runtime_nrf.go:135
+#2  runtime.sleepTicks (d=16383) at /home/ayke/src/github.com/tinygo-org/tinygo/src/runtime/runtime_nrf.go:73
+#3  runtime.scheduler () at /home/ayke/src/github.com/tinygo-org/tinygo/src/runtime/scheduler.go:158
+#4  runtime.run () at /home/ayke/src/github.com/tinygo-org/tinygo/src/runtime/scheduler_any.go:24
+#5  Reset_Handler () at /home/ayke/src/github.com/tinygo-org/tinygo/src/runtime/runtime_nrf.go:27
+(gdb) 
+```
+
+You can see that the program was somewhere in the scheduler and not in a goroutine.
+
+## Breakpoints
+
+One of the main features of GDB is setting breakpoints. For example, let's say we want to break on printing a string. For that, we can break on the `runtime.printstring` function using the `b` or `break` command:
+
+```
+~$ tinygo gdb -target=microbit examples/serial
+[...]
+target halted due to debug-request, current mode: Thread 
+xPSR: 0xc1000000 pc: 0x0000071c msp: 0x20000800
+(gdb) b runtime.printstring
+Breakpoint 1 at 0x19c: file /home/ayke/src/github.com/tinygo-org/tinygo/src/runtime/print.go, line 14.
+(gdb) c
+Continuing.
+Note: automatically using hardware breakpoints for read-only addresses.
+
+Breakpoint 1, runtime.printstring (s=...) at /home/ayke/src/github.com/tinygo-org/tinygo/src/runtime/print.go:14
+14			putchar(s[i])
+(gdb) bt
+#0  runtime.printstring (s=...) at /home/ayke/src/github.com/tinygo-org/tinygo/src/runtime/print.go:14
+#1  0x0000096e in main.main () at /home/ayke/src/github.com/tinygo-org/tinygo/src/examples/serial/serial.go:7
+(gdb) list
+9	}
+10	
+11	//go:nobounds
+12	func printstring(s string) {
+13		for i := 0; i < len(s); i++ {
+14			putchar(s[i])
+15		}
+16	}
+17	
+18	func printuint8(n uint8) {
+(gdb) 
+```
+
+Here, you can see the following commands:
+
+ 1. `b runtime.printstring` to set a breakpoint on the `printstring` function in the runtime package.
+ 2. `c` to start running the program (it was paused).
+ 3. The program hits the breakpoint almost immediately.
+ 4. `bt` shows the backtrace, which stops at the `main.main` function because that's the root function of the goroutine.
+ 5. `list` shows the code around the breakpoint.


### PR DESCRIPTION
This documentation isn't complete but should provide the basics that can be extended. For example:

  * How to use a different board (such as the Xiao) to debug another board.
  * Troubleshooting common issues.
  * More in-depth examples how to debug a board without built-in debug adapter.