### PR TITLE
microcontrollers: add new boards that are part of 0.19 release

### DIFF
--- a/content/docs/reference/microcontrollers/feather-rp2040.md
+++ b/content/docs/reference/microcontrollers/feather-rp2040.md
@@ -1,0 +1,47 @@
+---
+title: "Adafruit Feather RP2040"
+weight: 3
+---
+
+The [Adafruit Feather RP2040]() is a tiny development board based on the Raspberry Pi [RP2040]() microcontroller.
+
+## Interfaces
+
+| Interface | Hardware Supported | TinyGo Support |
+| --------- | ------------- | ----- |
+| GPIO      | YES | YES |
+| UART      | YES | YES |
+| SPI      | YES | YES |
+| I2C      | YES | YES |
+| ADC      | YES | YES |
+| PWM      | YES | YES |
+
+## Machine Package Docs
+
+[Documentation for the machine package for the Adafruit Feather RP2040](../machine/feather-rp2040)
+
+## Flashing
+
+### UF2
+
+The Feather RP2040 comes with the [UF2 bootloader](https://github.com/Microsoft/uf2) already installed.
+
+### CLI Flashing
+
+- Plug your Feather RP2040 into your computer's USB port while holding down the RESET button on the board.
+- One plugged in, release the RESET button.
+- Flash your TinyGo program to the board using this command:
+
+    ```shell
+    tinygo flash -target=feather-rp2040 [PATH TO YOUR PROGRAM]
+    ```
+
+- The Feather RP2040 board should restart and then begin running your program.
+
+### Troubleshooting
+
+Any troubleshooting tips go here.
+
+## Notes
+
+You cannot yet use the USB port to the Feather RP2040 as a serial port. Instead `UART0` refers to the TX/RX pins on the board itself.

--- a/content/docs/reference/microcontrollers/feather-rp2040.md
+++ b/content/docs/reference/microcontrollers/feather-rp2040.md
@@ -3,7 +3,7 @@ title: "Adafruit Feather RP2040"
 weight: 3
 ---
 
-The [Adafruit Feather RP2040]() is a tiny development board based on the Raspberry Pi [RP2040]() microcontroller.
+The [Adafruit Feather RP2040](https://www.adafruit.com/product/4884) is a tiny development board based on the Raspberry Pi [RP2040](https://datasheets.raspberrypi.org/rp2040/rp2040-datasheet.pdf) microcontroller.
 
 ## Interfaces
 

--- a/content/docs/reference/microcontrollers/nano-33-ble.md
+++ b/content/docs/reference/microcontrollers/nano-33-ble.md
@@ -1,0 +1,60 @@
+---
+title: "Arduino Nano33 BLE"
+weight: 3
+---
+
+The [Arduino Nano33 BLE](h) is a very small ARM development board based on the Nordic Semiconductor [nrf52840](https://www.nordicsemi.com/eng/Products/nRF52840) processor.
+
+## Interfaces
+
+| Interface | Hardware Supported | TinyGo Support |
+| --------- | ------------- | ----- |
+| GPIO      | YES | YES |
+| UART      | YES | YES |
+| SPI      | YES | YES |
+| I2C      | YES | YES |
+| ADC      | YES | YES |
+| PWM      | YES | YES |
+
+## Machine Package Docs
+
+[Documentation for the machine package for the Arduino Nano33 IoT](../machine/arduino-nano33-ble)
+
+## Installing BOSSA
+
+In order to flash your TinyGo programs onto the Arduino Nano33 BLE board, you will need to install the "arduino_bossac" command line utility which is a special build of the [BOSSA command line utilities](https://github.com/shumatech/BOSSA).
+
+### macOS
+
+Instructions needed here.
+
+### Linux
+
+Instructions needed here.
+
+### Windows
+
+Instructions needed here.
+
+## Flashing
+
+Once you have installed the needed BOSSA command line utility, as in the previous section, you are ready to build and flash code to your Arduino Nano33 BLE board.
+
+### CLI Flashing
+
+- Plug your Arduino Nano33 BLE board into your computer's USB port.
+- Build and flash your TinyGo code using the `tinygo flash` command. This command flashes the Arduino Nano33 BLE with the blinky1 example:
+
+    ```shell
+    tinygo flash -target=arduino-nano33-ble examples/blinky1
+    ```
+
+- The Arduino Nano33 BLE board should restart and then begin running your program.
+
+### Troubleshooting
+
+Instructions needed here.
+
+## Notes
+
+You can use the USB port to the Arduino Nano33 BLE as a serial port. `UART0` refers to this connection.

--- a/content/docs/reference/microcontrollers/nano-33-ble.md
+++ b/content/docs/reference/microcontrollers/nano-33-ble.md
@@ -3,7 +3,9 @@ title: "Arduino Nano33 BLE"
 weight: 3
 ---
 
-The [Arduino Nano33 BLE](h) is a very small ARM development board based on the Nordic Semiconductor [nrf52840](https://www.nordicsemi.com/eng/Products/nRF52840) processor.
+The [Arduino Nano33 BLE](https://store.arduino.cc/arduino-nano-33-ble) is a very small ARM development board based on the Nordic Semiconductor [nrf52840](https://www.nordicsemi.com/eng/Products/nRF52840) processor.
+
+There is also the [Arduino Nano33 BLE Sense](https://store.arduino.cc/arduino-nano-33-ble-sense) which is the exact same board but with additional onboard sensors.
 
 ## Interfaces
 
@@ -18,23 +20,35 @@ The [Arduino Nano33 BLE](h) is a very small ARM development board based on the N
 
 ## Machine Package Docs
 
-[Documentation for the machine package for the Arduino Nano33 IoT](../machine/arduino-nano33-ble)
+[Documentation for the machine package for the Arduino Nano33 BLE](../machine/nano-33-ble)
 
 ## Installing BOSSA
 
-In order to flash your TinyGo programs onto the Arduino Nano33 BLE board, you will need to install the "arduino_bossac" command line utility which is a special build of the [BOSSA command line utilities](https://github.com/shumatech/BOSSA).
+In order to flash your TinyGo programs onto the Arduino Nano33 BLE board, you will need to install the "bossac_arduino2" command line utility which is a special build of the [BOSSA command line utilities](https://github.com/shumatech/BOSSA).
 
 ### macOS
 
-Instructions needed here.
+If you have a Mac computer with an Intel processor, download the `bossac_arduino2` program from http://downloads.arduino.cc/tools/bossac-1.9.1-arduino2-osx.tar.gz
+
+Extract the downloaded file to a directory on your computer.
+
+Make sure to add that directory into your PATH.
 
 ### Linux
 
-Instructions needed here.
+Download the `bossac_arduino2` program from http://downloads.arduino.cc/tools/bossac-1.9.1-arduino2-linux64.tar.gz
+
+Extract the downloaded file to a directory on your computer.
+
+Make sure to add that directory into your PATH.
 
 ### Windows
 
-Instructions needed here.
+Download the `bossac_arduino2` program from http://downloads.arduino.cc/tools/bossac-1.9.1-arduino2-windows.tar.gz
+
+Extract the downloaded file to a directory on your computer.
+
+Make sure to add that directory into your PATH.
 
 ## Flashing
 
@@ -46,7 +60,7 @@ Once you have installed the needed BOSSA command line utility, as in the previou
 - Build and flash your TinyGo code using the `tinygo flash` command. This command flashes the Arduino Nano33 BLE with the blinky1 example:
 
     ```shell
-    tinygo flash -target=arduino-nano33-ble examples/blinky1
+    tinygo flash -target=nano-33-ble examples/blinky1
     ```
 
 - The Arduino Nano33 BLE board should restart and then begin running your program.

--- a/content/docs/reference/microcontrollers/nano-rp2040.md
+++ b/content/docs/reference/microcontrollers/nano-rp2040.md
@@ -3,12 +3,12 @@ title: "Nano RP2040"
 weight: 3
 ---
 
-The [Nano RP2040]() is a tiny development board based on the Raspberry Pi [RP2040]() microcontroller.
+The [Nano RP2040](https://store.arduino.cc/nano-rp2040-connect) is a tiny development board based on the Raspberry Pi [RP2040](https://datasheets.raspberrypi.org/rp2040/rp2040-datasheet.pdf) microcontroller.
 
 ## Interfaces
 
 | Interface | Hardware Supported | TinyGo Support |
-| --------- | ------------- | ----- |
+| --------- | ------------- | ----- |Well, I think 
 | GPIO      | YES | YES |
 | UART      | YES | YES |
 | SPI      | YES | YES |
@@ -28,8 +28,8 @@ The Nano RP2040 comes with the [UF2 bootloader](https://github.com/Microsoft/uf2
 
 ### CLI Flashing
 
-- Plug your Nano RP2040 into your computer's USB port while holding down the RESET button on the board.
-- One plugged in, release the RESET button.
+- Plug your Nano RP2040 into your computer's USB port while shorting the pins REC and GND with a jumper wire.
+- Once plugged in, remove the jumper pin.
 - Flash your TinyGo program to the board using this command:
 
     ```shell

--- a/content/docs/reference/microcontrollers/nano-rp2040.md
+++ b/content/docs/reference/microcontrollers/nano-rp2040.md
@@ -1,0 +1,47 @@
+---
+title: "Nano RP2040"
+weight: 3
+---
+
+The [Nano RP2040]() is a tiny development board based on the Raspberry Pi [RP2040]() microcontroller.
+
+## Interfaces
+
+| Interface | Hardware Supported | TinyGo Support |
+| --------- | ------------- | ----- |
+| GPIO      | YES | YES |
+| UART      | YES | YES |
+| SPI      | YES | YES |
+| I2C      | YES | YES |
+| ADC      | YES | YES |
+| PWM      | YES | YES |
+
+## Machine Package Docs
+
+[Documentation for the machine package for the Nano RP2040](../machine/nano-rp2040)
+
+## Flashing
+
+### UF2
+
+The Nano RP2040 comes with the [UF2 bootloader](https://github.com/Microsoft/uf2) already installed.
+
+### CLI Flashing
+
+- Plug your Nano RP2040 into your computer's USB port while holding down the RESET button on the board.
+- One plugged in, release the RESET button.
+- Flash your TinyGo program to the board using this command:
+
+    ```shell
+    tinygo flash -target=nano-rp2040 [PATH TO YOUR PROGRAM]
+    ```
+
+- The Nano RP2040 board should restart and then begin running your program.
+
+### Troubleshooting
+
+Any troubleshooting tips go here.
+
+## Notes
+
+You cannot yet use the USB port to the Nano RP2040 as a serial port. Instead `UART0` refers to the TX/RX pins on the board itself.

--- a/content/docs/reference/microcontrollers/pico.md
+++ b/content/docs/reference/microcontrollers/pico.md
@@ -1,0 +1,47 @@
+---
+title: "Pico"
+weight: 3
+---
+
+The [Raspberry Pi Pico](https://www.raspberrypi.org/products/raspberry-pi-pico/) is a tiny development board based on the Raspberry Pi [RP2040](https://datasheets.raspberrypi.org/rp2040/rp2040-datasheet.pdf) microcontroller.
+
+## Interfaces
+
+| Interface | Hardware Supported | TinyGo Support |
+| --------- | ------------- | ----- |
+| GPIO      | YES | YES |
+| UART      | YES | YES |
+| SPI      | YES | YES |
+| I2C      | YES | YES |
+| ADC      | YES | YES |
+| PWM      | YES | YES |
+
+## Machine Package Docs
+
+[Documentation for the machine package for the Pico](../machine/pico)
+
+## Flashing
+
+### UF2
+
+The Pico comes with the [UF2 bootloader](https://github.com/Microsoft/uf2) already installed.
+
+### CLI Flashing
+
+- Plug your Pico into your computer's USB port while holding down the RESET button on the board.
+- One plugged in, release the RESET button.
+- Flash your TinyGo program to the board using this command:
+
+    ```shell
+    tinygo flash -target=pico [PATH TO YOUR PROGRAM]
+    ```
+
+- The Pico board should restart and then begin running your program.
+
+### Troubleshooting
+
+Any troubleshooting tips go here.
+
+## Notes
+
+You cannot yet use the USB port to the Pico as a serial port. Instead `UART0` refers to the TX/RX pins on the board itself.


### PR DESCRIPTION
This PR adds new boards that are part of the immanent 0.19 release.

The pages are still missing info, and need to have the docs regenerated once updated.