### PR TITLE
fix Machine package documentation URL

### DIFF
--- a/content/docs/reference/microcontrollers/clue.md
+++ b/content/docs/reference/microcontrollers/clue.md
@@ -19,7 +19,7 @@ The [Adafruit CLUE](https://www.adafruit.com/product/4500) is small ARM developm
 
 ## Machine Package Docs
 
-[Documentation for the machine package for the Adafruit CLUE](../machine/adafruit-clue)
+[Documentation for the machine package for the Adafruit CLUE](../machine/clue)
 
 ## Flashing
 


### PR DESCRIPTION
tiny fix on the machine package documentation URL.
(but needed to fork and PR, sorry for the delay)