### PR TITLE
doc-gen: skip unexported receiver

### DIFF
--- a/doc-gen/main.go
+++ b/doc-gen/main.go
@@ -229,7 +229,9 @@ func writeMachinePackageDoc(path, target string, pkg *packages.Package) error {
 					default:
 						return fmt.Errorf("unknown receiver for %s", decl.Name.Name)
 					}
-					doc.Types[receiverName].Funcs[decl.Name.Name] = decl
+					if ast.IsExported(receiverName) {
+						doc.Types[receiverName].Funcs[decl.Name.Name] = decl
+					}
 				}
 			}
 		}


### PR DESCRIPTION
This PR will skip the case where the receiver is private.

#228 had a panic in the following source code.
https://github.com/tinygo-org/tinygo/blob/dev/src/machine/machine_rp2040_i2c.go#L440-L444