### PR TITLE
microcontrollers: add m5stamp-c3

### DIFF
--- a/content/docs/reference/microcontrollers/m5stamp-c3.md
+++ b/content/docs/reference/microcontrollers/m5stamp-c3.md
@@ -1,0 +1,50 @@
+---
+title: "M5Stamp C3"
+weight: 3
+---
+
+The [M5Stamp-C3](https://docs.m5stack.com/en/core/stamp_c3) is a development board based on the Espressif ESP32-C3 a powerful chip that is used on many different board mostly because of the built-in radio that can be used for WiFi or Bluetooth wireless connections.
+
+## Interfaces
+
+| Interface | Hardware Supported | TinyGo Support |
+| --------- | ------------- | ----- |
+| GPIO      | YES | YES |
+| UART      | YES | YES |
+| SPI      | YES | Not yet |
+| I2C      | YES | Not yet |
+| ADC      | YES | Not yet |
+| PWM      | YES | Not yet |
+| WiFi      | YES | Not Yet |
+| Bluetooth      | YES | Not yet |
+
+## Machine Package Docs
+
+[Documentation for the machine package for the M5Stamp-C3](../machine/m5stamp-c3)
+
+## Flashing
+
+### CLI Flashing
+
+In addition, you must install the `esptool` flashing tool:
+
+https://github.com/espressif/esptool#easy-installation
+
+Now you should be able to flash your board as follows:
+
+- Plug your ESP32-C3 board into your computer's USB port.
+- Build and flash your TinyGo code using the `tinygo flash` command. This command flashes the ESP32-C3 with the serial example:
+
+    ```
+    tinygo flash -target=m5stack-core2 examples/serial
+    ```
+
+- The ESP32-C3 board should restart and then begin running your program.
+
+### Troubleshooting
+
+Goes here
+
+## Notes
+
+Goes here

--- a/content/docs/reference/microcontrollers/machine/m5stamp-c3.md
+++ b/content/docs/reference/microcontrollers/machine/m5stamp-c3.md
@@ -1,0 +1,567 @@
+
+---
+title: m5stamp-c3
+---
+
+
+## Constants
+
+```go
+const (
+	IO0	Pin	= 0
+	IO1	Pin	= 1
+	IO2	Pin	= 2
+	IO3	Pin	= 3
+	IO4	Pin	= 4
+	IO5	Pin	= 5
+	IO6	Pin	= 6
+	IO7	Pin	= 7
+	IO8	Pin	= 8
+	IO9	Pin	= 9
+	IO10	Pin	= 10
+	IO11	Pin	= 11
+	IO12	Pin	= 12
+	IO13	Pin	= 13
+	IO14	Pin	= 14
+	IO15	Pin	= 15
+	IO16	Pin	= 16
+	IO17	Pin	= 17
+	IO18	Pin	= 18
+	IO19	Pin	= 19
+	IO20	Pin	= 20
+	IO21	Pin	= 21
+
+	XTAL_32K_P	= IO0
+	XTAL_32K_N	= IO1
+	MTMS		= IO4
+	MTDI		= IO5
+	MTCK		= IO6
+	MTDO		= IO7
+	VDD_SPI		= IO11
+	SPIHD		= IO12
+	SPISP		= IO13
+	SPICS0		= IO14
+	SPICLK		= IO15
+	SPID		= IO16
+	SPIQ		= IO17
+	U0RXD		= IO20
+	U0TXD		= IO21
+)
+```
+
+
+
+```go
+const (
+	WS2812 = IO2
+)
+```
+
+
+
+```go
+const Device = deviceName
+```
+
+Device is the running program's chip name, such as "ATSAMD51J19A" or
+"nrf52840". It is not the same as the CPU name.
+
+The constant is some hardcoded default value if the program does not target a
+particular chip but instead runs in WebAssembly for example.
+
+
+```go
+const NoPin = Pin(0xff)
+```
+
+NoPin explicitly indicates "not a pin". Use this pin if you want to leave one
+of the pins in a peripheral unconfigured (if supported by the hardware).
+
+
+```go
+const (
+	PinOutput	PinMode	= iota
+	PinInput
+	PinInputPullup
+	PinInputPulldown
+)
+```
+
+
+
+```go
+const (
+	// ParityNone means to not use any parity checking. This is
+	// the most common setting.
+	ParityNone	UARTParity	= 0
+
+	// ParityEven means to expect that the total number of 1 bits sent
+	// should be an even number.
+	ParityEven	UARTParity	= 1
+
+	// ParityOdd means to expect that the total number of 1 bits sent
+	// should be an odd number.
+	ParityOdd	UARTParity	= 2
+)
+```
+
+
+
+
+
+
+## Variables
+
+```go
+var (
+	ErrTimeoutRNG		= errors.New("machine: RNG Timeout")
+	ErrInvalidInputPin	= errors.New("machine: invalid input pin")
+	ErrInvalidOutputPin	= errors.New("machine: invalid output pin")
+	ErrInvalidClockPin	= errors.New("machine: invalid clock pin")
+	ErrInvalidDataPin	= errors.New("machine: invalid data pin")
+	ErrNoPinChangeChannel	= errors.New("machine: no channel available for pin interrupt")
+)
+```
+
+
+
+```go
+var DefaultUART = UART0
+```
+
+
+
+```go
+var (
+	UART0	= &_UART0
+	_UART0	= UART{Bus: esp.UART0, Buffer: NewRingBuffer()}
+	UART1	= &_UART1
+	_UART1	= UART{Bus: esp.UART1, Buffer: NewRingBuffer()}
+)
+```
+
+
+
+```go
+var (
+	ErrPWMPeriodTooLong = errors.New("pwm: period too long")
+)
+```
+
+
+
+```go
+var Serial = DefaultUART
+```
+
+Serial is implemented via the default (usually the first) UART on the chip.
+
+
+
+
+
+### func CPUFrequency
+
+```go
+func CPUFrequency() uint32
+```
+
+CPUFrequency returns the current CPU frequency of the chip.
+Currently it is a fixed frequency but it may allow changing in the future.
+
+
+### func NewRingBuffer
+
+```go
+func NewRingBuffer() *RingBuffer
+```
+
+NewRingBuffer returns a new ring buffer.
+
+
+
+
+## type ADC
+
+```go
+type ADC struct {
+	Pin Pin
+}
+```
+
+
+
+
+
+
+## type ADCConfig
+
+```go
+type ADCConfig struct {
+	Reference	uint32	// analog reference voltage (AREF) in millivolts
+	Resolution	uint32	// number of bits for a single conversion (e.g., 8, 10, 12)
+	Samples		uint32	// number of samples for a single conversion (e.g., 4, 8, 16, 32)
+}
+```
+
+ADCConfig holds ADC configuration parameters. If left unspecified, the zero
+value of each parameter will use the peripheral's default settings.
+
+
+
+
+
+## type NullSerial
+
+```go
+type NullSerial struct {
+}
+```
+
+NullSerial is a serial version of /dev/null (or null router): it drops
+everything that is written to it.
+
+
+
+### func (NullSerial) Buffered
+
+```go
+func (ns NullSerial) Buffered() int
+```
+
+Buffered returns how many bytes are buffered in the UART. It always returns 0
+as there are no bytes to read.
+
+
+### func (NullSerial) Configure
+
+```go
+func (ns NullSerial) Configure(config UARTConfig) error
+```
+
+Configure does nothing: the null serial has no configuration.
+
+
+### func (NullSerial) ReadByte
+
+```go
+func (ns NullSerial) ReadByte() (byte, error)
+```
+
+ReadByte always returns an error because there aren't any bytes to read.
+
+
+### func (NullSerial) Write
+
+```go
+func (ns NullSerial) Write(p []byte) (n int, err error)
+```
+
+Write is a no-op: none of the data is being written and it will not return an
+error.
+
+
+### func (NullSerial) WriteByte
+
+```go
+func (ns NullSerial) WriteByte(b byte) error
+```
+
+WriteByte is a no-op: the null serial doesn't write bytes.
+
+
+
+
+## type PWMConfig
+
+```go
+type PWMConfig struct {
+	// PWM period in nanosecond. Leaving this zero will pick a reasonable period
+	// value for use with LEDs.
+	// If you want to configure a frequency instead of a period, you can use the
+	// following formula to calculate a period from a frequency:
+	//
+	//     period = 1e9 / frequency
+	//
+	Period uint64
+}
+```
+
+PWMConfig allows setting some configuration while configuring a PWM
+peripheral. A zero PWMConfig is ready to use for simple applications such as
+dimming LEDs.
+
+
+
+
+
+## type Pin
+
+```go
+type Pin uint8
+```
+
+Pin is a single pin on a chip, which may be connected to other hardware
+devices. It can either be used directly as GPIO pin or it can be used in
+other peripherals like ADC, I2C, etc.
+
+
+
+### func (Pin) Configure
+
+```go
+func (p Pin) Configure(config PinConfig)
+```
+
+Configure this pin with the given configuration.
+
+
+### func (Pin) Get
+
+```go
+func (p Pin) Get() bool
+```
+
+Get returns the current value of a GPIO pin when configured as an input or as
+an output.
+
+
+### func (Pin) High
+
+```go
+func (p Pin) High()
+```
+
+High sets this GPIO pin to high, assuming it has been configured as an output
+pin. It is hardware dependent (and often undefined) what happens if you set a
+pin to high that is not configured as an output pin.
+
+
+### func (Pin) Low
+
+```go
+func (p Pin) Low()
+```
+
+Low sets this GPIO pin to low, assuming it has been configured as an output
+pin. It is hardware dependent (and often undefined) what happens if you set a
+pin to low that is not configured as an output pin.
+
+
+### func (Pin) PortMaskClear
+
+```go
+func (p Pin) PortMaskClear() (*uint32, uint32)
+```
+
+Return the register and mask to disable a given GPIO pin. This can be used to
+implement bit-banged drivers.
+
+Warning: only use this on an output pin!
+
+
+### func (Pin) PortMaskSet
+
+```go
+func (p Pin) PortMaskSet() (*uint32, uint32)
+```
+
+Return the register and mask to enable a given GPIO pin. This can be used to
+implement bit-banged drivers.
+
+Warning: only use this on an output pin!
+
+
+### func (Pin) Set
+
+```go
+func (p Pin) Set(value bool)
+```
+
+Set the pin to high or low.
+Warning: only use this on an output pin!
+
+
+
+
+## type PinConfig
+
+```go
+type PinConfig struct {
+	Mode PinMode
+}
+```
+
+
+
+
+
+
+## type PinMode
+
+```go
+type PinMode uint8
+```
+
+PinMode sets the direction and pull mode of the pin. For example, PinOutput
+sets the pin as an output and PinInputPullup sets the pin as an input with a
+pull-up.
+
+
+
+
+
+## type RingBuffer
+
+```go
+type RingBuffer struct {
+	rxbuffer	[bufferSize]volatile.Register8
+	head		volatile.Register8
+	tail		volatile.Register8
+}
+```
+
+RingBuffer is ring buffer implementation inspired by post at
+https://www.embeddedrelated.com/showthread/comp.arch.embedded/77084-1.php
+
+
+
+### func (*RingBuffer) Clear
+
+```go
+func (rb *RingBuffer) Clear()
+```
+
+Clear resets the head and tail pointer to zero.
+
+
+### func (*RingBuffer) Get
+
+```go
+func (rb *RingBuffer) Get() (byte, bool)
+```
+
+Get returns a byte from the buffer. If the buffer is empty,
+the method will return a false as the second value.
+
+
+### func (*RingBuffer) Put
+
+```go
+func (rb *RingBuffer) Put(val byte) bool
+```
+
+Put stores a byte in the buffer. If the buffer is already
+full, the method will return false.
+
+
+### func (*RingBuffer) Used
+
+```go
+func (rb *RingBuffer) Used() uint8
+```
+
+Used returns how many bytes in buffer have been used.
+
+
+
+
+## type UART
+
+```go
+type UART struct {
+	Bus	*esp.UART_Type
+	Buffer	*RingBuffer
+}
+```
+
+
+
+
+### func (*UART) Buffered
+
+```go
+func (uart *UART) Buffered() int
+```
+
+Buffered returns the number of bytes currently stored in the RX buffer.
+
+
+### func (*UART) Read
+
+```go
+func (uart *UART) Read(data []byte) (n int, err error)
+```
+
+Read from the RX buffer.
+
+
+### func (*UART) ReadByte
+
+```go
+func (uart *UART) ReadByte() (byte, error)
+```
+
+ReadByte reads a single byte from the RX buffer.
+If there is no data in the buffer, returns an error.
+
+
+### func (*UART) Receive
+
+```go
+func (uart *UART) Receive(data byte)
+```
+
+Receive handles adding data to the UART's data buffer.
+Usually called by the IRQ handler for a machine.
+
+
+### func (*UART) Write
+
+```go
+func (uart *UART) Write(data []byte) (n int, err error)
+```
+
+Write data to the UART.
+
+
+### func (*UART) WriteByte
+
+```go
+func (uart *UART) WriteByte(b byte) error
+```
+
+
+
+
+
+## type UARTConfig
+
+```go
+type UARTConfig struct {
+	BaudRate	uint32
+	TX		Pin
+	RX		Pin
+}
+```
+
+UARTConfig is a struct with which a UART (or similar object) can be
+configured. The baud rate is usually respected, but TX and RX may be ignored
+depending on the chip and the type of object.
+
+
+
+
+
+## type UARTParity
+
+```go
+type UARTParity int
+```
+
+UARTParity is the parity setting to be used for UART communication.
+
+
+
+
+


### PR DESCRIPTION
In this PR, we will add documentation for m5stamp-c3.

I ran doc-gen with the following branch.
https://github.com/tinygo-org/tinygo/pull/2576