### PR TITLE
fix: update path instructions for ubuntu

### DIFF
--- a/content/getting-started/install/linux.md
+++ b/content/getting-started/install/linux.md
@@ -42,7 +42,7 @@ sudo dpkg -i tinygo_0.22.0_arm.deb
 You will need to ensure that the path to the `tinygo` executable file is in your `PATH` variable.
 
 ```shell
-export PATH=$PATH:/usr/local/tinygo/bin
+export PATH=$PATH:/usr/local/bin
 ```
 
 You can test that the installation is working properly by running this code which should display the version number:


### PR DESCRIPTION
fix incorrect `/usr/local/tinygo/bin` path, correct to actual `/usr/local/bin`

fixes #251 