### PR TITLE
Document adafruit products associated with LED controllers.

### DIFF
--- a/content/docs/reference/devices/_index.md
+++ b/content/docs/reference/devices/_index.md
@@ -20,7 +20,7 @@ The following 67 devices are supported.
 | [ADXL345 accelerometer](http://www.analog.com/media/en/technical-documentation/data-sheets/ADXL345.pdf) | I2C |
 | [AHT20 I2C Temperature and Humidity Sensor](http://www.aosong.com/userfiles/files/media/AHT20%20%E8%8B%B1%E6%96%87%E7%89%88%E8%AF%B4%E6%98%8E%E4%B9%A6%20A0%2020201222.pdf) | I2C |
 | [AMG88xx 8x8 Thermal camera sensor](https://cdn-learn.adafruit.com/assets/assets/000/043/261/original/Grid-EYE_SPECIFICATIONS%28Reference%29.pdf) | I2C |
-| [APA102 RGB LED](https://cdn-shop.adafruit.com/product-files/2343/APA102C.pdf) | SPI |
+| [APA102 RGB LED (Adafruit DotStar)](https://cdn-shop.adafruit.com/product-files/2343/APA102C.pdf) | SPI |
 | [AT24CX 2-wire serial EEPROM](https://www.openimpulse.com/blog/wp-content/uploads/wpsc/downloadables/24C32-Datasheet.pdf) | I2C |
 | [BBC micro:bit LED matrix](https://github.com/bbcmicrobit/hardware/blob/master/SCH_BBC-Microbit_V1.3B.pdf) | GPIO |
 | [BH1750 ambient light sensor](https://www.mouser.com/ds/2/348/bh1750fvi-e-186247.pdf) | I2C |
@@ -83,7 +83,7 @@ The following 67 devices are supported.
 | [Waveshare 2.13" (B & C) e-paper display](https://www.waveshare.com/w/upload/d/d3/2.13inch-e-paper-b-Specification.pdf) | SPI |
 | [Waveshare 2.13" e-paper display](https://www.waveshare.com/w/upload/e/e6/2.13inch_e-Paper_Datasheet.pdf) | SPI |
 | [Waveshare 4.2" e-paper B/W display](https://www.waveshare.com/w/upload/6/6a/4.2inch-e-paper-specification.pdf) | SPI |
-| [WS2812 RGB LED](https://cdn-shop.adafruit.com/datasheets/WS2812.pdf) | GPIO |
+| [WS2812 RGB LED (Adafruit Neopixel)](https://cdn-shop.adafruit.com/datasheets/WS2812.pdf) | GPIO |
 
 We also give you the ability to add new drivers. If your device isn't listed here, please raise an issue in the [issue tracker](https://github.com/tinygo-org/drivers/issues).
 

--- a/content/docs/reference/microcontrollers/circuitplay-bluefruit.md
+++ b/content/docs/reference/microcontrollers/circuitplay-bluefruit.md
@@ -58,6 +58,8 @@ Once you have updated your Circuit Playground Bluefruit board the first time, af
 
 You can use the USB port to the Circuit Playground Bluefruit as a serial port. `UART0` refers to this connection.
 
+The Neopixel LED on the Circuit Playground Bluefruit can be accessed using the [WS2812](https://pkg.go.dev/tinygo.org/x/drivers/ws2812) driver via the `D8` pin.
+
 For an example that uses the built-in Neopixel LEDs, take a look at the TinyGo drivers repository located at [https://github.com/tinygo-org/drivers/tree/release/examples](https://github.com/tinygo-org/drivers)
 
 Bluetooth support is now available for the Circuit Playground Bluefruit board. See https://github.com/tinygo-org/bluetooth for more information.

--- a/content/docs/reference/microcontrollers/circuitplay-express.md
+++ b/content/docs/reference/microcontrollers/circuitplay-express.md
@@ -55,4 +55,6 @@ Once you have updated your Circuit Playground Express board the first time, afte
 
 You can use the USB port to the Circuit Playground Express as a serial port. `UART0` refers to this connection.
 
+The Neopixel LED on the Circuit Playground Express can be accessed using the [WS2812](https://pkg.go.dev/tinygo.org/x/drivers/ws2812) driver via the `PB23` pin.
+
 For an example that uses the built-in Neopixel LEDs, take a look at the TinyGo drivers repository located at [https://github.com/tinygo-org/drivers/tree/release/examples](https://github.com/tinygo-org/drivers)

--- a/content/docs/reference/microcontrollers/grandcentral-m4.md
+++ b/content/docs/reference/microcontrollers/grandcentral-m4.md
@@ -56,3 +56,5 @@ Once you have updated your Grand Central M4 board the first time, after that you
 ## Notes
 
 You can use the USB port to the Grand Central M4 as a serial port. `UART0` refers to this connection.
+
+The Neopixel LED on the Grand Central M4 can be accessed using the [WS2812](https://pkg.go.dev/tinygo.org/x/drivers/ws2812) driver via the `PC24` pin

--- a/content/docs/reference/microcontrollers/itsybitsy-m0.md
+++ b/content/docs/reference/microcontrollers/itsybitsy-m0.md
@@ -54,3 +54,5 @@ Once you have updated your ItsyBitsy M0 board the first time, after that you sho
 ## Notes
 
 You can use the USB port to the ItsyBitsy M0 as a serial port. `UART0` refers to this connection.
+
+The DotStar LED on the ItsyBitsy M0 can be accessed using the [APA102](https://pkg.go.dev/tinygo.org/x/drivers/apa102) driver via a software SPI on the `PA00` and `PA01` pins

--- a/content/docs/reference/microcontrollers/itsybitsy-m4.md
+++ b/content/docs/reference/microcontrollers/itsybitsy-m4.md
@@ -54,3 +54,5 @@ Once you have updated your ItsyBitsy M4 board the first time, after that you sho
 ## Notes
 
 You can use the USB port to the ItsyBitsy M4 as a serial port. `UART0` refers to this connection.
+
+The DotStar LED on the ItsyBitsy M0 can be accessed using the [APA102](https://pkg.go.dev/tinygo.org/x/drivers/apa102) driver via a software SPI on the `PB02` and `PB03` pins

--- a/content/docs/reference/microcontrollers/itsybitsy-m4.md
+++ b/content/docs/reference/microcontrollers/itsybitsy-m4.md
@@ -55,4 +55,4 @@ Once you have updated your ItsyBitsy M4 board the first time, after that you sho
 
 You can use the USB port to the ItsyBitsy M4 as a serial port. `UART0` refers to this connection.
 
-The DotStar LED on the ItsyBitsy M0 can be accessed using the [APA102](https://pkg.go.dev/tinygo.org/x/drivers/apa102) driver via a software SPI on the `PB02` and `PB03` pins
+The DotStar LED on the ItsyBitsy M4 can be accessed using the [APA102](https://pkg.go.dev/tinygo.org/x/drivers/apa102) driver via a software SPI on the `PB02` and `PB03` pins

--- a/content/docs/reference/microcontrollers/metro-m4-airlift.md
+++ b/content/docs/reference/microcontrollers/metro-m4-airlift.md
@@ -55,4 +55,4 @@ Once you have updated your Metro M4 Express board the first time, after that you
 
 You can use the USB port to the Metro M4 Express as a serial port. `UART0` refers to this connection.
 
-The Neopixel LED on the Feather M0 can be accessed using the [WS2812](https://pkg.go.dev/tinygo.org/x/drivers/ws2812) driver via the `PB22` pin
+The Neopixel LED on the Metro M4 Express can be accessed using the [WS2812](https://pkg.go.dev/tinygo.org/x/drivers/ws2812) driver via the `PB22` pin

--- a/content/docs/reference/microcontrollers/metro-m4-airlift.md
+++ b/content/docs/reference/microcontrollers/metro-m4-airlift.md
@@ -54,3 +54,5 @@ Once you have updated your Metro M4 Express board the first time, after that you
 ## Notes
 
 You can use the USB port to the Metro M4 Express as a serial port. `UART0` refers to this connection.
+
+The Neopixel LED on the Feather M0 can be accessed using the [WS2812](https://pkg.go.dev/tinygo.org/x/drivers/ws2812) driver via the `PB22` pin

--- a/content/docs/reference/microcontrollers/trinket-m0.md
+++ b/content/docs/reference/microcontrollers/trinket-m0.md
@@ -54,3 +54,5 @@ Once you have updated your Trinket M0 board the first time, after that you shoul
 ## Notes
 
 You can use the USB port to the Trinket M0 as a serial port. `UART0` refers to this connection.
+
+The DotStar LED on the Trinket M0 can be accessed using the [APA102](https://pkg.go.dev/tinygo.org/x/drivers/apa102) driver via a software SPI on the `PA01` and `PA00` pins


### PR DESCRIPTION
Some of Adafruit's boards have LEDs they call DotStar or Neopixel. In TinyGo, the driver used for them uses the technical name rather than the one Adafruit uses, and it is not easily clear which driver should be used.

This PR adds notes to the microcontrollers page of each board with a Neopixel or DotStar LED.

tinygo-org/tinygo#2591