### PR TITLE
"Contributing" section

### DIFF
--- a/content/docs/guides/contributing/_index.md
+++ b/content/docs/guides/contributing/_index.md
@@ -1,0 +1,57 @@
+---
+title: "Contributing"
+weight: 5
+description: >
+  Adding support for new chips, fixing bugs, improving the compiler, or otherwise improving the TinyGo project.
+---
+
+Thank you for your interest in improving TinyGo.
+
+We would like your help to make this project better, so we appreciate any contributions. See if one of the following descriptions matches your situation:
+
+### New to TinyGo
+
+We'd love to get your feedback on getting started with TinyGo. Run into any difficulty, confusion, or anything else? You are not alone. We want to know about your experience, so we can help the next people. Please open a Github issue with your questions, or you can also get in touch directly with us on our Slack channel at [https://gophers.slack.com/messages/CDJD3SUP6](https://gophers.slack.com/messages/CDJD3SUP6).
+
+### Something in TinyGo is not working as you expect
+
+Please open a Github issue with your problem, and we will be happy to assist.
+
+### Something in Go that you want/need does not appear to be in TinyGo
+
+We probably have not implemented it yet. Please take a look at our [Roadmap](https://github.com/tinygo-org/tinygo/wiki/Roadmap). Your pull request adding the functionality to TinyGo would be greatly appreciated.
+
+Please open a Github issue. We want to help, and also make sure that there is no duplications of efforts. Sometimes what you need is already being worked on by someone else.
+
+A long tail of small (and large) language features haven't been implemented yet. In almost all cases, the compiler will show a `todo:` error from `compiler/compiler.go` when you try to use it. You can try implementing it, or open a bug report with a small code sample that fails to compile.
+
+### Some specific hardware you want to use does not appear to be in TinyGo
+
+As above, we probably have not implemented it yet. Your contribution adding the hardware support to TinyGo would be greatly appreciated.
+
+Please start by opening a Github issue. We want to help you to help us to help you.
+
+Lots of targets/boards are still unsupported. Adding an architecture often requires a few compiler changes, but if the architecture is supported you can try implementing support for a new chip or board in `src/runtime`. For details, see [this wiki entry on adding archs/chips/boards](https://github.com/tinygo-org/tinygo/wiki/Adding-a-new-board).
+
+Microcontrollers have lots of peripherals (I2C, SPI, ADC, etc.) and many don't have an implementation yet in the `machine` package. Adding support for new peripherals is very useful.
+
+## How to use our Github repository
+
+The `release` branch of this repo will always have the latest released version of TinyGo. All of the active development work for the next release will take place in the `dev` branch. TinyGo will use semantic versioning and will create a tag/release for each release.
+
+Here is how to contribute back some code or documentation:
+
+- Fork repo
+- Create a feature branch off of the `dev` branch
+- Make some useful change
+- Make sure the tests still pass
+- Submit a pull request against the `dev` branch.
+- Be kind
+
+## How to run tests
+
+To run the tests:
+
+```
+make test
+```

--- a/content/docs/guides/contributing/organization.md
+++ b/content/docs/guides/contributing/organization.md
@@ -1,0 +1,33 @@
+---
+title: "Package organization"
+weight: 1
+description: >
+  How code is organized in TinyGo.
+---
+
+There are many packages in the TinyGo repository. Here is an overview, and a brief description what they're for.
+
+Packages can be split in two kinds: compiler packages and GOROOT packages. Compiler packages are the ones that are part of the TinyGo compiler itself: they will generate the object files and call a linker to link them together. The GOROOT packages are the packages you can import from a program, such as the TinyGo `"machine"` package.
+
+## Compiler packages
+
+  - root: contains the command line interface for the `tinygo` command and all its subcommands
+  - `builder`: orchestrates the build
+  - `loader`: loads and typechecks the code, and produces an AST
+  - `compiler`: the compiler itself, makes little attempt at optimizing code
+  - `interp`: tries to run package initializers at compile time as far as possible
+  - `transform`: implements various optimizations necessary to produce working and efficient code
+
+There are a few more, but you don't usually need to look at them. The above packages are the most important packages. To see how these packages work together, you can also take a look at [Pipeline]({{< ref "pipeline.md" >}}).
+
+## `GOROOT` packages
+
+The `GOROOT` directory in TinyGo is actually a constructed GOROOT, cached and reused over different compiler invocations. It is a combination of Go standard library packages and special TinyGo modified packages. For example, the `fmt` package is the exact same package that's used in regular Go, while the `runtime` package is a custom implementation for TinyGo and replaced altogether.
+
+These replaced (or added) packages live in the src subdirectory:
+
+  - `src/runtime`: the replacement runtime package that contains the things you would expect of a runtime package. It implements a heap with a garbage collector, a scheduler for goroutines, channels, and perhaps less obviously: it contains various things that are not implemented in the compiler like maps, the slice `append` built-in, and various other language features. It also implements a few device specific things, namely: runtime initialization and timers (used by the time packkage). These last two are device specific and need to be implemented per device.
+  - `src/device`: contains hardware register access (memory-mapped I/O) without abstractions. Most of the subpackages are automatically generated. These packages are only used for baremetal programming.
+  - `src/machine`: contains a hardware abstraction layer for chips. You could think of this as the equivalent of the `os` package: it provides portable APIs for common hardware peripherals. For example, every chip vendor implements [I2C]({{<ref "i2c.md">}}) differently but the machine package wraps this in a single `*machine.I2C` type that has the same interface on any supported chip. For more information, see the [machine package doucumentation]({{<ref "../../reference/machine.md">}})
+
+There are a few more packages but these are the ones that are the most important for contributing to TinyGo.


### PR DESCRIPTION
This is an attempt to replace the CONTRIBUTING.md page in the TinyGo root directory. The code organization page is new, and is primarily intended for people who would like to add new hardware support.