### PR TITLE
search: add Algolia search to site

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -26,6 +26,11 @@ unsafe = true
 [params]
 copyright = "The TinyGo Authors"
 
+# Google Custom Search Engine ID. Remove or comment out to disable search.
+# gcs_engine_id = "feba5f0a3db52897d"
+
+# Enable Algolia DocSearch
+algolia_docsearch = true
 
 # Repository configuration (URLs for in-page links to opening issues and suggesting changes)
 github_repo = "https://github.com/tinygo-org/tinygo-site"
@@ -41,7 +46,7 @@ sidebar_menu_compact = true
 #  Set to true to disable breadcrumb navigation.
 breadcrumb_disable = false
 #  Set to true to hide the sidebar search box (the top nav search box will still be displayed if search is enabled)
-sidebar_search_disable = false
+sidebar_search_disable = true
 #  Set to false if you don't want to display a logo (/assets/icons/logo.svg) in the top nav bar
 navbar_logo = true
 # Set to true to disable the About link in the site footer

--- a/content/search.md
+++ b/content/search.md
@@ -1,0 +1,4 @@
+---
+title: Search Results
+layout: search
+---

--- a/layouts/partials/hooks/body-end.html
+++ b/layouts/partials/hooks/body-end.html
@@ -1,0 +1,8 @@
+<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
+<script type="text/javascript"> docsearch({
+    apiKey: '42f398a5126d862b7112ee3ba7fddfb2',
+    indexName: 'tinygo',
+    inputSelector: '.td-search-input',
+    debug: false // Set debug to true if you want to inspect the dropdown
+});
+</script>

--- a/layouts/partials/hooks/head-end.html
+++ b/layouts/partials/hooks/head-end.html
@@ -1,0 +1,1 @@
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />


### PR DESCRIPTION
This PR adds Algolia docs search to the site.

https://docsearch.algolia.com/

Looks nicer and works better than the Google Site Search which I also tried.

