### PR TITLE
Added references to articles and videos on Pragmatik.tech

### DIFF
--- a/content/media/articles.md
+++ b/content/media/articles.md
@@ -6,6 +6,8 @@ weight: 45
 description: >
   Articles and blog posts talking about TinyGo
 ---
+**Pragmatik.tech - Multiple articles on TinyGo and Raspberry Pi Pico** - *July 2022 onwards*
+https://pragmatik.tech/tags/tinygo/
 
 **Aurélie Vache - "Learning Go by examples: part 5 - Create a Game Boy Advance (GBA) game in Go"** - *August 11, 2021*
 https://dev.to/aurelievache/learning-go-by-examples-part-5-create-a-game-boy-advance-gba-game-in-go-5944

--- a/content/media/video.md
+++ b/content/media/video.md
@@ -7,6 +7,9 @@ description: >
   Videos/Podcasts talking about TinyGo
 ---
 
+**Pragmatik.tech - Charath Ranganathan - Multiple videos on TinyGo and Raspberry Pi Pico** - *July 2022 onwards*
+https://www.youtube.com/channel/UChxDHx-FThGJscOn3ljTi6A
+
 **CALM - Thierry Chantier - "TinyGo sur Pygamer" [FR]** - *June 15, 2021*
 https://www.youtube.com/watch?v=FI0_tC6ESJA&t=694s
 


### PR DESCRIPTION
I took the liberty of adding references to my [site](https://pragmatik.tech/tags/tinygo/) in both the articles and videos section. I intend to create at least a video a month on TinyGo, and would love to share them with the community.

Apologies if this violates your terms of submission.

If this PR violates your terms of submission, please let me know how I can submit a request for inclusion of my articles and videos to your site.