### PR TITLE
boards: add USBDevice support status

### DIFF
--- a/content/docs/reference/microcontrollers/arduino-mega1280.md
+++ b/content/docs/reference/microcontrollers/arduino-mega1280.md
@@ -13,10 +13,11 @@ Note: the AVR backend of LLVM is still experimental so you may encounter bugs.
 | --------- | ------------- | ----- |
 | GPIO      | YES | YES |
 | UART      | YES | YES |
-| SPI      | YES | YES |
-| I2C      | YES | YES |
-| ADC      | YES | YES |
-| PWM      | YES | YES |
+| SPI       | YES | YES |
+| I2C       | YES | YES |
+| ADC       | YES | YES |
+| PWM       | YES | YES |
+| USBDevice | NO  | NO  |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/arduino-mega2560.md
+++ b/content/docs/reference/microcontrollers/arduino-mega2560.md
@@ -13,10 +13,11 @@ Note: the AVR backend of LLVM is still experimental so you may encounter bugs.
 | --------- | ------------- | ----- |
 | GPIO      | YES | YES |
 | UART      | YES | YES |
-| SPI      | YES | YES |
-| I2C      | YES | YES |
-| ADC      | YES | YES |
-| PWM      | YES | Not yet |
+| SPI       | YES | YES |
+| I2C       | YES | YES |
+| ADC       | YES | YES |
+| PWM       | YES | Not yet |
+| USBDevice | NO  | NO  |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/arduino-mkr1000.md
+++ b/content/docs/reference/microcontrollers/arduino-mkr1000.md
@@ -11,10 +11,11 @@ The [Arduino MKR1000](https://store.arduino.cc/arduino-mkr1000-wifi) is a very s
 | --------- | ------------- | ----- |
 | GPIO      | YES | YES |
 | UART      | YES | YES |
-| SPI      | YES | YES |
-| I2C      | YES | YES |
-| ADC      | YES | YES |
-| PWM      | YES | YES |
+| SPI       | YES | YES |
+| I2C       | YES | YES |
+| ADC       | YES | YES |
+| PWM       | YES | YES |
+| USBDevice | YES | YES |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/arduino-mkrwifi1010.md
+++ b/content/docs/reference/microcontrollers/arduino-mkrwifi1010.md
@@ -11,10 +11,11 @@ The [Arduino MKR WiFi 1010](https://store.arduino.cc/usa/mkr-wifi-1010) is a ver
 | --------- | ------------- | ----- |
 | GPIO      | YES | YES |
 | UART      | YES | YES |
-| SPI      | YES | YES |
-| I2C      | YES | YES |
-| ADC      | YES | YES |
-| PWM      | YES | YES |
+| SPI       | YES | YES |
+| I2C       | YES | YES |
+| ADC       | YES | YES |
+| PWM       | YES | YES |
+| USBDevice | YES | YES |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/arduino-nano.md
+++ b/content/docs/reference/microcontrollers/arduino-nano.md
@@ -13,10 +13,11 @@ Note: the AVR backend of LLVM is still experimental so you may encounter bugs.
 | --------- | ------------- | ----- |
 | GPIO      | YES | YES |
 | UART      | YES | YES |
-| SPI      | YES | YES |
-| I2C      | YES | YES |
-| ADC      | YES | YES |
-| PWM      | YES | YES |
+| SPI       | YES | YES |
+| I2C       | YES | YES |
+| ADC       | YES | YES |
+| PWM       | YES | YES |
+| USBDevice | NO  | NO  |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/arduino-nano33.md
+++ b/content/docs/reference/microcontrollers/arduino-nano33.md
@@ -15,10 +15,11 @@ Peripherals:
 | --------- | ------------- | ----- |
 | GPIO      | YES | YES |
 | UART      | YES | YES |
-| SPI      | YES | YES |
-| I2C      | YES | YES |
-| ADC      | YES | YES |
-| PWM      | YES | YES |
+| SPI       | YES | YES |
+| I2C       | YES | YES |
+| ADC       | YES | YES |
+| PWM       | YES | YES |
+| USBDevice | YES | YES |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/arduino-zero.md
+++ b/content/docs/reference/microcontrollers/arduino-zero.md
@@ -11,10 +11,11 @@ The [Arduino Zero](https://store.arduino.cc/arduino-zero) is a very small ARM de
 | --------- | ------------- | ----- |
 | GPIO      | YES | YES |
 | UART      | YES | YES |
-| SPI      | YES | YES |
-| I2C      | YES | YES |
-| ADC      | YES | YES |
-| PWM      | YES | YES |
+| SPI       | YES | YES |
+| I2C       | YES | YES |
+| ADC       | YES | YES |
+| PWM       | YES | YES |
+| USBDevice | YES | YES |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/arduino.md
+++ b/content/docs/reference/microcontrollers/arduino.md
@@ -13,10 +13,11 @@ Note: the AVR backend of LLVM is still experimental so you may encounter bugs.
 | --------- | ------------- | ----- |
 | GPIO      | YES | YES |
 | UART      | YES | YES |
-| SPI      | YES | YES |
-| I2C      | YES | YES |
-| ADC      | YES | YES |
-| PWM      | YES | YES |
+| SPI       | YES | YES |
+| I2C       | YES | YES |
+| ADC       | YES | YES |
+| PWM       | YES | YES |
+| USBDevice | NO  | NO  |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/atsame54-xpro.md
+++ b/content/docs/reference/microcontrollers/atsame54-xpro.md
@@ -11,10 +11,11 @@ The [Microchip SAM E54 Xplained Pro](https://www.microchip.com/developmenttools/
 | --------- | ------------- | ----- |
 | GPIO      | YES | YES |
 | UART      | YES | YES |
-| SPI      | YES | YES |
-| I2C      | YES | YES |
-| ADC      | YES | YES |
-| PWM      | YES | YES |
+| SPI       | YES | YES |
+| I2C       | YES | YES |
+| ADC       | YES | YES |
+| PWM       | YES | YES |
+| USBDevice | YES | YES |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/bluepill.md
+++ b/content/docs/reference/microcontrollers/bluepill.md
@@ -11,10 +11,11 @@ The [Bluepill](http://wiki.stm32duino.com/index.php?title=Blue_Pill) is a popula
 | --------- | ------------- | ----- |
 | GPIO      | YES | YES |
 | UART      | YES | YES |
-| SPI      | YES | YES |
-| I2C      | YES | YES |
-| ADC      | YES | YES |
-| PWM      | YES | Not yet |
+| SPI       | YES | YES |
+| I2C       | YES | YES |
+| ADC       | YES | YES |
+| PWM       | YES | Not yet |
+| USBDevice | YES | Not yet |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/circuitplay-bluefruit.md
+++ b/content/docs/reference/microcontrollers/circuitplay-bluefruit.md
@@ -11,11 +11,12 @@ The [Adafruit Circuit Playground Bluefruit](https://www.adafruit.com/product/433
 | --------- | ------------- | ----- |
 | GPIO      | YES | YES |
 | UART      | YES | YES |
-| SPI      | YES | YES |
-| I2C      | YES | YES |
-| ADC      | YES | YES |
-| PWM      | YES | YES |
-| Bluetooth      | YES | YES |
+| SPI       | YES | YES |
+| I2C       | YES | YES |
+| ADC       | YES | YES |
+| PWM       | YES | YES |
+| USBDevice | YES | YES |
+| Bluetooth | YES | YES |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/circuitplay-express.md
+++ b/content/docs/reference/microcontrollers/circuitplay-express.md
@@ -11,10 +11,11 @@ The [Adafruit Circuit Playground Express](https://www.adafruit.com/product/3333)
 | --------- | ------------- | ----- |
 | GPIO      | YES | YES |
 | UART      | YES | YES |
-| SPI      | YES | YES |
-| I2C      | YES | YES |
-| ADC      | YES | YES |
-| PWM      | YES | YES |
+| SPI       | YES | YES |
+| I2C       | YES | YES |
+| ADC       | YES | YES |
+| PWM       | YES | YES |
+| USBDevice | YES | YES |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/clue.md
+++ b/content/docs/reference/microcontrollers/clue.md
@@ -11,11 +11,12 @@ The [Adafruit CLUE](https://www.adafruit.com/product/4500) is small ARM developm
 | --------- | ------------- | ----- |
 | GPIO      | YES | YES |
 | UART      | YES | YES |
-| SPI      | YES | YES |
-| I2C      | YES | YES |
-| ADC      | YES | YES |
-| PWM      | YES | YES |
-| Bluetooth      | YES | YES |
+| SPI       | YES | YES |
+| I2C       | YES | YES |
+| ADC       | YES | YES |
+| PWM       | YES | YES |
+| USBDevice | YES | YES |
+| Bluetooth | YES | YES |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/d1mini.md
+++ b/content/docs/reference/microcontrollers/d1mini.md
@@ -11,10 +11,11 @@ The [Espressif ESP8266](https://www.espressif.com/en/products/socs/esp8266) d1mi
 | --------- | ------------- | ----- |
 | GPIO      | YES | YES |
 | UART      | YES | YES |
-| SPI      | YES | Not yet |
-| I2C      | NO (software only) | Not yet |
-| ADC      | YES | Not yet |
-| PWM      | YES | Not yet |
+| SPI       | YES | Not yet |
+| I2C       | NO (software only) | Not yet |
+| ADC       | YES | Not yet |
+| PWM       | YES | Not yet |
+| USBDevice | NO  | NO  |
 | WiFi      | YES | Not Yet |
 
 ## Machine Package Docs

--- a/content/docs/reference/microcontrollers/digispark.md
+++ b/content/docs/reference/microcontrollers/digispark.md
@@ -15,10 +15,11 @@ Note: the AVR backend of LLVM is still experimental so you may encounter bugs.
 | --------- | ------------- | ----- |
 | GPIO      | YES | YES |
 | UART      | YES | Not yet |
-| SPI      | Requires software | Not yet |
-| I2C      | Requires software | Not yet |
-| ADC      | YES | YES |
-| PWM      | YES | Not yet |
+| SPI       | Requires software | Not yet |
+| I2C       | Requires software | Not yet |
+| ADC       | YES | YES |
+| PWM       | YES | Not yet |
+| USBDevice | NO  | NO  |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/esp32-coreboard-v2.md
+++ b/content/docs/reference/microcontrollers/esp32-coreboard-v2.md
@@ -11,12 +11,13 @@ The esp32-coreboard-v2 is a development board based on the [Espressif ESP32](htt
 | --------- | ------------- | ----- |
 | GPIO      | YES | YES |
 | UART      | YES | YES |
-| SPI      | YES | YES |
-| I2C      | YES | Not yet |
-| ADC      | YES | Not yet |
-| PWM      | YES | Not yet |
+| SPI       | YES | YES |
+| I2C       | YES | Not yet |
+| ADC       | YES | Not yet |
+| PWM       | YES | Not yet |
+| USBDevice | NO  | NO  |
 | WiFi      | YES | Not Yet |
-| Bluetooth      | YES | Not yet |
+| Bluetooth | YES | Not yet |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/esp32-mini32.md
+++ b/content/docs/reference/microcontrollers/esp32-mini32.md
@@ -11,12 +11,13 @@ The mini32 is a small development board based on the popular [Espressif ESP32](h
 | --------- | ------------- | ----- |
 | GPIO      | YES | YES |
 | UART      | YES | YES |
-| SPI      | YES | YES |
-| I2C      | YES | Not yet |
-| ADC      | YES | Not yet |
-| PWM      | YES | Not yet |
+| SPI       | YES | YES |
+| I2C       | YES | Not yet |
+| ADC       | YES | Not yet |
+| PWM       | YES | Not yet |
+| USBDevice | NO  | NO  |
 | WiFi      | YES | Not Yet |
-| Bluetooth      | YES | Not yet |
+| Bluetooth | YES | Not yet |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/feather-m0.md
+++ b/content/docs/reference/microcontrollers/feather-m0.md
@@ -11,10 +11,11 @@ The [Adafruit Feather M0](https://www.adafruit.com/product/3403) is a tiny ARM d
 | --------- | ------------- | ----- |
 | GPIO      | YES | YES |
 | UART      | YES | YES |
-| SPI      | YES | YES |
-| I2C      | YES | YES |
-| ADC      | YES | YES |
-| PWM      | YES | YES |
+| SPI       | YES | YES |
+| I2C       | YES | YES |
+| ADC       | YES | YES |
+| PWM       | YES | YES |
+| USBDevice | YES | YES |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/feather-m4-can.md
+++ b/content/docs/reference/microcontrollers/feather-m4-can.md
@@ -11,10 +11,11 @@ The [Adafruit Feather M4 CAN](https://www.adafruit.com/product/4759) is a tiny A
 | --------- | ------------- | ----- |
 | GPIO      | YES | YES |
 | UART      | YES | YES |
-| SPI      | YES | YES |
-| I2C      | YES | YES |
-| ADC      | YES | YES |
-| PWM      | YES | YES |
+| SPI       | YES | YES |
+| I2C       | YES | YES |
+| ADC       | YES | YES |
+| PWM       | YES | YES |
+| USBDevice | YES | YES |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/feather-m4.md
+++ b/content/docs/reference/microcontrollers/feather-m4.md
@@ -11,10 +11,11 @@ The [Adafruit Feather M4](https://www.adafruit.com/product/3857) is a tiny ARM d
 | --------- | ------------- | ----- |
 | GPIO      | YES | YES |
 | UART      | YES | YES |
-| SPI      | YES | YES |
-| I2C      | YES | YES |
-| ADC      | YES | YES |
-| PWM      | YES | YES |
+| SPI       | YES | YES |
+| I2C       | YES | YES |
+| ADC       | YES | YES |
+| PWM       | YES | YES |
+| USBDevice | YES | YES |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/feather-nrf52840-sense.md
+++ b/content/docs/reference/microcontrollers/feather-nrf52840-sense.md
@@ -11,11 +11,12 @@ The [Adafruit Feather nRF52840 Sense](https://www.adafruit.com/product/4516) is 
 | --------- | ------------- | ----- |
 | GPIO      | YES | YES |
 | UART      | YES | YES |
-| SPI      | YES | YES |
-| I2C      | YES | YES |
-| ADC      | YES | YES |
-| PWM      | YES | YES |
-| Bluetooth      | YES | YES |
+| SPI       | YES | YES |
+| I2C       | YES | YES |
+| ADC       | YES | YES |
+| PWM       | YES | YES |
+| USBDevice | YES | YES |
+| Bluetooth | YES | YES |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/feather-nrf52840.md
+++ b/content/docs/reference/microcontrollers/feather-nrf52840.md
@@ -11,11 +11,12 @@ The [Adafruit Feather nRF52840](https://www.adafruit.com/product/4500) is a smal
 | --------- | ------------- | ----- |
 | GPIO      | YES | YES |
 | UART      | YES | YES |
-| SPI      | YES | YES |
-| I2C      | YES | YES |
-| ADC      | YES | YES |
-| PWM      | YES | YES |
-| Bluetooth      | YES | YES |
+| SPI       | YES | YES |
+| I2C       | YES | YES |
+| ADC       | YES | YES |
+| PWM       | YES | YES |
+| USBDevice | YES | YES |
+| Bluetooth | YES | YES |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/feather-rp2040.md
+++ b/content/docs/reference/microcontrollers/feather-rp2040.md
@@ -11,10 +11,11 @@ The [Adafruit Feather RP2040](https://www.adafruit.com/product/4884) is a tiny d
 | --------- | ------------- | ----- |
 | GPIO      | YES | YES |
 | UART      | YES | YES |
-| SPI      | YES | YES |
-| I2C      | YES | YES |
-| ADC      | YES | YES |
-| PWM      | YES | YES |
+| SPI       | YES | YES |
+| I2C       | YES | YES |
+| ADC       | YES | YES |
+| PWM       | YES | YES |
+| USBDevice | YES | YES |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/feather-stm32f405.md
+++ b/content/docs/reference/microcontrollers/feather-stm32f405.md
@@ -11,10 +11,11 @@ The [Adafruit Feather STM32F405](https://www.adafruit.com/product/4382) is a tin
 | --------- | ------------- | ----- |
 | GPIO      | YES | YES |
 | UART      | YES | YES |
-| SPI      | YES | YES |
-| I2C      | YES | YES |
-| ADC      | YES | YES |
-| PWM      | YES | Not yet |
+| SPI       | YES | YES |
+| I2C       | YES | YES |
+| ADC       | YES | YES |
+| PWM       | YES | Not yet |
+| USBDevice | YES | Not yet |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/gameboy-advance.md
+++ b/content/docs/reference/microcontrollers/gameboy-advance.md
@@ -9,12 +9,13 @@ The [Game Boy Advance](https://en.wikipedia.org/wiki/Game_Boy_Advance) is a hand
 
 | Interface | Hardware Supported | TinyGo Support |
 | --------- | ------------- | ----- |
-| GPIO      | ? | ? |
-| UART      | ? | ? |
-| SPI      | ? | ? |
-| I2C      | ? | ? |
-| ADC      | ? | ? |
-| PWM      | ? | ? |
+| GPIO      | ?   | ?   |
+| UART      | ?   | ?   |
+| SPI       | ?   | ?   |
+| I2C       | ?   | ?   |
+| ADC       | ?   | ?   |
+| PWM       | ?   | ?   |
+| USBDevice | ?   | ?   |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/grandcentral-m4.md
+++ b/content/docs/reference/microcontrollers/grandcentral-m4.md
@@ -11,10 +11,11 @@ The [Adafruit Grand Central M4](https://www.adafruit.com/product/4064) is a tiny
 | --------- | ------------- | ----- |
 | GPIO      | YES | YES |
 | UART      | YES | YES |
-| SPI      | YES | YES |
-| I2C      | YES | YES |
-| ADC      | YES | YES |
-| PWM      | YES | YES |
+| SPI       | YES | YES |
+| I2C       | YES | YES |
+| ADC       | YES | YES |
+| PWM       | YES | YES |
+| USBDevice | YES | YES |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/hifive1b.md
+++ b/content/docs/reference/microcontrollers/hifive1b.md
@@ -11,10 +11,11 @@ The [HiFive1 Rev B](https://www.sifive.com/boards/hifive1-rev-b) is low-cost, Ar
 | --------- | ------------- | ----- |
 | GPIO      | YES | YES |
 | UART      | YES | YES |
-| SPI      | YES | YES |
-| I2C      | YES | YES |
-| ADC      | NO | NO |
-| PWM      | YES | Not yet |
+| SPI       | YES | YES |
+| I2C       | YES | YES |
+| ADC       | NO  | NO  |
+| PWM       | YES | Not yet |
+| USBDevice | ?   | ?   |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/itsybitsy-m0.md
+++ b/content/docs/reference/microcontrollers/itsybitsy-m0.md
@@ -11,10 +11,11 @@ The [Adafruit ItsyBitsy M0](https://www.adafruit.com/product/3727) is very compa
 | --------- | ------------- | ----- |
 | GPIO      | YES | YES |
 | UART      | YES | YES |
-| SPI      | YES | YES |
-| I2C      | YES | YES |
-| ADC      | YES | YES |
-| PWM      | YES | YES |
+| SPI       | YES | YES |
+| I2C       | YES | YES |
+| ADC       | YES | YES |
+| PWM       | YES | YES |
+| USBDevice | YES | YES |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/itsybitsy-m4.md
+++ b/content/docs/reference/microcontrollers/itsybitsy-m4.md
@@ -11,10 +11,11 @@ The [Adafruit ItsyBitsy M4](https://www.adafruit.com/product/3800) is very compa
 | --------- | ------------- | ----- |
 | GPIO      | YES | YES |
 | UART      | YES | YES |
-| SPI      | YES | YES |
-| I2C      | YES | YES |
-| ADC      | YES | YES |
-| PWM      | YES | YES |
+| SPI       | YES | YES |
+| I2C       | YES | YES |
+| ADC       | YES | YES |
+| PWM       | YES | YES |
+| USBDevice | YES | YES |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/itsybitsy-nrf52840.md
+++ b/content/docs/reference/microcontrollers/itsybitsy-nrf52840.md
@@ -11,11 +11,12 @@ The [Adafruit ItsyBitsy-nRF52840](https://www.adafruit.com/product/4333) is a sm
 | --------- | ------------- | ----- |
 | GPIO      | YES | YES |
 | UART      | YES | YES |
-| SPI      | YES | YES |
-| I2C      | YES | YES |
-| ADC      | YES | YES |
-| PWM      | YES | YES |
-| Bluetooth      | YES | YES |
+| SPI       | YES | YES |
+| I2C       | YES | YES |
+| ADC       | YES | YES |
+| PWM       | YES | YES |
+| USBDevice | YES | YES |
+| Bluetooth | YES | YES |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/lgt92.md
+++ b/content/docs/reference/microcontrollers/lgt92.md
@@ -11,10 +11,11 @@ The [Dragino LGT-92](https://www.dragino.com/products/lora-lorawan-end-node/item
 | --------- | ------------- | ----- |
 | GPIO      | YES | YES |
 | UART      | YES | YES |
-| SPI      | YES | YES |
-| I2C      | YES | YES |
-| ADC      | YES | Not yet |
-| PWM      | YES | Not yet |
+| SPI       | YES | YES |
+| I2C       | YES | YES |
+| ADC       | YES | Not yet |
+| PWM       | YES | Not yet |
+| USBDevice | YES | Not yet |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/lorae5.md
+++ b/content/docs/reference/microcontrollers/lorae5.md
@@ -13,10 +13,11 @@ It has onboard LoRa®, (G)FSK, (G)MSK, and BPSK as well as 1 user LED, 1 user bu
 | --------- | ------------- | ----- |
 | GPIO      | YES | YES |
 | UART      | YES | YES |
-| SPI      | YES | YES |
-| I2C      | YES | YES |
-| ADC      | YES | Not yet |
-| PWM      | YES | Not yet |
+| SPI       | YES | YES |
+| I2C       | YES | YES |
+| ADC       | YES | Not yet |
+| PWM       | YES | Not yet |
+| USBDevice | NO  | NO  |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/m5stack-core2.md
+++ b/content/docs/reference/microcontrollers/m5stack-core2.md
@@ -11,12 +11,13 @@ The [m5stack-core2](https://shop.m5stack.com/products/m5stack-core2-esp32-iot-de
 | --------- | ------------- | ----- |
 | GPIO      | YES | YES |
 | UART      | YES | YES |
-| SPI      | YES | YES |
-| I2C      | YES | Not yet |
-| ADC      | YES | Not yet |
-| PWM      | YES | Not yet |
+| SPI       | YES | YES |
+| I2C       | YES | Not yet |
+| ADC       | YES | Not yet |
+| PWM       | YES | Not yet |
+| USBDevice | NO  | NO  |
 | WiFi      | YES | Not Yet |
-| Bluetooth      | YES | Not yet |
+| Bluetooth | YES | Not yet |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/m5stack.md
+++ b/content/docs/reference/microcontrollers/m5stack.md
@@ -11,12 +11,13 @@ The [m5stack](https://docs.m5stack.com/en/core/basic) is a development board bas
 | --------- | ------------- | ----- |
 | GPIO      | YES | YES |
 | UART      | YES | YES |
-| SPI      | YES | YES |
-| I2C      | YES | Not yet |
-| ADC      | YES | Not yet |
-| PWM      | YES | Not yet |
+| SPI       | YES | YES |
+| I2C       | YES | Not yet |
+| ADC       | YES | Not yet |
+| PWM       | YES | Not yet |
+| USBDevice | NO  | NO  |
 | WiFi      | YES | Not Yet |
-| Bluetooth      | YES | Not yet |
+| Bluetooth | YES | Not yet |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/m5stamp-c3.md
+++ b/content/docs/reference/microcontrollers/m5stamp-c3.md
@@ -11,12 +11,13 @@ The [M5Stamp-C3](https://docs.m5stack.com/en/core/stamp_c3) is a development boa
 | --------- | ------------- | ----- |
 | GPIO      | YES | YES |
 | UART      | YES | YES |
-| SPI      | YES | Not yet |
-| I2C      | YES | Not yet |
-| ADC      | YES | Not yet |
-| PWM      | YES | Not yet |
+| SPI       | YES | Not yet |
+| I2C       | YES | Not yet |
+| ADC       | YES | Not yet |
+| PWM       | YES | Not yet |
+| USBDevice | YES | Not yet |
 | WiFi      | YES | Not Yet |
-| Bluetooth      | YES | Not yet |
+| Bluetooth | YES | Not yet |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/machine/arduino-mega1280.md
+++ b/content/docs/reference/microcontrollers/machine/arduino-mega1280.md
@@ -377,6 +377,14 @@ func InitADC()
 InitADC initializes the registers needed for ADC.
 
 
+### func InitSerial
+
+```go
+func InitSerial()
+```
+
+
+
 ### func NewRingBuffer
 
 ```go

--- a/content/docs/reference/microcontrollers/machine/arduino-mega2560.md
+++ b/content/docs/reference/microcontrollers/machine/arduino-mega2560.md
@@ -422,6 +422,14 @@ func InitADC()
 InitADC initializes the registers needed for ADC.
 
 
+### func InitSerial
+
+```go
+func InitSerial()
+```
+
+
+
 ### func NewRingBuffer
 
 ```go

--- a/content/docs/reference/microcontrollers/machine/arduino-mkr1000.md
+++ b/content/docs/reference/microcontrollers/machine/arduino-mkr1000.md
@@ -352,15 +352,6 @@ The SAM D21 has three TCC peripherals, which have PWM as one feature.
 
 ```go
 var (
-	USB		= &USBCDC{Buffer: NewRingBuffer()}
-	waitHidTxc	bool
-)
-```
-
-
-
-```go
-var (
 	DAC0 = DAC{}
 )
 ```
@@ -376,10 +367,28 @@ var (
 
 
 ```go
-var Serial = USB
+var Serial Serialer
 ```
 
 Serial is implemented via USB (USB-CDC).
+
+
+```go
+var (
+	USBDev	= &USBDevice{}
+	USBCDC	Serialer
+)
+```
+
+
+
+```go
+var (
+	ErrUSBReadTimeout	= errors.New("USB read timeout")
+	ErrUSBBytesRead		= errors.New("USB invalid number of bytes read")
+)
+```
+
 
 
 
@@ -394,13 +403,40 @@ func CPUFrequency() uint32
 Return the current CPU frequency in hertz.
 
 
+### func EnableCDC
+
+```go
+func EnableCDC(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
+```
+
+
+
 ### func EnableHID
 
 ```go
-func EnableHID(callback func())
+func EnableHID(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
 ```
 
 EnableHID enables HID. This function must be executed from the init().
+
+
+### func EnableMIDI
+
+```go
+func EnableMIDI(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
+```
+
+EnableMIDI enables MIDI. This function must be executed from the init().
+
+
+### func EnterBootloader
+
+```go
+func EnterBootloader()
+```
+
+EnterBootloader should perform a system reset in preperation
+to switch to the bootloader to flash new firmware.
 
 
 ### func InitADC
@@ -412,6 +448,14 @@ func InitADC()
 InitADC initializes the ADC.
 
 
+### func InitSerial
+
+```go
+func InitSerial()
+```
+
+
+
 ### func NewRingBuffer
 
 ```go
@@ -421,23 +465,29 @@ func NewRingBuffer() *RingBuffer
 NewRingBuffer returns a new ring buffer.
 
 
-### func ResetProcessor
+### func ReceiveUSBControlPacket
 
 ```go
-func ResetProcessor()
+func ReceiveUSBControlPacket() ([cdcLineInfoSize]byte, error)
 ```
 
-ResetProcessor should perform a system reset in preperation
-to switch to the bootloader to flash new firmware.
 
 
-### func SendUSBHIDPacket
+### func SendUSBInPacket
 
 ```go
-func SendUSBHIDPacket(ep uint32, data []byte) bool
+func SendUSBInPacket(ep uint32, data []byte) bool
 ```
 
-SendUSBHIDPacket sends a packet for USBHID (interrupt / in).
+SendUSBInPacket sends a packet for USB (interrupt in / bulk in).
+
+
+### func SendZlp
+
+```go
+func SendZlp()
+```
+
 
 
 
@@ -1107,6 +1157,25 @@ SPIConfig is used to store config info for SPI.
 
 
 
+## type Serialer
+
+```go
+type Serialer interface {
+	WriteByte(c byte) error
+	Write(data []byte) (n int, err error)
+	Configure(config UARTConfig) error
+	Buffered() int
+	ReadByte() (byte, error)
+	DTR() bool
+	RTS() bool
+}
+```
+
+
+
+
+
+
 ## type TCC
 
 ```go
@@ -1341,143 +1410,24 @@ UARTParity is the parity setting to be used for UART communication.
 
 
 
-## type USBCDC
+## type USBDevice
 
 ```go
-type USBCDC struct {
-	Buffer			*RingBuffer
-	TxIdx			volatile.Register8
-	waitTxc			bool
-	waitTxcRetryCount	uint8
-	sent			bool
-	configured		bool
-}
-```
-
-USBCDC is the USB CDC aka serial over USB interface on the SAMD21.
-
-
-
-### func (*USBCDC) Buffered
-
-```go
-func (usbcdc *USBCDC) Buffered() int
-```
-
-Buffered returns the number of bytes currently stored in the RX buffer.
-
-
-### func (*USBCDC) Configure
-
-```go
-func (usbcdc *USBCDC) Configure(config UARTConfig)
-```
-
-Configure the USB CDC interface. The config is here for compatibility with the UART interface.
-
-
-### func (*USBCDC) Configured
-
-```go
-func (usbcdc *USBCDC) Configured() bool
-```
-
-Configured returns whether usbcdc is configured or not.
-
-
-### func (*USBCDC) DTR
-
-```go
-func (usbcdc *USBCDC) DTR() bool
-```
-
-
-
-### func (*USBCDC) Flush
-
-```go
-func (usbcdc *USBCDC) Flush() error
-```
-
-Flush flushes buffered data.
-
-
-### func (*USBCDC) RTS
-
-```go
-func (usbcdc *USBCDC) RTS() bool
-```
-
-
-
-### func (*USBCDC) Read
-
-```go
-func (usbcdc *USBCDC) Read(data []byte) (n int, err error)
-```
-
-Read from the RX buffer.
-
-
-### func (*USBCDC) ReadByte
-
-```go
-func (usbcdc *USBCDC) ReadByte() (byte, error)
-```
-
-ReadByte reads a single byte from the RX buffer.
-If there is no data in the buffer, returns an error.
-
-
-### func (*USBCDC) Receive
-
-```go
-func (usbcdc *USBCDC) Receive(data byte)
-```
-
-Receive handles adding data to the UART's data buffer.
-Usually called by the IRQ handler for a machine.
-
-
-### func (*USBCDC) Write
-
-```go
-func (usbcdc *USBCDC) Write(data []byte) (n int, err error)
-```
-
-Write data to the USBCDC.
-
-
-### func (*USBCDC) WriteByte
-
-```go
-func (usbcdc *USBCDC) WriteByte(c byte) error
-```
-
-WriteByte writes a byte of data to the USB CDC interface.
-
-
-
-
-## type USBDescriptor
-
-```go
-type USBDescriptor struct {
-	Device		[]byte
-	Configuration	[]byte
-	HID		map[uint16][]byte
+type USBDevice struct {
+	initcomplete bool
 }
 ```
 
 
 
 
-### func (*USBDescriptor) Configure
+### func (*USBDevice) Configure
 
 ```go
-func (d *USBDescriptor) Configure(idVendor, idProduct uint16)
+func (dev *USBDevice) Configure(config UARTConfig)
 ```
 
+Configure the USB peripheral. The config is here for compatibility with the UART interface.
 
 
 

--- a/content/docs/reference/microcontrollers/machine/arduino-mkrwifi1010.md
+++ b/content/docs/reference/microcontrollers/machine/arduino-mkrwifi1010.md
@@ -405,15 +405,6 @@ The SAM D21 has three TCC peripherals, which have PWM as one feature.
 
 ```go
 var (
-	USB		= &USBCDC{Buffer: NewRingBuffer()}
-	waitHidTxc	bool
-)
-```
-
-
-
-```go
-var (
 	DAC0 = DAC{}
 )
 ```
@@ -429,10 +420,28 @@ var (
 
 
 ```go
-var Serial = USB
+var Serial Serialer
 ```
 
 Serial is implemented via USB (USB-CDC).
+
+
+```go
+var (
+	USBDev	= &USBDevice{}
+	USBCDC	Serialer
+)
+```
+
+
+
+```go
+var (
+	ErrUSBReadTimeout	= errors.New("USB read timeout")
+	ErrUSBBytesRead		= errors.New("USB invalid number of bytes read")
+)
+```
+
 
 
 
@@ -447,13 +456,40 @@ func CPUFrequency() uint32
 Return the current CPU frequency in hertz.
 
 
+### func EnableCDC
+
+```go
+func EnableCDC(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
+```
+
+
+
 ### func EnableHID
 
 ```go
-func EnableHID(callback func())
+func EnableHID(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
 ```
 
 EnableHID enables HID. This function must be executed from the init().
+
+
+### func EnableMIDI
+
+```go
+func EnableMIDI(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
+```
+
+EnableMIDI enables MIDI. This function must be executed from the init().
+
+
+### func EnterBootloader
+
+```go
+func EnterBootloader()
+```
+
+EnterBootloader should perform a system reset in preperation
+to switch to the bootloader to flash new firmware.
 
 
 ### func InitADC
@@ -465,6 +501,14 @@ func InitADC()
 InitADC initializes the ADC.
 
 
+### func InitSerial
+
+```go
+func InitSerial()
+```
+
+
+
 ### func NewRingBuffer
 
 ```go
@@ -474,23 +518,29 @@ func NewRingBuffer() *RingBuffer
 NewRingBuffer returns a new ring buffer.
 
 
-### func ResetProcessor
+### func ReceiveUSBControlPacket
 
 ```go
-func ResetProcessor()
+func ReceiveUSBControlPacket() ([cdcLineInfoSize]byte, error)
 ```
 
-ResetProcessor should perform a system reset in preperation
-to switch to the bootloader to flash new firmware.
 
 
-### func SendUSBHIDPacket
+### func SendUSBInPacket
 
 ```go
-func SendUSBHIDPacket(ep uint32, data []byte) bool
+func SendUSBInPacket(ep uint32, data []byte) bool
 ```
 
-SendUSBHIDPacket sends a packet for USBHID (interrupt / in).
+SendUSBInPacket sends a packet for USB (interrupt in / bulk in).
+
+
+### func SendZlp
+
+```go
+func SendZlp()
+```
+
 
 
 
@@ -1160,6 +1210,25 @@ SPIConfig is used to store config info for SPI.
 
 
 
+## type Serialer
+
+```go
+type Serialer interface {
+	WriteByte(c byte) error
+	Write(data []byte) (n int, err error)
+	Configure(config UARTConfig) error
+	Buffered() int
+	ReadByte() (byte, error)
+	DTR() bool
+	RTS() bool
+}
+```
+
+
+
+
+
+
 ## type TCC
 
 ```go
@@ -1394,143 +1463,24 @@ UARTParity is the parity setting to be used for UART communication.
 
 
 
-## type USBCDC
+## type USBDevice
 
 ```go
-type USBCDC struct {
-	Buffer			*RingBuffer
-	TxIdx			volatile.Register8
-	waitTxc			bool
-	waitTxcRetryCount	uint8
-	sent			bool
-	configured		bool
-}
-```
-
-USBCDC is the USB CDC aka serial over USB interface on the SAMD21.
-
-
-
-### func (*USBCDC) Buffered
-
-```go
-func (usbcdc *USBCDC) Buffered() int
-```
-
-Buffered returns the number of bytes currently stored in the RX buffer.
-
-
-### func (*USBCDC) Configure
-
-```go
-func (usbcdc *USBCDC) Configure(config UARTConfig)
-```
-
-Configure the USB CDC interface. The config is here for compatibility with the UART interface.
-
-
-### func (*USBCDC) Configured
-
-```go
-func (usbcdc *USBCDC) Configured() bool
-```
-
-Configured returns whether usbcdc is configured or not.
-
-
-### func (*USBCDC) DTR
-
-```go
-func (usbcdc *USBCDC) DTR() bool
-```
-
-
-
-### func (*USBCDC) Flush
-
-```go
-func (usbcdc *USBCDC) Flush() error
-```
-
-Flush flushes buffered data.
-
-
-### func (*USBCDC) RTS
-
-```go
-func (usbcdc *USBCDC) RTS() bool
-```
-
-
-
-### func (*USBCDC) Read
-
-```go
-func (usbcdc *USBCDC) Read(data []byte) (n int, err error)
-```
-
-Read from the RX buffer.
-
-
-### func (*USBCDC) ReadByte
-
-```go
-func (usbcdc *USBCDC) ReadByte() (byte, error)
-```
-
-ReadByte reads a single byte from the RX buffer.
-If there is no data in the buffer, returns an error.
-
-
-### func (*USBCDC) Receive
-
-```go
-func (usbcdc *USBCDC) Receive(data byte)
-```
-
-Receive handles adding data to the UART's data buffer.
-Usually called by the IRQ handler for a machine.
-
-
-### func (*USBCDC) Write
-
-```go
-func (usbcdc *USBCDC) Write(data []byte) (n int, err error)
-```
-
-Write data to the USBCDC.
-
-
-### func (*USBCDC) WriteByte
-
-```go
-func (usbcdc *USBCDC) WriteByte(c byte) error
-```
-
-WriteByte writes a byte of data to the USB CDC interface.
-
-
-
-
-## type USBDescriptor
-
-```go
-type USBDescriptor struct {
-	Device		[]byte
-	Configuration	[]byte
-	HID		map[uint16][]byte
+type USBDevice struct {
+	initcomplete bool
 }
 ```
 
 
 
 
-### func (*USBDescriptor) Configure
+### func (*USBDevice) Configure
 
 ```go
-func (d *USBDescriptor) Configure(idVendor, idProduct uint16)
+func (dev *USBDevice) Configure(config UARTConfig)
 ```
 
+Configure the USB peripheral. The config is here for compatibility with the UART interface.
 
 
 

--- a/content/docs/reference/microcontrollers/machine/arduino-nano.md
+++ b/content/docs/reference/microcontrollers/machine/arduino-nano.md
@@ -280,6 +280,14 @@ func InitADC()
 InitADC initializes the registers needed for ADC.
 
 
+### func InitSerial
+
+```go
+func InitSerial()
+```
+
+
+
 ### func NewRingBuffer
 
 ```go

--- a/content/docs/reference/microcontrollers/machine/arduino-nano33.md
+++ b/content/docs/reference/microcontrollers/machine/arduino-nano33.md
@@ -408,15 +408,6 @@ The SAM D21 has three TCC peripherals, which have PWM as one feature.
 
 ```go
 var (
-	USB		= &USBCDC{Buffer: NewRingBuffer()}
-	waitHidTxc	bool
-)
-```
-
-
-
-```go
-var (
 	DAC0 = DAC{}
 )
 ```
@@ -432,10 +423,28 @@ var (
 
 
 ```go
-var Serial = USB
+var Serial Serialer
 ```
 
 Serial is implemented via USB (USB-CDC).
+
+
+```go
+var (
+	USBDev	= &USBDevice{}
+	USBCDC	Serialer
+)
+```
+
+
+
+```go
+var (
+	ErrUSBReadTimeout	= errors.New("USB read timeout")
+	ErrUSBBytesRead		= errors.New("USB invalid number of bytes read")
+)
+```
+
 
 
 
@@ -450,13 +459,40 @@ func CPUFrequency() uint32
 Return the current CPU frequency in hertz.
 
 
+### func EnableCDC
+
+```go
+func EnableCDC(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
+```
+
+
+
 ### func EnableHID
 
 ```go
-func EnableHID(callback func())
+func EnableHID(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
 ```
 
 EnableHID enables HID. This function must be executed from the init().
+
+
+### func EnableMIDI
+
+```go
+func EnableMIDI(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
+```
+
+EnableMIDI enables MIDI. This function must be executed from the init().
+
+
+### func EnterBootloader
+
+```go
+func EnterBootloader()
+```
+
+EnterBootloader should perform a system reset in preperation
+to switch to the bootloader to flash new firmware.
 
 
 ### func InitADC
@@ -468,6 +504,14 @@ func InitADC()
 InitADC initializes the ADC.
 
 
+### func InitSerial
+
+```go
+func InitSerial()
+```
+
+
+
 ### func NewRingBuffer
 
 ```go
@@ -477,23 +521,29 @@ func NewRingBuffer() *RingBuffer
 NewRingBuffer returns a new ring buffer.
 
 
-### func ResetProcessor
+### func ReceiveUSBControlPacket
 
 ```go
-func ResetProcessor()
+func ReceiveUSBControlPacket() ([cdcLineInfoSize]byte, error)
 ```
 
-ResetProcessor should perform a system reset in preperation
-to switch to the bootloader to flash new firmware.
 
 
-### func SendUSBHIDPacket
+### func SendUSBInPacket
 
 ```go
-func SendUSBHIDPacket(ep uint32, data []byte) bool
+func SendUSBInPacket(ep uint32, data []byte) bool
 ```
 
-SendUSBHIDPacket sends a packet for USBHID (interrupt / in).
+SendUSBInPacket sends a packet for USB (interrupt in / bulk in).
+
+
+### func SendZlp
+
+```go
+func SendZlp()
+```
+
 
 
 
@@ -1163,6 +1213,25 @@ SPIConfig is used to store config info for SPI.
 
 
 
+## type Serialer
+
+```go
+type Serialer interface {
+	WriteByte(c byte) error
+	Write(data []byte) (n int, err error)
+	Configure(config UARTConfig) error
+	Buffered() int
+	ReadByte() (byte, error)
+	DTR() bool
+	RTS() bool
+}
+```
+
+
+
+
+
+
 ## type TCC
 
 ```go
@@ -1397,143 +1466,24 @@ UARTParity is the parity setting to be used for UART communication.
 
 
 
-## type USBCDC
+## type USBDevice
 
 ```go
-type USBCDC struct {
-	Buffer			*RingBuffer
-	TxIdx			volatile.Register8
-	waitTxc			bool
-	waitTxcRetryCount	uint8
-	sent			bool
-	configured		bool
-}
-```
-
-USBCDC is the USB CDC aka serial over USB interface on the SAMD21.
-
-
-
-### func (*USBCDC) Buffered
-
-```go
-func (usbcdc *USBCDC) Buffered() int
-```
-
-Buffered returns the number of bytes currently stored in the RX buffer.
-
-
-### func (*USBCDC) Configure
-
-```go
-func (usbcdc *USBCDC) Configure(config UARTConfig)
-```
-
-Configure the USB CDC interface. The config is here for compatibility with the UART interface.
-
-
-### func (*USBCDC) Configured
-
-```go
-func (usbcdc *USBCDC) Configured() bool
-```
-
-Configured returns whether usbcdc is configured or not.
-
-
-### func (*USBCDC) DTR
-
-```go
-func (usbcdc *USBCDC) DTR() bool
-```
-
-
-
-### func (*USBCDC) Flush
-
-```go
-func (usbcdc *USBCDC) Flush() error
-```
-
-Flush flushes buffered data.
-
-
-### func (*USBCDC) RTS
-
-```go
-func (usbcdc *USBCDC) RTS() bool
-```
-
-
-
-### func (*USBCDC) Read
-
-```go
-func (usbcdc *USBCDC) Read(data []byte) (n int, err error)
-```
-
-Read from the RX buffer.
-
-
-### func (*USBCDC) ReadByte
-
-```go
-func (usbcdc *USBCDC) ReadByte() (byte, error)
-```
-
-ReadByte reads a single byte from the RX buffer.
-If there is no data in the buffer, returns an error.
-
-
-### func (*USBCDC) Receive
-
-```go
-func (usbcdc *USBCDC) Receive(data byte)
-```
-
-Receive handles adding data to the UART's data buffer.
-Usually called by the IRQ handler for a machine.
-
-
-### func (*USBCDC) Write
-
-```go
-func (usbcdc *USBCDC) Write(data []byte) (n int, err error)
-```
-
-Write data to the USBCDC.
-
-
-### func (*USBCDC) WriteByte
-
-```go
-func (usbcdc *USBCDC) WriteByte(c byte) error
-```
-
-WriteByte writes a byte of data to the USB CDC interface.
-
-
-
-
-## type USBDescriptor
-
-```go
-type USBDescriptor struct {
-	Device		[]byte
-	Configuration	[]byte
-	HID		map[uint16][]byte
+type USBDevice struct {
+	initcomplete bool
 }
 ```
 
 
 
 
-### func (*USBDescriptor) Configure
+### func (*USBDevice) Configure
 
 ```go
-func (d *USBDescriptor) Configure(idVendor, idProduct uint16)
+func (dev *USBDevice) Configure(config UARTConfig)
 ```
 
+Configure the USB peripheral. The config is here for compatibility with the UART interface.
 
 
 

--- a/content/docs/reference/microcontrollers/machine/arduino-zero.md
+++ b/content/docs/reference/microcontrollers/machine/arduino-zero.md
@@ -380,15 +380,6 @@ The SAM D21 has three TCC peripherals, which have PWM as one feature.
 
 ```go
 var (
-	USB		= &USBCDC{Buffer: NewRingBuffer()}
-	waitHidTxc	bool
-)
-```
-
-
-
-```go
-var (
 	DAC0 = DAC{}
 )
 ```
@@ -404,10 +395,28 @@ var (
 
 
 ```go
-var Serial = USB
+var Serial Serialer
 ```
 
 Serial is implemented via USB (USB-CDC).
+
+
+```go
+var (
+	USBDev	= &USBDevice{}
+	USBCDC	Serialer
+)
+```
+
+
+
+```go
+var (
+	ErrUSBReadTimeout	= errors.New("USB read timeout")
+	ErrUSBBytesRead		= errors.New("USB invalid number of bytes read")
+)
+```
+
 
 
 
@@ -422,13 +431,40 @@ func CPUFrequency() uint32
 Return the current CPU frequency in hertz.
 
 
+### func EnableCDC
+
+```go
+func EnableCDC(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
+```
+
+
+
 ### func EnableHID
 
 ```go
-func EnableHID(callback func())
+func EnableHID(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
 ```
 
 EnableHID enables HID. This function must be executed from the init().
+
+
+### func EnableMIDI
+
+```go
+func EnableMIDI(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
+```
+
+EnableMIDI enables MIDI. This function must be executed from the init().
+
+
+### func EnterBootloader
+
+```go
+func EnterBootloader()
+```
+
+EnterBootloader should perform a system reset in preperation
+to switch to the bootloader to flash new firmware.
 
 
 ### func InitADC
@@ -440,6 +476,14 @@ func InitADC()
 InitADC initializes the ADC.
 
 
+### func InitSerial
+
+```go
+func InitSerial()
+```
+
+
+
 ### func NewRingBuffer
 
 ```go
@@ -449,23 +493,29 @@ func NewRingBuffer() *RingBuffer
 NewRingBuffer returns a new ring buffer.
 
 
-### func ResetProcessor
+### func ReceiveUSBControlPacket
 
 ```go
-func ResetProcessor()
+func ReceiveUSBControlPacket() ([cdcLineInfoSize]byte, error)
 ```
 
-ResetProcessor should perform a system reset in preperation
-to switch to the bootloader to flash new firmware.
 
 
-### func SendUSBHIDPacket
+### func SendUSBInPacket
 
 ```go
-func SendUSBHIDPacket(ep uint32, data []byte) bool
+func SendUSBInPacket(ep uint32, data []byte) bool
 ```
 
-SendUSBHIDPacket sends a packet for USBHID (interrupt / in).
+SendUSBInPacket sends a packet for USB (interrupt in / bulk in).
+
+
+### func SendZlp
+
+```go
+func SendZlp()
+```
+
 
 
 
@@ -1135,6 +1185,25 @@ SPIConfig is used to store config info for SPI.
 
 
 
+## type Serialer
+
+```go
+type Serialer interface {
+	WriteByte(c byte) error
+	Write(data []byte) (n int, err error)
+	Configure(config UARTConfig) error
+	Buffered() int
+	ReadByte() (byte, error)
+	DTR() bool
+	RTS() bool
+}
+```
+
+
+
+
+
+
 ## type TCC
 
 ```go
@@ -1369,143 +1438,24 @@ UARTParity is the parity setting to be used for UART communication.
 
 
 
-## type USBCDC
+## type USBDevice
 
 ```go
-type USBCDC struct {
-	Buffer			*RingBuffer
-	TxIdx			volatile.Register8
-	waitTxc			bool
-	waitTxcRetryCount	uint8
-	sent			bool
-	configured		bool
-}
-```
-
-USBCDC is the USB CDC aka serial over USB interface on the SAMD21.
-
-
-
-### func (*USBCDC) Buffered
-
-```go
-func (usbcdc *USBCDC) Buffered() int
-```
-
-Buffered returns the number of bytes currently stored in the RX buffer.
-
-
-### func (*USBCDC) Configure
-
-```go
-func (usbcdc *USBCDC) Configure(config UARTConfig)
-```
-
-Configure the USB CDC interface. The config is here for compatibility with the UART interface.
-
-
-### func (*USBCDC) Configured
-
-```go
-func (usbcdc *USBCDC) Configured() bool
-```
-
-Configured returns whether usbcdc is configured or not.
-
-
-### func (*USBCDC) DTR
-
-```go
-func (usbcdc *USBCDC) DTR() bool
-```
-
-
-
-### func (*USBCDC) Flush
-
-```go
-func (usbcdc *USBCDC) Flush() error
-```
-
-Flush flushes buffered data.
-
-
-### func (*USBCDC) RTS
-
-```go
-func (usbcdc *USBCDC) RTS() bool
-```
-
-
-
-### func (*USBCDC) Read
-
-```go
-func (usbcdc *USBCDC) Read(data []byte) (n int, err error)
-```
-
-Read from the RX buffer.
-
-
-### func (*USBCDC) ReadByte
-
-```go
-func (usbcdc *USBCDC) ReadByte() (byte, error)
-```
-
-ReadByte reads a single byte from the RX buffer.
-If there is no data in the buffer, returns an error.
-
-
-### func (*USBCDC) Receive
-
-```go
-func (usbcdc *USBCDC) Receive(data byte)
-```
-
-Receive handles adding data to the UART's data buffer.
-Usually called by the IRQ handler for a machine.
-
-
-### func (*USBCDC) Write
-
-```go
-func (usbcdc *USBCDC) Write(data []byte) (n int, err error)
-```
-
-Write data to the USBCDC.
-
-
-### func (*USBCDC) WriteByte
-
-```go
-func (usbcdc *USBCDC) WriteByte(c byte) error
-```
-
-WriteByte writes a byte of data to the USB CDC interface.
-
-
-
-
-## type USBDescriptor
-
-```go
-type USBDescriptor struct {
-	Device		[]byte
-	Configuration	[]byte
-	HID		map[uint16][]byte
+type USBDevice struct {
+	initcomplete bool
 }
 ```
 
 
 
 
-### func (*USBDescriptor) Configure
+### func (*USBDevice) Configure
 
 ```go
-func (d *USBDescriptor) Configure(idVendor, idProduct uint16)
+func (dev *USBDevice) Configure(config UARTConfig)
 ```
 
+Configure the USB peripheral. The config is here for compatibility with the UART interface.
 
 
 

--- a/content/docs/reference/microcontrollers/machine/arduino.md
+++ b/content/docs/reference/microcontrollers/machine/arduino.md
@@ -280,6 +280,14 @@ func InitADC()
 InitADC initializes the registers needed for ADC.
 
 
+### func InitSerial
+
+```go
+func InitSerial()
+```
+
+
+
 ### func NewRingBuffer
 
 ```go

--- a/content/docs/reference/microcontrollers/machine/atsame54-xpro.md
+++ b/content/docs/reference/microcontrollers/machine/atsame54-xpro.md
@@ -687,16 +687,6 @@ var (
 
 ```go
 var (
-	// USB is a USB CDC interface.
-	USB		= &USBCDC{Buffer: NewRingBuffer()}
-	waitHidTxc	bool
-)
-```
-
-
-
-```go
-var (
 	DAC0 = DAC{}
 )
 ```
@@ -743,10 +733,28 @@ var (
 
 
 ```go
-var Serial = USB
+var Serial Serialer
 ```
 
 Serial is implemented via USB (USB-CDC).
+
+
+```go
+var (
+	USBDev	= &USBDevice{}
+	USBCDC	Serialer
+)
+```
+
+
+
+```go
+var (
+	ErrUSBReadTimeout	= errors.New("USB read timeout")
+	ErrUSBBytesRead		= errors.New("USB invalid number of bytes read")
+)
+```
+
 
 
 
@@ -778,13 +786,40 @@ func CPUFrequency() uint32
 
 
 
+### func EnableCDC
+
+```go
+func EnableCDC(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
+```
+
+
+
 ### func EnableHID
 
 ```go
-func EnableHID(callback func())
+func EnableHID(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
 ```
 
 EnableHID enables HID. This function must be executed from the init().
+
+
+### func EnableMIDI
+
+```go
+func EnableMIDI(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
+```
+
+EnableMIDI enables MIDI. This function must be executed from the init().
+
+
+### func EnterBootloader
+
+```go
+func EnterBootloader()
+```
+
+EnterBootloader should perform a system reset in preparation
+to switch to the bootloader to flash new firmware.
 
 
 ### func GetRNG
@@ -805,6 +840,14 @@ func InitADC()
 InitADC initializes the ADC.
 
 
+### func InitSerial
+
+```go
+func InitSerial()
+```
+
+
+
 ### func NewRingBuffer
 
 ```go
@@ -814,23 +857,29 @@ func NewRingBuffer() *RingBuffer
 NewRingBuffer returns a new ring buffer.
 
 
-### func ResetProcessor
+### func ReceiveUSBControlPacket
 
 ```go
-func ResetProcessor()
+func ReceiveUSBControlPacket() ([cdcLineInfoSize]byte, error)
 ```
 
-ResetProcessor should perform a system reset in preparation
-to switch to the bootloader to flash new firmware.
 
 
-### func SendUSBHIDPacket
+### func SendUSBInPacket
 
 ```go
-func SendUSBHIDPacket(ep uint32, data []byte) bool
+func SendUSBInPacket(ep uint32, data []byte) bool
 ```
 
-SendUSBHIDPacket sends a packet for USBHID (interrupt / in).
+SendUSBInPacket sends a packet for USB (interrupt in / bulk in).
+
+
+### func SendZlp
+
+```go
+func SendZlp()
+```
+
 
 
 
@@ -1656,6 +1705,25 @@ SPIConfig is used to store config info for SPI.
 
 
 
+## type Serialer
+
+```go
+type Serialer interface {
+	WriteByte(c byte) error
+	Write(data []byte) (n int, err error)
+	Configure(config UARTConfig) error
+	Buffered() int
+	ReadByte() (byte, error)
+	DTR() bool
+	RTS() bool
+}
+```
+
+
+
+
+
+
 ## type TCC
 
 ```go
@@ -1889,143 +1957,24 @@ UARTParity is the parity setting to be used for UART communication.
 
 
 
-## type USBCDC
+## type USBDevice
 
 ```go
-type USBCDC struct {
-	Buffer			*RingBuffer
-	TxIdx			volatile.Register8
-	waitTxc			bool
-	waitTxcRetryCount	uint8
-	sent			bool
-	configured		bool
-}
-```
-
-USBCDC is the USB CDC aka serial over USB interface on the SAMD21.
-
-
-
-### func (*USBCDC) Buffered
-
-```go
-func (usbcdc *USBCDC) Buffered() int
-```
-
-Buffered returns the number of bytes currently stored in the RX buffer.
-
-
-### func (*USBCDC) Configure
-
-```go
-func (usbcdc *USBCDC) Configure(config UARTConfig)
-```
-
-Configure the USB CDC interface. The config is here for compatibility with the UART interface.
-
-
-### func (*USBCDC) Configured
-
-```go
-func (usbcdc *USBCDC) Configured() bool
-```
-
-Configured returns whether usbcdc is configured or not.
-
-
-### func (*USBCDC) DTR
-
-```go
-func (usbcdc *USBCDC) DTR() bool
-```
-
-
-
-### func (*USBCDC) Flush
-
-```go
-func (usbcdc *USBCDC) Flush() error
-```
-
-Flush flushes buffered data.
-
-
-### func (*USBCDC) RTS
-
-```go
-func (usbcdc *USBCDC) RTS() bool
-```
-
-
-
-### func (*USBCDC) Read
-
-```go
-func (usbcdc *USBCDC) Read(data []byte) (n int, err error)
-```
-
-Read from the RX buffer.
-
-
-### func (*USBCDC) ReadByte
-
-```go
-func (usbcdc *USBCDC) ReadByte() (byte, error)
-```
-
-ReadByte reads a single byte from the RX buffer.
-If there is no data in the buffer, returns an error.
-
-
-### func (*USBCDC) Receive
-
-```go
-func (usbcdc *USBCDC) Receive(data byte)
-```
-
-Receive handles adding data to the UART's data buffer.
-Usually called by the IRQ handler for a machine.
-
-
-### func (*USBCDC) Write
-
-```go
-func (usbcdc *USBCDC) Write(data []byte) (n int, err error)
-```
-
-Write data to the USBCDC.
-
-
-### func (*USBCDC) WriteByte
-
-```go
-func (usbcdc *USBCDC) WriteByte(c byte) error
-```
-
-WriteByte writes a byte of data to the USB CDC interface.
-
-
-
-
-## type USBDescriptor
-
-```go
-type USBDescriptor struct {
-	Device		[]byte
-	Configuration	[]byte
-	HID		map[uint16][]byte
+type USBDevice struct {
+	initcomplete bool
 }
 ```
 
 
 
 
-### func (*USBDescriptor) Configure
+### func (*USBDevice) Configure
 
 ```go
-func (d *USBDescriptor) Configure(idVendor, idProduct uint16)
+func (dev *USBDevice) Configure(config UARTConfig)
 ```
 
+Configure the USB peripheral. The config is here for compatibility with the UART interface.
 
 
 

--- a/content/docs/reference/microcontrollers/machine/bluepill.md
+++ b/content/docs/reference/microcontrollers/machine/bluepill.md
@@ -632,6 +632,14 @@ func InitADC()
 InitADC initializes the registers needed for ADC1.
 
 
+### func InitSerial
+
+```go
+func InitSerial()
+```
+
+
+
 ### func NewRingBuffer
 
 ```go

--- a/content/docs/reference/microcontrollers/machine/circuitplay-express.md
+++ b/content/docs/reference/microcontrollers/machine/circuitplay-express.md
@@ -395,15 +395,6 @@ The SAM D21 has three TCC peripherals, which have PWM as one feature.
 
 ```go
 var (
-	USB		= &USBCDC{Buffer: NewRingBuffer()}
-	waitHidTxc	bool
-)
-```
-
-
-
-```go
-var (
 	DAC0 = DAC{}
 )
 ```
@@ -419,10 +410,28 @@ var (
 
 
 ```go
-var Serial = USB
+var Serial Serialer
 ```
 
 Serial is implemented via USB (USB-CDC).
+
+
+```go
+var (
+	USBDev	= &USBDevice{}
+	USBCDC	Serialer
+)
+```
+
+
+
+```go
+var (
+	ErrUSBReadTimeout	= errors.New("USB read timeout")
+	ErrUSBBytesRead		= errors.New("USB invalid number of bytes read")
+)
+```
+
 
 
 
@@ -437,13 +446,40 @@ func CPUFrequency() uint32
 Return the current CPU frequency in hertz.
 
 
+### func EnableCDC
+
+```go
+func EnableCDC(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
+```
+
+
+
 ### func EnableHID
 
 ```go
-func EnableHID(callback func())
+func EnableHID(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
 ```
 
 EnableHID enables HID. This function must be executed from the init().
+
+
+### func EnableMIDI
+
+```go
+func EnableMIDI(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
+```
+
+EnableMIDI enables MIDI. This function must be executed from the init().
+
+
+### func EnterBootloader
+
+```go
+func EnterBootloader()
+```
+
+EnterBootloader should perform a system reset in preperation
+to switch to the bootloader to flash new firmware.
 
 
 ### func InitADC
@@ -455,6 +491,14 @@ func InitADC()
 InitADC initializes the ADC.
 
 
+### func InitSerial
+
+```go
+func InitSerial()
+```
+
+
+
 ### func NewRingBuffer
 
 ```go
@@ -464,23 +508,29 @@ func NewRingBuffer() *RingBuffer
 NewRingBuffer returns a new ring buffer.
 
 
-### func ResetProcessor
+### func ReceiveUSBControlPacket
 
 ```go
-func ResetProcessor()
+func ReceiveUSBControlPacket() ([cdcLineInfoSize]byte, error)
 ```
 
-ResetProcessor should perform a system reset in preperation
-to switch to the bootloader to flash new firmware.
 
 
-### func SendUSBHIDPacket
+### func SendUSBInPacket
 
 ```go
-func SendUSBHIDPacket(ep uint32, data []byte) bool
+func SendUSBInPacket(ep uint32, data []byte) bool
 ```
 
-SendUSBHIDPacket sends a packet for USBHID (interrupt / in).
+SendUSBInPacket sends a packet for USB (interrupt in / bulk in).
+
+
+### func SendZlp
+
+```go
+func SendZlp()
+```
+
 
 
 
@@ -1150,6 +1200,25 @@ SPIConfig is used to store config info for SPI.
 
 
 
+## type Serialer
+
+```go
+type Serialer interface {
+	WriteByte(c byte) error
+	Write(data []byte) (n int, err error)
+	Configure(config UARTConfig) error
+	Buffered() int
+	ReadByte() (byte, error)
+	DTR() bool
+	RTS() bool
+}
+```
+
+
+
+
+
+
 ## type TCC
 
 ```go
@@ -1384,143 +1453,24 @@ UARTParity is the parity setting to be used for UART communication.
 
 
 
-## type USBCDC
+## type USBDevice
 
 ```go
-type USBCDC struct {
-	Buffer			*RingBuffer
-	TxIdx			volatile.Register8
-	waitTxc			bool
-	waitTxcRetryCount	uint8
-	sent			bool
-	configured		bool
-}
-```
-
-USBCDC is the USB CDC aka serial over USB interface on the SAMD21.
-
-
-
-### func (*USBCDC) Buffered
-
-```go
-func (usbcdc *USBCDC) Buffered() int
-```
-
-Buffered returns the number of bytes currently stored in the RX buffer.
-
-
-### func (*USBCDC) Configure
-
-```go
-func (usbcdc *USBCDC) Configure(config UARTConfig)
-```
-
-Configure the USB CDC interface. The config is here for compatibility with the UART interface.
-
-
-### func (*USBCDC) Configured
-
-```go
-func (usbcdc *USBCDC) Configured() bool
-```
-
-Configured returns whether usbcdc is configured or not.
-
-
-### func (*USBCDC) DTR
-
-```go
-func (usbcdc *USBCDC) DTR() bool
-```
-
-
-
-### func (*USBCDC) Flush
-
-```go
-func (usbcdc *USBCDC) Flush() error
-```
-
-Flush flushes buffered data.
-
-
-### func (*USBCDC) RTS
-
-```go
-func (usbcdc *USBCDC) RTS() bool
-```
-
-
-
-### func (*USBCDC) Read
-
-```go
-func (usbcdc *USBCDC) Read(data []byte) (n int, err error)
-```
-
-Read from the RX buffer.
-
-
-### func (*USBCDC) ReadByte
-
-```go
-func (usbcdc *USBCDC) ReadByte() (byte, error)
-```
-
-ReadByte reads a single byte from the RX buffer.
-If there is no data in the buffer, returns an error.
-
-
-### func (*USBCDC) Receive
-
-```go
-func (usbcdc *USBCDC) Receive(data byte)
-```
-
-Receive handles adding data to the UART's data buffer.
-Usually called by the IRQ handler for a machine.
-
-
-### func (*USBCDC) Write
-
-```go
-func (usbcdc *USBCDC) Write(data []byte) (n int, err error)
-```
-
-Write data to the USBCDC.
-
-
-### func (*USBCDC) WriteByte
-
-```go
-func (usbcdc *USBCDC) WriteByte(c byte) error
-```
-
-WriteByte writes a byte of data to the USB CDC interface.
-
-
-
-
-## type USBDescriptor
-
-```go
-type USBDescriptor struct {
-	Device		[]byte
-	Configuration	[]byte
-	HID		map[uint16][]byte
+type USBDevice struct {
+	initcomplete bool
 }
 ```
 
 
 
 
-### func (*USBDescriptor) Configure
+### func (*USBDevice) Configure
 
 ```go
-func (d *USBDescriptor) Configure(idVendor, idProduct uint16)
+func (dev *USBDevice) Configure(config UARTConfig)
 ```
 
+Configure the USB peripheral. The config is here for compatibility with the UART interface.
 
 
 

--- a/content/docs/reference/microcontrollers/machine/clue.md
+++ b/content/docs/reference/microcontrollers/machine/clue.md
@@ -353,40 +353,6 @@ PWM
 
 ```go
 var (
-	USB		= &_USB
-	_USB		= USBCDC{Buffer: NewRingBuffer()}
-	waitHidTxc	bool
-
-	usbEndpointDescriptors	[8]usbDeviceDescriptor
-
-	udd_ep_in_cache_buffer	[7][128]uint8
-	udd_ep_out_cache_buffer	[7][128]uint8
-
-	sendOnEP0DATADONE	struct {
-		ptr	*byte
-		count	int
-	}
-	isEndpointHalt		= false
-	isRemoteWakeUpEnabled	= false
-	endPoints		= []uint32{usb_ENDPOINT_TYPE_CONTROL,
-		(usb_ENDPOINT_TYPE_INTERRUPT | usbEndpointIn),
-		(usb_ENDPOINT_TYPE_BULK | usbEndpointOut),
-		(usb_ENDPOINT_TYPE_BULK | usbEndpointIn)}
-
-	usbConfiguration		uint8
-	usbSetInterface			uint8
-	usbLineInfo			= cdcLineInfo{115200, 0x00, 0x00, 0x08, 0x00}
-	epinen				uint32
-	epouten				uint32
-	easyDMABusy			volatile.Register8
-	epout0data_setlinecoding	bool
-)
-```
-
-
-
-```go
-var (
 	SPI0	= SPI{Bus: nrf.SPIM0, buf: new([1]byte)}
 	SPI1	= SPI{Bus: nrf.SPIM1, buf: new([1]byte)}
 	SPI2	= SPI{Bus: nrf.SPIM2, buf: new([1]byte)}
@@ -405,10 +371,28 @@ var (
 
 
 ```go
-var Serial = USB
+var Serial Serialer
 ```
 
 Serial is implemented via USB (USB-CDC).
+
+
+```go
+var (
+	USBDev	= &USBDevice{}
+	USBCDC	Serialer
+)
+```
+
+
+
+```go
+var (
+	ErrUSBReadTimeout	= errors.New("USB read timeout")
+	ErrUSBBytesRead		= errors.New("USB invalid number of bytes read")
+)
+```
+
 
 
 
@@ -422,13 +406,40 @@ func CPUFrequency() uint32
 
 
 
+### func EnableCDC
+
+```go
+func EnableCDC(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
+```
+
+
+
 ### func EnableHID
 
 ```go
-func EnableHID(callback func())
+func EnableHID(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
 ```
 
 EnableHID enables HID. This function must be executed from the init().
+
+
+### func EnableMIDI
+
+```go
+func EnableMIDI(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
+```
+
+EnableMIDI enables MIDI. This function must be executed from the init().
+
+
+### func EnterBootloader
+
+```go
+func EnterBootloader()
+```
+
+EnterBootloader resets the chip into the UF2 bootloader. After reset, it
+can be flashed via nrfutil or by copying a UF2 file to the mass storage device
 
 
 ### func EnterOTABootloader
@@ -470,6 +481,14 @@ func InitADC()
 InitADC initializes the registers needed for ADC.
 
 
+### func InitSerial
+
+```go
+func InitSerial()
+```
+
+
+
 ### func NewRingBuffer
 
 ```go
@@ -479,13 +498,29 @@ func NewRingBuffer() *RingBuffer
 NewRingBuffer returns a new ring buffer.
 
 
-### func SendUSBHIDPacket
+### func ReceiveUSBControlPacket
 
 ```go
-func SendUSBHIDPacket(ep uint32, data []byte) bool
+func ReceiveUSBControlPacket() ([cdcLineInfoSize]byte, error)
 ```
 
-SendUSBHIDPacket sends a packet for USBHID (interrupt / in).
+
+
+### func SendUSBInPacket
+
+```go
+func SendUSBInPacket(ep uint32, data []byte) bool
+```
+
+SendUSBInPacket sends a packet for USBHID (interrupt in / bulk in).
+
+
+### func SendZlp
+
+```go
+func SendZlp()
+```
+
 
 
 
@@ -1062,6 +1097,25 @@ SPIConfig is used to store config info for SPI.
 
 
 
+## type Serialer
+
+```go
+type Serialer interface {
+	WriteByte(c byte) error
+	Write(data []byte) (n int, err error)
+	Configure(config UARTConfig) error
+	Buffered() int
+	ReadByte() (byte, error)
+	DTR() bool
+	RTS() bool
+}
+```
+
+
+
+
+
+
 ## type UART
 
 ```go
@@ -1180,135 +1234,24 @@ UARTParity is the parity setting to be used for UART communication.
 
 
 
-## type USBCDC
+## type USBDevice
 
 ```go
-type USBCDC struct {
-	Buffer			*RingBuffer
-	interrupt		interrupt.Interrupt
-	initcomplete		bool
-	TxIdx			volatile.Register8
-	waitTxc			bool
-	waitTxcRetryCount	uint8
-	sent			bool
-}
-```
-
-USBCDC is the USB CDC aka serial over USB interface on the nRF52840
-
-
-
-### func (*USBCDC) Buffered
-
-```go
-func (usbcdc *USBCDC) Buffered() int
-```
-
-Buffered returns the number of bytes currently stored in the RX buffer.
-
-
-### func (*USBCDC) Configure
-
-```go
-func (usbcdc *USBCDC) Configure(config UARTConfig)
-```
-
-Configure the USB CDC interface. The config is here for compatibility with the UART interface.
-
-
-### func (*USBCDC) DTR
-
-```go
-func (usbcdc *USBCDC) DTR() bool
-```
-
-
-
-### func (*USBCDC) Flush
-
-```go
-func (usbcdc *USBCDC) Flush() error
-```
-
-Flush flushes buffered data.
-
-
-### func (*USBCDC) RTS
-
-```go
-func (usbcdc *USBCDC) RTS() bool
-```
-
-
-
-### func (*USBCDC) Read
-
-```go
-func (usbcdc *USBCDC) Read(data []byte) (n int, err error)
-```
-
-Read from the RX buffer.
-
-
-### func (*USBCDC) ReadByte
-
-```go
-func (usbcdc *USBCDC) ReadByte() (byte, error)
-```
-
-ReadByte reads a single byte from the RX buffer.
-If there is no data in the buffer, returns an error.
-
-
-### func (*USBCDC) Receive
-
-```go
-func (usbcdc *USBCDC) Receive(data byte)
-```
-
-Receive handles adding data to the UART's data buffer.
-Usually called by the IRQ handler for a machine.
-
-
-### func (*USBCDC) Write
-
-```go
-func (usbcdc *USBCDC) Write(data []byte) (n int, err error)
-```
-
-Write data to the USBCDC.
-
-
-### func (*USBCDC) WriteByte
-
-```go
-func (usbcdc *USBCDC) WriteByte(c byte) error
-```
-
-WriteByte writes a byte of data to the USB CDC interface.
-
-
-
-
-## type USBDescriptor
-
-```go
-type USBDescriptor struct {
-	Device		[]byte
-	Configuration	[]byte
-	HID		map[uint16][]byte
+type USBDevice struct {
+	initcomplete bool
 }
 ```
 
 
 
 
-### func (*USBDescriptor) Configure
+### func (*USBDevice) Configure
 
 ```go
-func (d *USBDescriptor) Configure(idVendor, idProduct uint16)
+func (dev *USBDevice) Configure(config UARTConfig)
 ```
 
+Configure the USB peripheral. The config is here for compatibility with the UART interface.
 
 
 

--- a/content/docs/reference/microcontrollers/machine/d1mini.md
+++ b/content/docs/reference/microcontrollers/machine/d1mini.md
@@ -165,6 +165,14 @@ func CPUFrequency() uint32
 
 
 
+### func InitSerial
+
+```go
+func InitSerial()
+```
+
+
+
 ### func NewRingBuffer
 
 ```go

--- a/content/docs/reference/microcontrollers/machine/digispark.md
+++ b/content/docs/reference/microcontrollers/machine/digispark.md
@@ -117,6 +117,14 @@ func InitADC()
 InitADC initializes the registers needed for ADC.
 
 
+### func InitSerial
+
+```go
+func InitSerial()
+```
+
+
+
 ### func NewRingBuffer
 
 ```go

--- a/content/docs/reference/microcontrollers/machine/esp32-coreboard-v2.md
+++ b/content/docs/reference/microcontrollers/machine/esp32-coreboard-v2.md
@@ -254,6 +254,14 @@ CPUFrequency returns the current CPU frequency of the chip.
 Currently it is a fixed frequency but it may allow changing in the future.
 
 
+### func InitSerial
+
+```go
+func InitSerial()
+```
+
+
+
 ### func NewRingBuffer
 
 ```go

--- a/content/docs/reference/microcontrollers/machine/esp32-mini32.md
+++ b/content/docs/reference/microcontrollers/machine/esp32-mini32.md
@@ -254,6 +254,14 @@ CPUFrequency returns the current CPU frequency of the chip.
 Currently it is a fixed frequency but it may allow changing in the future.
 
 
+### func InitSerial
+
+```go
+func InitSerial()
+```
+
+
+
 ### func NewRingBuffer
 
 ```go

--- a/content/docs/reference/microcontrollers/machine/feather-m0.md
+++ b/content/docs/reference/microcontrollers/machine/feather-m0.md
@@ -377,15 +377,6 @@ The SAM D21 has three TCC peripherals, which have PWM as one feature.
 
 ```go
 var (
-	USB		= &USBCDC{Buffer: NewRingBuffer()}
-	waitHidTxc	bool
-)
-```
-
-
-
-```go
-var (
 	DAC0 = DAC{}
 )
 ```
@@ -401,10 +392,28 @@ var (
 
 
 ```go
-var Serial = USB
+var Serial Serialer
 ```
 
 Serial is implemented via USB (USB-CDC).
+
+
+```go
+var (
+	USBDev	= &USBDevice{}
+	USBCDC	Serialer
+)
+```
+
+
+
+```go
+var (
+	ErrUSBReadTimeout	= errors.New("USB read timeout")
+	ErrUSBBytesRead		= errors.New("USB invalid number of bytes read")
+)
+```
+
 
 
 
@@ -419,13 +428,40 @@ func CPUFrequency() uint32
 Return the current CPU frequency in hertz.
 
 
+### func EnableCDC
+
+```go
+func EnableCDC(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
+```
+
+
+
 ### func EnableHID
 
 ```go
-func EnableHID(callback func())
+func EnableHID(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
 ```
 
 EnableHID enables HID. This function must be executed from the init().
+
+
+### func EnableMIDI
+
+```go
+func EnableMIDI(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
+```
+
+EnableMIDI enables MIDI. This function must be executed from the init().
+
+
+### func EnterBootloader
+
+```go
+func EnterBootloader()
+```
+
+EnterBootloader should perform a system reset in preperation
+to switch to the bootloader to flash new firmware.
 
 
 ### func InitADC
@@ -437,6 +473,14 @@ func InitADC()
 InitADC initializes the ADC.
 
 
+### func InitSerial
+
+```go
+func InitSerial()
+```
+
+
+
 ### func NewRingBuffer
 
 ```go
@@ -446,23 +490,29 @@ func NewRingBuffer() *RingBuffer
 NewRingBuffer returns a new ring buffer.
 
 
-### func ResetProcessor
+### func ReceiveUSBControlPacket
 
 ```go
-func ResetProcessor()
+func ReceiveUSBControlPacket() ([cdcLineInfoSize]byte, error)
 ```
 
-ResetProcessor should perform a system reset in preperation
-to switch to the bootloader to flash new firmware.
 
 
-### func SendUSBHIDPacket
+### func SendUSBInPacket
 
 ```go
-func SendUSBHIDPacket(ep uint32, data []byte) bool
+func SendUSBInPacket(ep uint32, data []byte) bool
 ```
 
-SendUSBHIDPacket sends a packet for USBHID (interrupt / in).
+SendUSBInPacket sends a packet for USB (interrupt in / bulk in).
+
+
+### func SendZlp
+
+```go
+func SendZlp()
+```
+
 
 
 
@@ -1132,6 +1182,25 @@ SPIConfig is used to store config info for SPI.
 
 
 
+## type Serialer
+
+```go
+type Serialer interface {
+	WriteByte(c byte) error
+	Write(data []byte) (n int, err error)
+	Configure(config UARTConfig) error
+	Buffered() int
+	ReadByte() (byte, error)
+	DTR() bool
+	RTS() bool
+}
+```
+
+
+
+
+
+
 ## type TCC
 
 ```go
@@ -1366,143 +1435,24 @@ UARTParity is the parity setting to be used for UART communication.
 
 
 
-## type USBCDC
+## type USBDevice
 
 ```go
-type USBCDC struct {
-	Buffer			*RingBuffer
-	TxIdx			volatile.Register8
-	waitTxc			bool
-	waitTxcRetryCount	uint8
-	sent			bool
-	configured		bool
-}
-```
-
-USBCDC is the USB CDC aka serial over USB interface on the SAMD21.
-
-
-
-### func (*USBCDC) Buffered
-
-```go
-func (usbcdc *USBCDC) Buffered() int
-```
-
-Buffered returns the number of bytes currently stored in the RX buffer.
-
-
-### func (*USBCDC) Configure
-
-```go
-func (usbcdc *USBCDC) Configure(config UARTConfig)
-```
-
-Configure the USB CDC interface. The config is here for compatibility with the UART interface.
-
-
-### func (*USBCDC) Configured
-
-```go
-func (usbcdc *USBCDC) Configured() bool
-```
-
-Configured returns whether usbcdc is configured or not.
-
-
-### func (*USBCDC) DTR
-
-```go
-func (usbcdc *USBCDC) DTR() bool
-```
-
-
-
-### func (*USBCDC) Flush
-
-```go
-func (usbcdc *USBCDC) Flush() error
-```
-
-Flush flushes buffered data.
-
-
-### func (*USBCDC) RTS
-
-```go
-func (usbcdc *USBCDC) RTS() bool
-```
-
-
-
-### func (*USBCDC) Read
-
-```go
-func (usbcdc *USBCDC) Read(data []byte) (n int, err error)
-```
-
-Read from the RX buffer.
-
-
-### func (*USBCDC) ReadByte
-
-```go
-func (usbcdc *USBCDC) ReadByte() (byte, error)
-```
-
-ReadByte reads a single byte from the RX buffer.
-If there is no data in the buffer, returns an error.
-
-
-### func (*USBCDC) Receive
-
-```go
-func (usbcdc *USBCDC) Receive(data byte)
-```
-
-Receive handles adding data to the UART's data buffer.
-Usually called by the IRQ handler for a machine.
-
-
-### func (*USBCDC) Write
-
-```go
-func (usbcdc *USBCDC) Write(data []byte) (n int, err error)
-```
-
-Write data to the USBCDC.
-
-
-### func (*USBCDC) WriteByte
-
-```go
-func (usbcdc *USBCDC) WriteByte(c byte) error
-```
-
-WriteByte writes a byte of data to the USB CDC interface.
-
-
-
-
-## type USBDescriptor
-
-```go
-type USBDescriptor struct {
-	Device		[]byte
-	Configuration	[]byte
-	HID		map[uint16][]byte
+type USBDevice struct {
+	initcomplete bool
 }
 ```
 
 
 
 
-### func (*USBDescriptor) Configure
+### func (*USBDevice) Configure
 
 ```go
-func (d *USBDescriptor) Configure(idVendor, idProduct uint16)
+func (dev *USBDevice) Configure(config UARTConfig)
 ```
 
+Configure the USB peripheral. The config is here for compatibility with the UART interface.
 
 
 

--- a/content/docs/reference/microcontrollers/machine/feather-m4-can.md
+++ b/content/docs/reference/microcontrollers/machine/feather-m4-can.md
@@ -543,16 +543,6 @@ var (
 
 ```go
 var (
-	// USB is a USB CDC interface.
-	USB		= &USBCDC{Buffer: NewRingBuffer()}
-	waitHidTxc	bool
-)
-```
-
-
-
-```go
-var (
 	DAC0 = DAC{}
 )
 ```
@@ -599,10 +589,28 @@ var (
 
 
 ```go
-var Serial = USB
+var Serial Serialer
 ```
 
 Serial is implemented via USB (USB-CDC).
+
+
+```go
+var (
+	USBDev	= &USBDevice{}
+	USBCDC	Serialer
+)
+```
+
+
+
+```go
+var (
+	ErrUSBReadTimeout	= errors.New("USB read timeout")
+	ErrUSBBytesRead		= errors.New("USB invalid number of bytes read")
+)
+```
+
 
 
 
@@ -634,13 +642,40 @@ func CPUFrequency() uint32
 
 
 
+### func EnableCDC
+
+```go
+func EnableCDC(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
+```
+
+
+
 ### func EnableHID
 
 ```go
-func EnableHID(callback func())
+func EnableHID(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
 ```
 
 EnableHID enables HID. This function must be executed from the init().
+
+
+### func EnableMIDI
+
+```go
+func EnableMIDI(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
+```
+
+EnableMIDI enables MIDI. This function must be executed from the init().
+
+
+### func EnterBootloader
+
+```go
+func EnterBootloader()
+```
+
+EnterBootloader should perform a system reset in preparation
+to switch to the bootloader to flash new firmware.
 
 
 ### func GetRNG
@@ -661,6 +696,14 @@ func InitADC()
 InitADC initializes the ADC.
 
 
+### func InitSerial
+
+```go
+func InitSerial()
+```
+
+
+
 ### func NewRingBuffer
 
 ```go
@@ -670,23 +713,29 @@ func NewRingBuffer() *RingBuffer
 NewRingBuffer returns a new ring buffer.
 
 
-### func ResetProcessor
+### func ReceiveUSBControlPacket
 
 ```go
-func ResetProcessor()
+func ReceiveUSBControlPacket() ([cdcLineInfoSize]byte, error)
 ```
 
-ResetProcessor should perform a system reset in preparation
-to switch to the bootloader to flash new firmware.
 
 
-### func SendUSBHIDPacket
+### func SendUSBInPacket
 
 ```go
-func SendUSBHIDPacket(ep uint32, data []byte) bool
+func SendUSBInPacket(ep uint32, data []byte) bool
 ```
 
-SendUSBHIDPacket sends a packet for USBHID (interrupt / in).
+SendUSBInPacket sends a packet for USB (interrupt in / bulk in).
+
+
+### func SendZlp
+
+```go
+func SendZlp()
+```
+
 
 
 
@@ -1512,6 +1561,25 @@ SPIConfig is used to store config info for SPI.
 
 
 
+## type Serialer
+
+```go
+type Serialer interface {
+	WriteByte(c byte) error
+	Write(data []byte) (n int, err error)
+	Configure(config UARTConfig) error
+	Buffered() int
+	ReadByte() (byte, error)
+	DTR() bool
+	RTS() bool
+}
+```
+
+
+
+
+
+
 ## type TCC
 
 ```go
@@ -1745,143 +1813,24 @@ UARTParity is the parity setting to be used for UART communication.
 
 
 
-## type USBCDC
+## type USBDevice
 
 ```go
-type USBCDC struct {
-	Buffer			*RingBuffer
-	TxIdx			volatile.Register8
-	waitTxc			bool
-	waitTxcRetryCount	uint8
-	sent			bool
-	configured		bool
-}
-```
-
-USBCDC is the USB CDC aka serial over USB interface on the SAMD21.
-
-
-
-### func (*USBCDC) Buffered
-
-```go
-func (usbcdc *USBCDC) Buffered() int
-```
-
-Buffered returns the number of bytes currently stored in the RX buffer.
-
-
-### func (*USBCDC) Configure
-
-```go
-func (usbcdc *USBCDC) Configure(config UARTConfig)
-```
-
-Configure the USB CDC interface. The config is here for compatibility with the UART interface.
-
-
-### func (*USBCDC) Configured
-
-```go
-func (usbcdc *USBCDC) Configured() bool
-```
-
-Configured returns whether usbcdc is configured or not.
-
-
-### func (*USBCDC) DTR
-
-```go
-func (usbcdc *USBCDC) DTR() bool
-```
-
-
-
-### func (*USBCDC) Flush
-
-```go
-func (usbcdc *USBCDC) Flush() error
-```
-
-Flush flushes buffered data.
-
-
-### func (*USBCDC) RTS
-
-```go
-func (usbcdc *USBCDC) RTS() bool
-```
-
-
-
-### func (*USBCDC) Read
-
-```go
-func (usbcdc *USBCDC) Read(data []byte) (n int, err error)
-```
-
-Read from the RX buffer.
-
-
-### func (*USBCDC) ReadByte
-
-```go
-func (usbcdc *USBCDC) ReadByte() (byte, error)
-```
-
-ReadByte reads a single byte from the RX buffer.
-If there is no data in the buffer, returns an error.
-
-
-### func (*USBCDC) Receive
-
-```go
-func (usbcdc *USBCDC) Receive(data byte)
-```
-
-Receive handles adding data to the UART's data buffer.
-Usually called by the IRQ handler for a machine.
-
-
-### func (*USBCDC) Write
-
-```go
-func (usbcdc *USBCDC) Write(data []byte) (n int, err error)
-```
-
-Write data to the USBCDC.
-
-
-### func (*USBCDC) WriteByte
-
-```go
-func (usbcdc *USBCDC) WriteByte(c byte) error
-```
-
-WriteByte writes a byte of data to the USB CDC interface.
-
-
-
-
-## type USBDescriptor
-
-```go
-type USBDescriptor struct {
-	Device		[]byte
-	Configuration	[]byte
-	HID		map[uint16][]byte
+type USBDevice struct {
+	initcomplete bool
 }
 ```
 
 
 
 
-### func (*USBDescriptor) Configure
+### func (*USBDevice) Configure
 
 ```go
-func (d *USBDescriptor) Configure(idVendor, idProduct uint16)
+func (dev *USBDevice) Configure(config UARTConfig)
 ```
 
+Configure the USB peripheral. The config is here for compatibility with the UART interface.
 
 
 

--- a/content/docs/reference/microcontrollers/machine/feather-m4.md
+++ b/content/docs/reference/microcontrollers/machine/feather-m4.md
@@ -475,16 +475,6 @@ var (
 
 ```go
 var (
-	// USB is a USB CDC interface.
-	USB		= &USBCDC{Buffer: NewRingBuffer()}
-	waitHidTxc	bool
-)
-```
-
-
-
-```go
-var (
 	DAC0 = DAC{}
 )
 ```
@@ -513,10 +503,28 @@ var (
 
 
 ```go
-var Serial = USB
+var Serial Serialer
 ```
 
 Serial is implemented via USB (USB-CDC).
+
+
+```go
+var (
+	USBDev	= &USBDevice{}
+	USBCDC	Serialer
+)
+```
+
+
+
+```go
+var (
+	ErrUSBReadTimeout	= errors.New("USB read timeout")
+	ErrUSBBytesRead		= errors.New("USB invalid number of bytes read")
+)
+```
+
 
 
 
@@ -530,13 +538,40 @@ func CPUFrequency() uint32
 
 
 
+### func EnableCDC
+
+```go
+func EnableCDC(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
+```
+
+
+
 ### func EnableHID
 
 ```go
-func EnableHID(callback func())
+func EnableHID(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
 ```
 
 EnableHID enables HID. This function must be executed from the init().
+
+
+### func EnableMIDI
+
+```go
+func EnableMIDI(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
+```
+
+EnableMIDI enables MIDI. This function must be executed from the init().
+
+
+### func EnterBootloader
+
+```go
+func EnterBootloader()
+```
+
+EnterBootloader should perform a system reset in preparation
+to switch to the bootloader to flash new firmware.
 
 
 ### func GetRNG
@@ -557,6 +592,14 @@ func InitADC()
 InitADC initializes the ADC.
 
 
+### func InitSerial
+
+```go
+func InitSerial()
+```
+
+
+
 ### func NewRingBuffer
 
 ```go
@@ -566,23 +609,29 @@ func NewRingBuffer() *RingBuffer
 NewRingBuffer returns a new ring buffer.
 
 
-### func ResetProcessor
+### func ReceiveUSBControlPacket
 
 ```go
-func ResetProcessor()
+func ReceiveUSBControlPacket() ([cdcLineInfoSize]byte, error)
 ```
 
-ResetProcessor should perform a system reset in preparation
-to switch to the bootloader to flash new firmware.
 
 
-### func SendUSBHIDPacket
+### func SendUSBInPacket
 
 ```go
-func SendUSBHIDPacket(ep uint32, data []byte) bool
+func SendUSBInPacket(ep uint32, data []byte) bool
 ```
 
-SendUSBHIDPacket sends a packet for USBHID (interrupt / in).
+SendUSBInPacket sends a packet for USB (interrupt in / bulk in).
+
+
+### func SendZlp
+
+```go
+func SendZlp()
+```
+
 
 
 
@@ -1209,6 +1258,25 @@ SPIConfig is used to store config info for SPI.
 
 
 
+## type Serialer
+
+```go
+type Serialer interface {
+	WriteByte(c byte) error
+	Write(data []byte) (n int, err error)
+	Configure(config UARTConfig) error
+	Buffered() int
+	ReadByte() (byte, error)
+	DTR() bool
+	RTS() bool
+}
+```
+
+
+
+
+
+
 ## type TCC
 
 ```go
@@ -1442,143 +1510,24 @@ UARTParity is the parity setting to be used for UART communication.
 
 
 
-## type USBCDC
+## type USBDevice
 
 ```go
-type USBCDC struct {
-	Buffer			*RingBuffer
-	TxIdx			volatile.Register8
-	waitTxc			bool
-	waitTxcRetryCount	uint8
-	sent			bool
-	configured		bool
-}
-```
-
-USBCDC is the USB CDC aka serial over USB interface on the SAMD21.
-
-
-
-### func (*USBCDC) Buffered
-
-```go
-func (usbcdc *USBCDC) Buffered() int
-```
-
-Buffered returns the number of bytes currently stored in the RX buffer.
-
-
-### func (*USBCDC) Configure
-
-```go
-func (usbcdc *USBCDC) Configure(config UARTConfig)
-```
-
-Configure the USB CDC interface. The config is here for compatibility with the UART interface.
-
-
-### func (*USBCDC) Configured
-
-```go
-func (usbcdc *USBCDC) Configured() bool
-```
-
-Configured returns whether usbcdc is configured or not.
-
-
-### func (*USBCDC) DTR
-
-```go
-func (usbcdc *USBCDC) DTR() bool
-```
-
-
-
-### func (*USBCDC) Flush
-
-```go
-func (usbcdc *USBCDC) Flush() error
-```
-
-Flush flushes buffered data.
-
-
-### func (*USBCDC) RTS
-
-```go
-func (usbcdc *USBCDC) RTS() bool
-```
-
-
-
-### func (*USBCDC) Read
-
-```go
-func (usbcdc *USBCDC) Read(data []byte) (n int, err error)
-```
-
-Read from the RX buffer.
-
-
-### func (*USBCDC) ReadByte
-
-```go
-func (usbcdc *USBCDC) ReadByte() (byte, error)
-```
-
-ReadByte reads a single byte from the RX buffer.
-If there is no data in the buffer, returns an error.
-
-
-### func (*USBCDC) Receive
-
-```go
-func (usbcdc *USBCDC) Receive(data byte)
-```
-
-Receive handles adding data to the UART's data buffer.
-Usually called by the IRQ handler for a machine.
-
-
-### func (*USBCDC) Write
-
-```go
-func (usbcdc *USBCDC) Write(data []byte) (n int, err error)
-```
-
-Write data to the USBCDC.
-
-
-### func (*USBCDC) WriteByte
-
-```go
-func (usbcdc *USBCDC) WriteByte(c byte) error
-```
-
-WriteByte writes a byte of data to the USB CDC interface.
-
-
-
-
-## type USBDescriptor
-
-```go
-type USBDescriptor struct {
-	Device		[]byte
-	Configuration	[]byte
-	HID		map[uint16][]byte
+type USBDevice struct {
+	initcomplete bool
 }
 ```
 
 
 
 
-### func (*USBDescriptor) Configure
+### func (*USBDevice) Configure
 
 ```go
-func (d *USBDescriptor) Configure(idVendor, idProduct uint16)
+func (dev *USBDevice) Configure(config UARTConfig)
 ```
 
+Configure the USB peripheral. The config is here for compatibility with the UART interface.
 
 
 

--- a/content/docs/reference/microcontrollers/machine/feather-nrf52840-sense.md
+++ b/content/docs/reference/microcontrollers/machine/feather-nrf52840-sense.md
@@ -325,40 +325,6 @@ PWM
 
 ```go
 var (
-	USB		= &_USB
-	_USB		= USBCDC{Buffer: NewRingBuffer()}
-	waitHidTxc	bool
-
-	usbEndpointDescriptors	[8]usbDeviceDescriptor
-
-	udd_ep_in_cache_buffer	[7][128]uint8
-	udd_ep_out_cache_buffer	[7][128]uint8
-
-	sendOnEP0DATADONE	struct {
-		ptr	*byte
-		count	int
-	}
-	isEndpointHalt		= false
-	isRemoteWakeUpEnabled	= false
-	endPoints		= []uint32{usb_ENDPOINT_TYPE_CONTROL,
-		(usb_ENDPOINT_TYPE_INTERRUPT | usbEndpointIn),
-		(usb_ENDPOINT_TYPE_BULK | usbEndpointOut),
-		(usb_ENDPOINT_TYPE_BULK | usbEndpointIn)}
-
-	usbConfiguration		uint8
-	usbSetInterface			uint8
-	usbLineInfo			= cdcLineInfo{115200, 0x00, 0x00, 0x08, 0x00}
-	epinen				uint32
-	epouten				uint32
-	easyDMABusy			volatile.Register8
-	epout0data_setlinecoding	bool
-)
-```
-
-
-
-```go
-var (
 	SPI0	= SPI{Bus: nrf.SPIM0, buf: new([1]byte)}
 	SPI1	= SPI{Bus: nrf.SPIM1, buf: new([1]byte)}
 	SPI2	= SPI{Bus: nrf.SPIM2, buf: new([1]byte)}
@@ -377,10 +343,28 @@ var (
 
 
 ```go
-var Serial = USB
+var Serial Serialer
 ```
 
 Serial is implemented via USB (USB-CDC).
+
+
+```go
+var (
+	USBDev	= &USBDevice{}
+	USBCDC	Serialer
+)
+```
+
+
+
+```go
+var (
+	ErrUSBReadTimeout	= errors.New("USB read timeout")
+	ErrUSBBytesRead		= errors.New("USB invalid number of bytes read")
+)
+```
+
 
 
 
@@ -394,13 +378,40 @@ func CPUFrequency() uint32
 
 
 
+### func EnableCDC
+
+```go
+func EnableCDC(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
+```
+
+
+
 ### func EnableHID
 
 ```go
-func EnableHID(callback func())
+func EnableHID(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
 ```
 
 EnableHID enables HID. This function must be executed from the init().
+
+
+### func EnableMIDI
+
+```go
+func EnableMIDI(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
+```
+
+EnableMIDI enables MIDI. This function must be executed from the init().
+
+
+### func EnterBootloader
+
+```go
+func EnterBootloader()
+```
+
+EnterBootloader resets the chip into the UF2 bootloader. After reset, it
+can be flashed via nrfutil or by copying a UF2 file to the mass storage device
 
 
 ### func EnterOTABootloader
@@ -442,6 +453,14 @@ func InitADC()
 InitADC initializes the registers needed for ADC.
 
 
+### func InitSerial
+
+```go
+func InitSerial()
+```
+
+
+
 ### func NewRingBuffer
 
 ```go
@@ -451,13 +470,29 @@ func NewRingBuffer() *RingBuffer
 NewRingBuffer returns a new ring buffer.
 
 
-### func SendUSBHIDPacket
+### func ReceiveUSBControlPacket
 
 ```go
-func SendUSBHIDPacket(ep uint32, data []byte) bool
+func ReceiveUSBControlPacket() ([cdcLineInfoSize]byte, error)
 ```
 
-SendUSBHIDPacket sends a packet for USBHID (interrupt / in).
+
+
+### func SendUSBInPacket
+
+```go
+func SendUSBInPacket(ep uint32, data []byte) bool
+```
+
+SendUSBInPacket sends a packet for USBHID (interrupt in / bulk in).
+
+
+### func SendZlp
+
+```go
+func SendZlp()
+```
+
 
 
 
@@ -1034,6 +1069,25 @@ SPIConfig is used to store config info for SPI.
 
 
 
+## type Serialer
+
+```go
+type Serialer interface {
+	WriteByte(c byte) error
+	Write(data []byte) (n int, err error)
+	Configure(config UARTConfig) error
+	Buffered() int
+	ReadByte() (byte, error)
+	DTR() bool
+	RTS() bool
+}
+```
+
+
+
+
+
+
 ## type UART
 
 ```go
@@ -1152,135 +1206,24 @@ UARTParity is the parity setting to be used for UART communication.
 
 
 
-## type USBCDC
+## type USBDevice
 
 ```go
-type USBCDC struct {
-	Buffer			*RingBuffer
-	interrupt		interrupt.Interrupt
-	initcomplete		bool
-	TxIdx			volatile.Register8
-	waitTxc			bool
-	waitTxcRetryCount	uint8
-	sent			bool
-}
-```
-
-USBCDC is the USB CDC aka serial over USB interface on the nRF52840
-
-
-
-### func (*USBCDC) Buffered
-
-```go
-func (usbcdc *USBCDC) Buffered() int
-```
-
-Buffered returns the number of bytes currently stored in the RX buffer.
-
-
-### func (*USBCDC) Configure
-
-```go
-func (usbcdc *USBCDC) Configure(config UARTConfig)
-```
-
-Configure the USB CDC interface. The config is here for compatibility with the UART interface.
-
-
-### func (*USBCDC) DTR
-
-```go
-func (usbcdc *USBCDC) DTR() bool
-```
-
-
-
-### func (*USBCDC) Flush
-
-```go
-func (usbcdc *USBCDC) Flush() error
-```
-
-Flush flushes buffered data.
-
-
-### func (*USBCDC) RTS
-
-```go
-func (usbcdc *USBCDC) RTS() bool
-```
-
-
-
-### func (*USBCDC) Read
-
-```go
-func (usbcdc *USBCDC) Read(data []byte) (n int, err error)
-```
-
-Read from the RX buffer.
-
-
-### func (*USBCDC) ReadByte
-
-```go
-func (usbcdc *USBCDC) ReadByte() (byte, error)
-```
-
-ReadByte reads a single byte from the RX buffer.
-If there is no data in the buffer, returns an error.
-
-
-### func (*USBCDC) Receive
-
-```go
-func (usbcdc *USBCDC) Receive(data byte)
-```
-
-Receive handles adding data to the UART's data buffer.
-Usually called by the IRQ handler for a machine.
-
-
-### func (*USBCDC) Write
-
-```go
-func (usbcdc *USBCDC) Write(data []byte) (n int, err error)
-```
-
-Write data to the USBCDC.
-
-
-### func (*USBCDC) WriteByte
-
-```go
-func (usbcdc *USBCDC) WriteByte(c byte) error
-```
-
-WriteByte writes a byte of data to the USB CDC interface.
-
-
-
-
-## type USBDescriptor
-
-```go
-type USBDescriptor struct {
-	Device		[]byte
-	Configuration	[]byte
-	HID		map[uint16][]byte
+type USBDevice struct {
+	initcomplete bool
 }
 ```
 
 
 
 
-### func (*USBDescriptor) Configure
+### func (*USBDevice) Configure
 
 ```go
-func (d *USBDescriptor) Configure(idVendor, idProduct uint16)
+func (dev *USBDevice) Configure(config UARTConfig)
 ```
 
+Configure the USB peripheral. The config is here for compatibility with the UART interface.
 
 
 

--- a/content/docs/reference/microcontrollers/machine/feather-nrf52840.md
+++ b/content/docs/reference/microcontrollers/machine/feather-nrf52840.md
@@ -325,40 +325,6 @@ PWM
 
 ```go
 var (
-	USB		= &_USB
-	_USB		= USBCDC{Buffer: NewRingBuffer()}
-	waitHidTxc	bool
-
-	usbEndpointDescriptors	[8]usbDeviceDescriptor
-
-	udd_ep_in_cache_buffer	[7][128]uint8
-	udd_ep_out_cache_buffer	[7][128]uint8
-
-	sendOnEP0DATADONE	struct {
-		ptr	*byte
-		count	int
-	}
-	isEndpointHalt		= false
-	isRemoteWakeUpEnabled	= false
-	endPoints		= []uint32{usb_ENDPOINT_TYPE_CONTROL,
-		(usb_ENDPOINT_TYPE_INTERRUPT | usbEndpointIn),
-		(usb_ENDPOINT_TYPE_BULK | usbEndpointOut),
-		(usb_ENDPOINT_TYPE_BULK | usbEndpointIn)}
-
-	usbConfiguration		uint8
-	usbSetInterface			uint8
-	usbLineInfo			= cdcLineInfo{115200, 0x00, 0x00, 0x08, 0x00}
-	epinen				uint32
-	epouten				uint32
-	easyDMABusy			volatile.Register8
-	epout0data_setlinecoding	bool
-)
-```
-
-
-
-```go
-var (
 	SPI0	= SPI{Bus: nrf.SPIM0, buf: new([1]byte)}
 	SPI1	= SPI{Bus: nrf.SPIM1, buf: new([1]byte)}
 	SPI2	= SPI{Bus: nrf.SPIM2, buf: new([1]byte)}
@@ -377,10 +343,28 @@ var (
 
 
 ```go
-var Serial = USB
+var Serial Serialer
 ```
 
 Serial is implemented via USB (USB-CDC).
+
+
+```go
+var (
+	USBDev	= &USBDevice{}
+	USBCDC	Serialer
+)
+```
+
+
+
+```go
+var (
+	ErrUSBReadTimeout	= errors.New("USB read timeout")
+	ErrUSBBytesRead		= errors.New("USB invalid number of bytes read")
+)
+```
+
 
 
 
@@ -394,13 +378,40 @@ func CPUFrequency() uint32
 
 
 
+### func EnableCDC
+
+```go
+func EnableCDC(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
+```
+
+
+
 ### func EnableHID
 
 ```go
-func EnableHID(callback func())
+func EnableHID(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
 ```
 
 EnableHID enables HID. This function must be executed from the init().
+
+
+### func EnableMIDI
+
+```go
+func EnableMIDI(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
+```
+
+EnableMIDI enables MIDI. This function must be executed from the init().
+
+
+### func EnterBootloader
+
+```go
+func EnterBootloader()
+```
+
+EnterBootloader resets the chip into the UF2 bootloader. After reset, it
+can be flashed via nrfutil or by copying a UF2 file to the mass storage device
 
 
 ### func EnterOTABootloader
@@ -442,6 +453,14 @@ func InitADC()
 InitADC initializes the registers needed for ADC.
 
 
+### func InitSerial
+
+```go
+func InitSerial()
+```
+
+
+
 ### func NewRingBuffer
 
 ```go
@@ -451,13 +470,29 @@ func NewRingBuffer() *RingBuffer
 NewRingBuffer returns a new ring buffer.
 
 
-### func SendUSBHIDPacket
+### func ReceiveUSBControlPacket
 
 ```go
-func SendUSBHIDPacket(ep uint32, data []byte) bool
+func ReceiveUSBControlPacket() ([cdcLineInfoSize]byte, error)
 ```
 
-SendUSBHIDPacket sends a packet for USBHID (interrupt / in).
+
+
+### func SendUSBInPacket
+
+```go
+func SendUSBInPacket(ep uint32, data []byte) bool
+```
+
+SendUSBInPacket sends a packet for USBHID (interrupt in / bulk in).
+
+
+### func SendZlp
+
+```go
+func SendZlp()
+```
+
 
 
 
@@ -1034,6 +1069,25 @@ SPIConfig is used to store config info for SPI.
 
 
 
+## type Serialer
+
+```go
+type Serialer interface {
+	WriteByte(c byte) error
+	Write(data []byte) (n int, err error)
+	Configure(config UARTConfig) error
+	Buffered() int
+	ReadByte() (byte, error)
+	DTR() bool
+	RTS() bool
+}
+```
+
+
+
+
+
+
 ## type UART
 
 ```go
@@ -1152,135 +1206,24 @@ UARTParity is the parity setting to be used for UART communication.
 
 
 
-## type USBCDC
+## type USBDevice
 
 ```go
-type USBCDC struct {
-	Buffer			*RingBuffer
-	interrupt		interrupt.Interrupt
-	initcomplete		bool
-	TxIdx			volatile.Register8
-	waitTxc			bool
-	waitTxcRetryCount	uint8
-	sent			bool
-}
-```
-
-USBCDC is the USB CDC aka serial over USB interface on the nRF52840
-
-
-
-### func (*USBCDC) Buffered
-
-```go
-func (usbcdc *USBCDC) Buffered() int
-```
-
-Buffered returns the number of bytes currently stored in the RX buffer.
-
-
-### func (*USBCDC) Configure
-
-```go
-func (usbcdc *USBCDC) Configure(config UARTConfig)
-```
-
-Configure the USB CDC interface. The config is here for compatibility with the UART interface.
-
-
-### func (*USBCDC) DTR
-
-```go
-func (usbcdc *USBCDC) DTR() bool
-```
-
-
-
-### func (*USBCDC) Flush
-
-```go
-func (usbcdc *USBCDC) Flush() error
-```
-
-Flush flushes buffered data.
-
-
-### func (*USBCDC) RTS
-
-```go
-func (usbcdc *USBCDC) RTS() bool
-```
-
-
-
-### func (*USBCDC) Read
-
-```go
-func (usbcdc *USBCDC) Read(data []byte) (n int, err error)
-```
-
-Read from the RX buffer.
-
-
-### func (*USBCDC) ReadByte
-
-```go
-func (usbcdc *USBCDC) ReadByte() (byte, error)
-```
-
-ReadByte reads a single byte from the RX buffer.
-If there is no data in the buffer, returns an error.
-
-
-### func (*USBCDC) Receive
-
-```go
-func (usbcdc *USBCDC) Receive(data byte)
-```
-
-Receive handles adding data to the UART's data buffer.
-Usually called by the IRQ handler for a machine.
-
-
-### func (*USBCDC) Write
-
-```go
-func (usbcdc *USBCDC) Write(data []byte) (n int, err error)
-```
-
-Write data to the USBCDC.
-
-
-### func (*USBCDC) WriteByte
-
-```go
-func (usbcdc *USBCDC) WriteByte(c byte) error
-```
-
-WriteByte writes a byte of data to the USB CDC interface.
-
-
-
-
-## type USBDescriptor
-
-```go
-type USBDescriptor struct {
-	Device		[]byte
-	Configuration	[]byte
-	HID		map[uint16][]byte
+type USBDevice struct {
+	initcomplete bool
 }
 ```
 
 
 
 
-### func (*USBDescriptor) Configure
+### func (*USBDevice) Configure
 
 ```go
-func (d *USBDescriptor) Configure(idVendor, idProduct uint16)
+func (dev *USBDevice) Configure(config UARTConfig)
 ```
 
+Configure the USB peripheral. The config is here for compatibility with the UART interface.
 
 
 

--- a/content/docs/reference/microcontrollers/machine/feather-rp2040.md
+++ b/content/docs/reference/microcontrollers/machine/feather-rp2040.md
@@ -86,6 +86,20 @@ SPI default pins
 
 ```go
 const (
+	UART0_TX_PIN	= GPIO0
+	UART0_RX_PIN	= GPIO1
+	UART1_TX_PIN	= GPIO8
+	UART1_RX_PIN	= GPIO9
+	UART_TX_PIN	= UART0_TX_PIN
+	UART_RX_PIN	= UART0_RX_PIN
+)
+```
+
+UART pins
+
+
+```go
+const (
 	TWI_FREQ_100KHZ	= 100000
 	TWI_FREQ_400KHZ	= 400000
 )
@@ -159,20 +173,6 @@ const (
 
 ```go
 const (
-	UART_TX_PIN	= UART0_TX_PIN
-	UART_RX_PIN	= UART0_RX_PIN
-	UART0_TX_PIN	= GPIO0
-	UART0_RX_PIN	= GPIO1
-	UART1_TX_PIN	= GPIO8
-	UART1_RX_PIN	= GPIO9
-)
-```
-
-UART pins
-
-
-```go
-const (
 	adc0_CH	ADCChannel	= iota
 	adc1_CH
 	adc2_CH
@@ -236,6 +236,47 @@ TODO: This field is not available in the device file.
 
 ```go
 const (
+	// DPRAM : Endpoint control register
+	usbEpControlEnable			= 0x80000000
+	usbEpControlDoubleBuffered		= 0x40000000
+	usbEpControlInterruptPerBuff		= 0x20000000
+	usbEpControlInterruptPerDoubleBuff	= 0x10000000
+	usbEpControlEndpointType		= 0x0c000000
+	usbEpControlInterruptOnStall		= 0x00020000
+	usbEpControlInterruptOnNak		= 0x00010000
+	usbEpControlBufferAddress		= 0x0000ffff
+
+	usbEpControlEndpointTypeControl		= 0x00000000
+	usbEpControlEndpointTypeISO		= 0x04000000
+	usbEpControlEndpointTypeBulk		= 0x08000000
+	usbEpControlEndpointTypeInterrupt	= 0x0c000000
+
+	// Endpoint buffer control bits
+	usbBuf1CtrlFull		= 0x80000000
+	usbBuf1CtrlLast		= 0x40000000
+	usbBuf1CtrlData0Pid	= 0x20000000
+	usbBuf1CtrlData1Pid	= 0x00000000
+	usbBuf1CtrlSel		= 0x10000000
+	usbBuf1CtrlStall	= 0x08000000
+	usbBuf1CtrlAvail	= 0x04000000
+	usbBuf1CtrlLenMask	= 0x03FF0000
+	usbBuf0CtrlFull		= 0x00008000
+	usbBuf0CtrlLast		= 0x00004000
+	usbBuf0CtrlData0Pid	= 0x00000000
+	usbBuf0CtrlData1Pid	= 0x00002000
+	usbBuf0CtrlSel		= 0x00001000
+	usbBuf0CtrlStall	= 0x00000800
+	usbBuf0CtrlAvail	= 0x00000400
+	usbBuf0CtrlLenMask	= 0x000003FF
+
+	USBBufferLen	= 64
+)
+```
+
+
+
+```go
+const (
 	// ParityNone means to not use any parity checking. This is
 	// the most common setting.
 	ParityNone	UARTParity	= 0
@@ -259,19 +300,6 @@ const (
 
 ```go
 var (
-	ErrTimeoutRNG		= errors.New("machine: RNG Timeout")
-	ErrInvalidInputPin	= errors.New("machine: invalid input pin")
-	ErrInvalidOutputPin	= errors.New("machine: invalid output pin")
-	ErrInvalidClockPin	= errors.New("machine: invalid clock pin")
-	ErrInvalidDataPin	= errors.New("machine: invalid data pin")
-	ErrNoPinChangeChannel	= errors.New("machine: no channel available for pin interrupt")
-)
-```
-
-
-
-```go
-var (
 	UART0	= &_UART0
 	_UART0	= UART{
 		Buffer:	NewRingBuffer(),
@@ -291,6 +319,19 @@ UART on the RP2040
 
 ```go
 var DefaultUART = UART0
+```
+
+
+
+```go
+var (
+	ErrTimeoutRNG		= errors.New("machine: RNG Timeout")
+	ErrInvalidInputPin	= errors.New("machine: invalid input pin")
+	ErrInvalidOutputPin	= errors.New("machine: invalid output pin")
+	ErrInvalidClockPin	= errors.New("machine: invalid clock pin")
+	ErrInvalidDataPin	= errors.New("machine: invalid data pin")
+	ErrNoPinChangeChannel	= errors.New("machine: no channel available for pin interrupt")
+)
 ```
 
 
@@ -396,10 +437,28 @@ var (
 
 
 ```go
-var Serial = DefaultUART
+var Serial Serialer
 ```
 
-Serial is implemented via the default (usually the first) UART on the chip.
+Serial is implemented via USB (USB-CDC).
+
+
+```go
+var (
+	USBDev	= &USBDevice{}
+	USBCDC	Serialer
+)
+```
+
+
+
+```go
+var (
+	ErrUSBReadTimeout	= errors.New("USB read timeout")
+	ErrUSBBytesRead		= errors.New("USB invalid number of bytes read")
+)
+```
+
 
 
 
@@ -422,6 +481,32 @@ func CurrentCore() int
 CurrentCore returns the core number the call was made from.
 
 
+### func EnableCDC
+
+```go
+func EnableCDC(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
+```
+
+
+
+### func EnableHID
+
+```go
+func EnableHID(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
+```
+
+EnableHID enables HID. This function must be executed from the init().
+
+
+### func EnableMIDI
+
+```go
+func EnableMIDI(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
+```
+
+EnableMIDI enables MIDI. This function must be executed from the init().
+
+
 ### func InitADC
 
 ```go
@@ -429,6 +514,14 @@ func InitADC()
 ```
 
 InitADC resets the ADC peripheral.
+
+
+### func InitSerial
+
+```go
+func InitSerial()
+```
+
 
 
 ### func NewRingBuffer
@@ -458,6 +551,31 @@ func PWMPeripheral(pin Pin) (sliceNum uint8, err error)
 Peripheral returns the RP2040 PWM peripheral which ranges from 0 to 7. Each
 PWM peripheral has 2 channels, A and B which correspond to 0 and 1 in the program.
 This number corresponds to the package's PWM0 throughout PWM7 handles
+
+
+### func ReceiveUSBControlPacket
+
+```go
+func ReceiveUSBControlPacket() ([cdcLineInfoSize]byte, error)
+```
+
+
+
+### func SendUSBInPacket
+
+```go
+func SendUSBInPacket(ep uint32, data []byte) bool
+```
+
+SendUSBInPacket sends a packet for USB (interrupt in / bulk in).
+
+
+### func SendZlp
+
+```go
+func SendZlp()
+```
+
 
 
 
@@ -1062,6 +1180,25 @@ SPIConfig is used to store config info for SPI.
 
 
 
+## type Serialer
+
+```go
+type Serialer interface {
+	WriteByte(c byte) error
+	Write(data []byte) (n int, err error)
+	Configure(config UARTConfig) error
+	Buffered() int
+	ReadByte() (byte, error)
+	DTR() bool
+	RTS() bool
+}
+```
+
+
+
+
+
+
 ## type UART
 
 ```go
@@ -1186,6 +1323,88 @@ type UARTParity int
 ```
 
 UARTParity is the parity setting to be used for UART communication.
+
+
+
+
+
+## type USBBuffer
+
+```go
+type USBBuffer struct {
+	Buffer0	[USBBufferLen]byte
+	Buffer1	[USBBufferLen]byte
+}
+```
+
+
+
+
+
+
+## type USBBufferControlRegister
+
+```go
+type USBBufferControlRegister struct {
+	In	volatile.Register32
+	Out	volatile.Register32
+}
+```
+
+
+
+
+
+
+## type USBDPSRAM
+
+```go
+type USBDPSRAM struct {
+	// Note that EPxControl[0] is not EP0Control but 8-byte setup data.
+	EPxControl	[16]USBEndpointControlRegister
+
+	EPxBufferControl	[16]USBBufferControlRegister
+
+	EPxBuffer	[16]USBBuffer
+}
+```
+
+
+
+
+
+
+## type USBDevice
+
+```go
+type USBDevice struct {
+	initcomplete bool
+}
+```
+
+
+
+
+### func (*USBDevice) Configure
+
+```go
+func (dev *USBDevice) Configure(config UARTConfig)
+```
+
+Configure the USB peripheral. The config is here for compatibility with the UART interface.
+
+
+
+
+## type USBEndpointControlRegister
+
+```go
+type USBEndpointControlRegister struct {
+	In	volatile.Register32
+	Out	volatile.Register32
+}
+```
+
 
 
 

--- a/content/docs/reference/microcontrollers/machine/feather-stm32f405.md
+++ b/content/docs/reference/microcontrollers/machine/feather-stm32f405.md
@@ -872,6 +872,14 @@ func InitADC()
 InitADC initializes the registers needed for ADC1.
 
 
+### func InitSerial
+
+```go
+func InitSerial()
+```
+
+
+
 ### func NewRingBuffer
 
 ```go

--- a/content/docs/reference/microcontrollers/machine/gameboy-advance.md
+++ b/content/docs/reference/microcontrollers/machine/gameboy-advance.md
@@ -90,6 +90,14 @@ Serial is a null device: writes to it are ignored.
 
 
 
+### func InitSerial
+
+```go
+func InitSerial()
+```
+
+
+
 ### func NewRingBuffer
 
 ```go

--- a/content/docs/reference/microcontrollers/machine/grandcentral-m4.md
+++ b/content/docs/reference/microcontrollers/machine/grandcentral-m4.md
@@ -649,16 +649,6 @@ var (
 
 ```go
 var (
-	// USB is a USB CDC interface.
-	USB		= &USBCDC{Buffer: NewRingBuffer()}
-	waitHidTxc	bool
-)
-```
-
-
-
-```go
-var (
 	DAC0 = DAC{}
 )
 ```
@@ -687,10 +677,28 @@ var (
 
 
 ```go
-var Serial = USB
+var Serial Serialer
 ```
 
 Serial is implemented via USB (USB-CDC).
+
+
+```go
+var (
+	USBDev	= &USBDevice{}
+	USBCDC	Serialer
+)
+```
+
+
+
+```go
+var (
+	ErrUSBReadTimeout	= errors.New("USB read timeout")
+	ErrUSBBytesRead		= errors.New("USB invalid number of bytes read")
+)
+```
+
 
 
 
@@ -704,13 +712,40 @@ func CPUFrequency() uint32
 
 
 
+### func EnableCDC
+
+```go
+func EnableCDC(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
+```
+
+
+
 ### func EnableHID
 
 ```go
-func EnableHID(callback func())
+func EnableHID(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
 ```
 
 EnableHID enables HID. This function must be executed from the init().
+
+
+### func EnableMIDI
+
+```go
+func EnableMIDI(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
+```
+
+EnableMIDI enables MIDI. This function must be executed from the init().
+
+
+### func EnterBootloader
+
+```go
+func EnterBootloader()
+```
+
+EnterBootloader should perform a system reset in preparation
+to switch to the bootloader to flash new firmware.
 
 
 ### func GetRNG
@@ -731,6 +766,14 @@ func InitADC()
 InitADC initializes the ADC.
 
 
+### func InitSerial
+
+```go
+func InitSerial()
+```
+
+
+
 ### func NewRingBuffer
 
 ```go
@@ -740,23 +783,29 @@ func NewRingBuffer() *RingBuffer
 NewRingBuffer returns a new ring buffer.
 
 
-### func ResetProcessor
+### func ReceiveUSBControlPacket
 
 ```go
-func ResetProcessor()
+func ReceiveUSBControlPacket() ([cdcLineInfoSize]byte, error)
 ```
 
-ResetProcessor should perform a system reset in preparation
-to switch to the bootloader to flash new firmware.
 
 
-### func SendUSBHIDPacket
+### func SendUSBInPacket
 
 ```go
-func SendUSBHIDPacket(ep uint32, data []byte) bool
+func SendUSBInPacket(ep uint32, data []byte) bool
 ```
 
-SendUSBHIDPacket sends a packet for USBHID (interrupt / in).
+SendUSBInPacket sends a packet for USB (interrupt in / bulk in).
+
+
+### func SendZlp
+
+```go
+func SendZlp()
+```
+
 
 
 
@@ -1383,6 +1432,25 @@ SPIConfig is used to store config info for SPI.
 
 
 
+## type Serialer
+
+```go
+type Serialer interface {
+	WriteByte(c byte) error
+	Write(data []byte) (n int, err error)
+	Configure(config UARTConfig) error
+	Buffered() int
+	ReadByte() (byte, error)
+	DTR() bool
+	RTS() bool
+}
+```
+
+
+
+
+
+
 ## type TCC
 
 ```go
@@ -1616,143 +1684,24 @@ UARTParity is the parity setting to be used for UART communication.
 
 
 
-## type USBCDC
+## type USBDevice
 
 ```go
-type USBCDC struct {
-	Buffer			*RingBuffer
-	TxIdx			volatile.Register8
-	waitTxc			bool
-	waitTxcRetryCount	uint8
-	sent			bool
-	configured		bool
-}
-```
-
-USBCDC is the USB CDC aka serial over USB interface on the SAMD21.
-
-
-
-### func (*USBCDC) Buffered
-
-```go
-func (usbcdc *USBCDC) Buffered() int
-```
-
-Buffered returns the number of bytes currently stored in the RX buffer.
-
-
-### func (*USBCDC) Configure
-
-```go
-func (usbcdc *USBCDC) Configure(config UARTConfig)
-```
-
-Configure the USB CDC interface. The config is here for compatibility with the UART interface.
-
-
-### func (*USBCDC) Configured
-
-```go
-func (usbcdc *USBCDC) Configured() bool
-```
-
-Configured returns whether usbcdc is configured or not.
-
-
-### func (*USBCDC) DTR
-
-```go
-func (usbcdc *USBCDC) DTR() bool
-```
-
-
-
-### func (*USBCDC) Flush
-
-```go
-func (usbcdc *USBCDC) Flush() error
-```
-
-Flush flushes buffered data.
-
-
-### func (*USBCDC) RTS
-
-```go
-func (usbcdc *USBCDC) RTS() bool
-```
-
-
-
-### func (*USBCDC) Read
-
-```go
-func (usbcdc *USBCDC) Read(data []byte) (n int, err error)
-```
-
-Read from the RX buffer.
-
-
-### func (*USBCDC) ReadByte
-
-```go
-func (usbcdc *USBCDC) ReadByte() (byte, error)
-```
-
-ReadByte reads a single byte from the RX buffer.
-If there is no data in the buffer, returns an error.
-
-
-### func (*USBCDC) Receive
-
-```go
-func (usbcdc *USBCDC) Receive(data byte)
-```
-
-Receive handles adding data to the UART's data buffer.
-Usually called by the IRQ handler for a machine.
-
-
-### func (*USBCDC) Write
-
-```go
-func (usbcdc *USBCDC) Write(data []byte) (n int, err error)
-```
-
-Write data to the USBCDC.
-
-
-### func (*USBCDC) WriteByte
-
-```go
-func (usbcdc *USBCDC) WriteByte(c byte) error
-```
-
-WriteByte writes a byte of data to the USB CDC interface.
-
-
-
-
-## type USBDescriptor
-
-```go
-type USBDescriptor struct {
-	Device		[]byte
-	Configuration	[]byte
-	HID		map[uint16][]byte
+type USBDevice struct {
+	initcomplete bool
 }
 ```
 
 
 
 
-### func (*USBDescriptor) Configure
+### func (*USBDevice) Configure
 
 ```go
-func (d *USBDescriptor) Configure(idVendor, idProduct uint16)
+func (dev *USBDevice) Configure(config UARTConfig)
 ```
 
+Configure the USB peripheral. The config is here for compatibility with the UART interface.
 
 
 

--- a/content/docs/reference/microcontrollers/machine/hifive1b.md
+++ b/content/docs/reference/microcontrollers/machine/hifive1b.md
@@ -279,6 +279,14 @@ func CPUFrequency() uint32
 
 
 
+### func InitSerial
+
+```go
+func InitSerial()
+```
+
+
+
 ### func NewRingBuffer
 
 ```go

--- a/content/docs/reference/microcontrollers/machine/itsybitsy-m0.md
+++ b/content/docs/reference/microcontrollers/machine/itsybitsy-m0.md
@@ -398,15 +398,6 @@ The SAM D21 has three TCC peripherals, which have PWM as one feature.
 
 ```go
 var (
-	USB		= &USBCDC{Buffer: NewRingBuffer()}
-	waitHidTxc	bool
-)
-```
-
-
-
-```go
-var (
 	DAC0 = DAC{}
 )
 ```
@@ -422,10 +413,28 @@ var (
 
 
 ```go
-var Serial = USB
+var Serial Serialer
 ```
 
 Serial is implemented via USB (USB-CDC).
+
+
+```go
+var (
+	USBDev	= &USBDevice{}
+	USBCDC	Serialer
+)
+```
+
+
+
+```go
+var (
+	ErrUSBReadTimeout	= errors.New("USB read timeout")
+	ErrUSBBytesRead		= errors.New("USB invalid number of bytes read")
+)
+```
+
 
 
 
@@ -440,13 +449,40 @@ func CPUFrequency() uint32
 Return the current CPU frequency in hertz.
 
 
+### func EnableCDC
+
+```go
+func EnableCDC(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
+```
+
+
+
 ### func EnableHID
 
 ```go
-func EnableHID(callback func())
+func EnableHID(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
 ```
 
 EnableHID enables HID. This function must be executed from the init().
+
+
+### func EnableMIDI
+
+```go
+func EnableMIDI(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
+```
+
+EnableMIDI enables MIDI. This function must be executed from the init().
+
+
+### func EnterBootloader
+
+```go
+func EnterBootloader()
+```
+
+EnterBootloader should perform a system reset in preperation
+to switch to the bootloader to flash new firmware.
 
 
 ### func InitADC
@@ -458,6 +494,14 @@ func InitADC()
 InitADC initializes the ADC.
 
 
+### func InitSerial
+
+```go
+func InitSerial()
+```
+
+
+
 ### func NewRingBuffer
 
 ```go
@@ -467,23 +511,29 @@ func NewRingBuffer() *RingBuffer
 NewRingBuffer returns a new ring buffer.
 
 
-### func ResetProcessor
+### func ReceiveUSBControlPacket
 
 ```go
-func ResetProcessor()
+func ReceiveUSBControlPacket() ([cdcLineInfoSize]byte, error)
 ```
 
-ResetProcessor should perform a system reset in preperation
-to switch to the bootloader to flash new firmware.
 
 
-### func SendUSBHIDPacket
+### func SendUSBInPacket
 
 ```go
-func SendUSBHIDPacket(ep uint32, data []byte) bool
+func SendUSBInPacket(ep uint32, data []byte) bool
 ```
 
-SendUSBHIDPacket sends a packet for USBHID (interrupt / in).
+SendUSBInPacket sends a packet for USB (interrupt in / bulk in).
+
+
+### func SendZlp
+
+```go
+func SendZlp()
+```
+
 
 
 
@@ -1153,6 +1203,25 @@ SPIConfig is used to store config info for SPI.
 
 
 
+## type Serialer
+
+```go
+type Serialer interface {
+	WriteByte(c byte) error
+	Write(data []byte) (n int, err error)
+	Configure(config UARTConfig) error
+	Buffered() int
+	ReadByte() (byte, error)
+	DTR() bool
+	RTS() bool
+}
+```
+
+
+
+
+
+
 ## type TCC
 
 ```go
@@ -1387,143 +1456,24 @@ UARTParity is the parity setting to be used for UART communication.
 
 
 
-## type USBCDC
+## type USBDevice
 
 ```go
-type USBCDC struct {
-	Buffer			*RingBuffer
-	TxIdx			volatile.Register8
-	waitTxc			bool
-	waitTxcRetryCount	uint8
-	sent			bool
-	configured		bool
-}
-```
-
-USBCDC is the USB CDC aka serial over USB interface on the SAMD21.
-
-
-
-### func (*USBCDC) Buffered
-
-```go
-func (usbcdc *USBCDC) Buffered() int
-```
-
-Buffered returns the number of bytes currently stored in the RX buffer.
-
-
-### func (*USBCDC) Configure
-
-```go
-func (usbcdc *USBCDC) Configure(config UARTConfig)
-```
-
-Configure the USB CDC interface. The config is here for compatibility with the UART interface.
-
-
-### func (*USBCDC) Configured
-
-```go
-func (usbcdc *USBCDC) Configured() bool
-```
-
-Configured returns whether usbcdc is configured or not.
-
-
-### func (*USBCDC) DTR
-
-```go
-func (usbcdc *USBCDC) DTR() bool
-```
-
-
-
-### func (*USBCDC) Flush
-
-```go
-func (usbcdc *USBCDC) Flush() error
-```
-
-Flush flushes buffered data.
-
-
-### func (*USBCDC) RTS
-
-```go
-func (usbcdc *USBCDC) RTS() bool
-```
-
-
-
-### func (*USBCDC) Read
-
-```go
-func (usbcdc *USBCDC) Read(data []byte) (n int, err error)
-```
-
-Read from the RX buffer.
-
-
-### func (*USBCDC) ReadByte
-
-```go
-func (usbcdc *USBCDC) ReadByte() (byte, error)
-```
-
-ReadByte reads a single byte from the RX buffer.
-If there is no data in the buffer, returns an error.
-
-
-### func (*USBCDC) Receive
-
-```go
-func (usbcdc *USBCDC) Receive(data byte)
-```
-
-Receive handles adding data to the UART's data buffer.
-Usually called by the IRQ handler for a machine.
-
-
-### func (*USBCDC) Write
-
-```go
-func (usbcdc *USBCDC) Write(data []byte) (n int, err error)
-```
-
-Write data to the USBCDC.
-
-
-### func (*USBCDC) WriteByte
-
-```go
-func (usbcdc *USBCDC) WriteByte(c byte) error
-```
-
-WriteByte writes a byte of data to the USB CDC interface.
-
-
-
-
-## type USBDescriptor
-
-```go
-type USBDescriptor struct {
-	Device		[]byte
-	Configuration	[]byte
-	HID		map[uint16][]byte
+type USBDevice struct {
+	initcomplete bool
 }
 ```
 
 
 
 
-### func (*USBDescriptor) Configure
+### func (*USBDevice) Configure
 
 ```go
-func (d *USBDescriptor) Configure(idVendor, idProduct uint16)
+func (dev *USBDevice) Configure(config UARTConfig)
 ```
 
+Configure the USB peripheral. The config is here for compatibility with the UART interface.
 
 
 

--- a/content/docs/reference/microcontrollers/machine/itsybitsy-m4.md
+++ b/content/docs/reference/microcontrollers/machine/itsybitsy-m4.md
@@ -473,16 +473,6 @@ var (
 
 ```go
 var (
-	// USB is a USB CDC interface.
-	USB		= &USBCDC{Buffer: NewRingBuffer()}
-	waitHidTxc	bool
-)
-```
-
-
-
-```go
-var (
 	DAC0 = DAC{}
 )
 ```
@@ -509,10 +499,28 @@ var (
 
 
 ```go
-var Serial = USB
+var Serial Serialer
 ```
 
 Serial is implemented via USB (USB-CDC).
+
+
+```go
+var (
+	USBDev	= &USBDevice{}
+	USBCDC	Serialer
+)
+```
+
+
+
+```go
+var (
+	ErrUSBReadTimeout	= errors.New("USB read timeout")
+	ErrUSBBytesRead		= errors.New("USB invalid number of bytes read")
+)
+```
+
 
 
 
@@ -526,13 +534,40 @@ func CPUFrequency() uint32
 
 
 
+### func EnableCDC
+
+```go
+func EnableCDC(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
+```
+
+
+
 ### func EnableHID
 
 ```go
-func EnableHID(callback func())
+func EnableHID(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
 ```
 
 EnableHID enables HID. This function must be executed from the init().
+
+
+### func EnableMIDI
+
+```go
+func EnableMIDI(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
+```
+
+EnableMIDI enables MIDI. This function must be executed from the init().
+
+
+### func EnterBootloader
+
+```go
+func EnterBootloader()
+```
+
+EnterBootloader should perform a system reset in preparation
+to switch to the bootloader to flash new firmware.
 
 
 ### func GetRNG
@@ -553,6 +588,14 @@ func InitADC()
 InitADC initializes the ADC.
 
 
+### func InitSerial
+
+```go
+func InitSerial()
+```
+
+
+
 ### func NewRingBuffer
 
 ```go
@@ -562,23 +605,29 @@ func NewRingBuffer() *RingBuffer
 NewRingBuffer returns a new ring buffer.
 
 
-### func ResetProcessor
+### func ReceiveUSBControlPacket
 
 ```go
-func ResetProcessor()
+func ReceiveUSBControlPacket() ([cdcLineInfoSize]byte, error)
 ```
 
-ResetProcessor should perform a system reset in preparation
-to switch to the bootloader to flash new firmware.
 
 
-### func SendUSBHIDPacket
+### func SendUSBInPacket
 
 ```go
-func SendUSBHIDPacket(ep uint32, data []byte) bool
+func SendUSBInPacket(ep uint32, data []byte) bool
 ```
 
-SendUSBHIDPacket sends a packet for USBHID (interrupt / in).
+SendUSBInPacket sends a packet for USB (interrupt in / bulk in).
+
+
+### func SendZlp
+
+```go
+func SendZlp()
+```
+
 
 
 
@@ -1205,6 +1254,25 @@ SPIConfig is used to store config info for SPI.
 
 
 
+## type Serialer
+
+```go
+type Serialer interface {
+	WriteByte(c byte) error
+	Write(data []byte) (n int, err error)
+	Configure(config UARTConfig) error
+	Buffered() int
+	ReadByte() (byte, error)
+	DTR() bool
+	RTS() bool
+}
+```
+
+
+
+
+
+
 ## type TCC
 
 ```go
@@ -1438,143 +1506,24 @@ UARTParity is the parity setting to be used for UART communication.
 
 
 
-## type USBCDC
+## type USBDevice
 
 ```go
-type USBCDC struct {
-	Buffer			*RingBuffer
-	TxIdx			volatile.Register8
-	waitTxc			bool
-	waitTxcRetryCount	uint8
-	sent			bool
-	configured		bool
-}
-```
-
-USBCDC is the USB CDC aka serial over USB interface on the SAMD21.
-
-
-
-### func (*USBCDC) Buffered
-
-```go
-func (usbcdc *USBCDC) Buffered() int
-```
-
-Buffered returns the number of bytes currently stored in the RX buffer.
-
-
-### func (*USBCDC) Configure
-
-```go
-func (usbcdc *USBCDC) Configure(config UARTConfig)
-```
-
-Configure the USB CDC interface. The config is here for compatibility with the UART interface.
-
-
-### func (*USBCDC) Configured
-
-```go
-func (usbcdc *USBCDC) Configured() bool
-```
-
-Configured returns whether usbcdc is configured or not.
-
-
-### func (*USBCDC) DTR
-
-```go
-func (usbcdc *USBCDC) DTR() bool
-```
-
-
-
-### func (*USBCDC) Flush
-
-```go
-func (usbcdc *USBCDC) Flush() error
-```
-
-Flush flushes buffered data.
-
-
-### func (*USBCDC) RTS
-
-```go
-func (usbcdc *USBCDC) RTS() bool
-```
-
-
-
-### func (*USBCDC) Read
-
-```go
-func (usbcdc *USBCDC) Read(data []byte) (n int, err error)
-```
-
-Read from the RX buffer.
-
-
-### func (*USBCDC) ReadByte
-
-```go
-func (usbcdc *USBCDC) ReadByte() (byte, error)
-```
-
-ReadByte reads a single byte from the RX buffer.
-If there is no data in the buffer, returns an error.
-
-
-### func (*USBCDC) Receive
-
-```go
-func (usbcdc *USBCDC) Receive(data byte)
-```
-
-Receive handles adding data to the UART's data buffer.
-Usually called by the IRQ handler for a machine.
-
-
-### func (*USBCDC) Write
-
-```go
-func (usbcdc *USBCDC) Write(data []byte) (n int, err error)
-```
-
-Write data to the USBCDC.
-
-
-### func (*USBCDC) WriteByte
-
-```go
-func (usbcdc *USBCDC) WriteByte(c byte) error
-```
-
-WriteByte writes a byte of data to the USB CDC interface.
-
-
-
-
-## type USBDescriptor
-
-```go
-type USBDescriptor struct {
-	Device		[]byte
-	Configuration	[]byte
-	HID		map[uint16][]byte
+type USBDevice struct {
+	initcomplete bool
 }
 ```
 
 
 
 
-### func (*USBDescriptor) Configure
+### func (*USBDevice) Configure
 
 ```go
-func (d *USBDescriptor) Configure(idVendor, idProduct uint16)
+func (dev *USBDevice) Configure(config UARTConfig)
 ```
 
+Configure the USB peripheral. The config is here for compatibility with the UART interface.
 
 
 

--- a/content/docs/reference/microcontrollers/machine/itsybitsy-nrf52840.md
+++ b/content/docs/reference/microcontrollers/machine/itsybitsy-nrf52840.md
@@ -319,40 +319,6 @@ PWM
 
 ```go
 var (
-	USB		= &_USB
-	_USB		= USBCDC{Buffer: NewRingBuffer()}
-	waitHidTxc	bool
-
-	usbEndpointDescriptors	[8]usbDeviceDescriptor
-
-	udd_ep_in_cache_buffer	[7][128]uint8
-	udd_ep_out_cache_buffer	[7][128]uint8
-
-	sendOnEP0DATADONE	struct {
-		ptr	*byte
-		count	int
-	}
-	isEndpointHalt		= false
-	isRemoteWakeUpEnabled	= false
-	endPoints		= []uint32{usb_ENDPOINT_TYPE_CONTROL,
-		(usb_ENDPOINT_TYPE_INTERRUPT | usbEndpointIn),
-		(usb_ENDPOINT_TYPE_BULK | usbEndpointOut),
-		(usb_ENDPOINT_TYPE_BULK | usbEndpointIn)}
-
-	usbConfiguration		uint8
-	usbSetInterface			uint8
-	usbLineInfo			= cdcLineInfo{115200, 0x00, 0x00, 0x08, 0x00}
-	epinen				uint32
-	epouten				uint32
-	easyDMABusy			volatile.Register8
-	epout0data_setlinecoding	bool
-)
-```
-
-
-
-```go
-var (
 	SPI0	= SPI{Bus: nrf.SPIM0, buf: new([1]byte)}
 	SPI1	= SPI{Bus: nrf.SPIM1, buf: new([1]byte)}
 	SPI2	= SPI{Bus: nrf.SPIM2, buf: new([1]byte)}
@@ -371,10 +337,28 @@ var (
 
 
 ```go
-var Serial = USB
+var Serial Serialer
 ```
 
 Serial is implemented via USB (USB-CDC).
+
+
+```go
+var (
+	USBDev	= &USBDevice{}
+	USBCDC	Serialer
+)
+```
+
+
+
+```go
+var (
+	ErrUSBReadTimeout	= errors.New("USB read timeout")
+	ErrUSBBytesRead		= errors.New("USB invalid number of bytes read")
+)
+```
+
 
 
 
@@ -388,13 +372,40 @@ func CPUFrequency() uint32
 
 
 
+### func EnableCDC
+
+```go
+func EnableCDC(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
+```
+
+
+
 ### func EnableHID
 
 ```go
-func EnableHID(callback func())
+func EnableHID(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
 ```
 
 EnableHID enables HID. This function must be executed from the init().
+
+
+### func EnableMIDI
+
+```go
+func EnableMIDI(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
+```
+
+EnableMIDI enables MIDI. This function must be executed from the init().
+
+
+### func EnterBootloader
+
+```go
+func EnterBootloader()
+```
+
+EnterBootloader resets the chip into the UF2 bootloader. After reset, it
+can be flashed via nrfutil or by copying a UF2 file to the mass storage device
 
 
 ### func EnterOTABootloader
@@ -436,6 +447,14 @@ func InitADC()
 InitADC initializes the registers needed for ADC.
 
 
+### func InitSerial
+
+```go
+func InitSerial()
+```
+
+
+
 ### func NewRingBuffer
 
 ```go
@@ -445,13 +464,29 @@ func NewRingBuffer() *RingBuffer
 NewRingBuffer returns a new ring buffer.
 
 
-### func SendUSBHIDPacket
+### func ReceiveUSBControlPacket
 
 ```go
-func SendUSBHIDPacket(ep uint32, data []byte) bool
+func ReceiveUSBControlPacket() ([cdcLineInfoSize]byte, error)
 ```
 
-SendUSBHIDPacket sends a packet for USBHID (interrupt / in).
+
+
+### func SendUSBInPacket
+
+```go
+func SendUSBInPacket(ep uint32, data []byte) bool
+```
+
+SendUSBInPacket sends a packet for USBHID (interrupt in / bulk in).
+
+
+### func SendZlp
+
+```go
+func SendZlp()
+```
+
 
 
 
@@ -1028,6 +1063,25 @@ SPIConfig is used to store config info for SPI.
 
 
 
+## type Serialer
+
+```go
+type Serialer interface {
+	WriteByte(c byte) error
+	Write(data []byte) (n int, err error)
+	Configure(config UARTConfig) error
+	Buffered() int
+	ReadByte() (byte, error)
+	DTR() bool
+	RTS() bool
+}
+```
+
+
+
+
+
+
 ## type UART
 
 ```go
@@ -1146,135 +1200,24 @@ UARTParity is the parity setting to be used for UART communication.
 
 
 
-## type USBCDC
+## type USBDevice
 
 ```go
-type USBCDC struct {
-	Buffer			*RingBuffer
-	interrupt		interrupt.Interrupt
-	initcomplete		bool
-	TxIdx			volatile.Register8
-	waitTxc			bool
-	waitTxcRetryCount	uint8
-	sent			bool
-}
-```
-
-USBCDC is the USB CDC aka serial over USB interface on the nRF52840
-
-
-
-### func (*USBCDC) Buffered
-
-```go
-func (usbcdc *USBCDC) Buffered() int
-```
-
-Buffered returns the number of bytes currently stored in the RX buffer.
-
-
-### func (*USBCDC) Configure
-
-```go
-func (usbcdc *USBCDC) Configure(config UARTConfig)
-```
-
-Configure the USB CDC interface. The config is here for compatibility with the UART interface.
-
-
-### func (*USBCDC) DTR
-
-```go
-func (usbcdc *USBCDC) DTR() bool
-```
-
-
-
-### func (*USBCDC) Flush
-
-```go
-func (usbcdc *USBCDC) Flush() error
-```
-
-Flush flushes buffered data.
-
-
-### func (*USBCDC) RTS
-
-```go
-func (usbcdc *USBCDC) RTS() bool
-```
-
-
-
-### func (*USBCDC) Read
-
-```go
-func (usbcdc *USBCDC) Read(data []byte) (n int, err error)
-```
-
-Read from the RX buffer.
-
-
-### func (*USBCDC) ReadByte
-
-```go
-func (usbcdc *USBCDC) ReadByte() (byte, error)
-```
-
-ReadByte reads a single byte from the RX buffer.
-If there is no data in the buffer, returns an error.
-
-
-### func (*USBCDC) Receive
-
-```go
-func (usbcdc *USBCDC) Receive(data byte)
-```
-
-Receive handles adding data to the UART's data buffer.
-Usually called by the IRQ handler for a machine.
-
-
-### func (*USBCDC) Write
-
-```go
-func (usbcdc *USBCDC) Write(data []byte) (n int, err error)
-```
-
-Write data to the USBCDC.
-
-
-### func (*USBCDC) WriteByte
-
-```go
-func (usbcdc *USBCDC) WriteByte(c byte) error
-```
-
-WriteByte writes a byte of data to the USB CDC interface.
-
-
-
-
-## type USBDescriptor
-
-```go
-type USBDescriptor struct {
-	Device		[]byte
-	Configuration	[]byte
-	HID		map[uint16][]byte
+type USBDevice struct {
+	initcomplete bool
 }
 ```
 
 
 
 
-### func (*USBDescriptor) Configure
+### func (*USBDevice) Configure
 
 ```go
-func (d *USBDescriptor) Configure(idVendor, idProduct uint16)
+func (dev *USBDevice) Configure(config UARTConfig)
 ```
 
+Configure the USB peripheral. The config is here for compatibility with the UART interface.
 
 
 

--- a/content/docs/reference/microcontrollers/machine/lgt92.md
+++ b/content/docs/reference/microcontrollers/machine/lgt92.md
@@ -567,6 +567,14 @@ func GetRNG() (uint32, error)
 GetRNG returns 32 bits of cryptographically secure random data
 
 
+### func InitSerial
+
+```go
+func InitSerial()
+```
+
+
+
 ### func NewRingBuffer
 
 ```go

--- a/content/docs/reference/microcontrollers/machine/lorae5.md
+++ b/content/docs/reference/microcontrollers/machine/lorae5.md
@@ -429,6 +429,14 @@ func GetRNG() (uint32, error)
 GetRNG returns 32 bits of cryptographically secure random data
 
 
+### func InitSerial
+
+```go
+func InitSerial()
+```
+
+
+
 ### func NewRingBuffer
 
 ```go

--- a/content/docs/reference/microcontrollers/machine/m5stack-core2.md
+++ b/content/docs/reference/microcontrollers/machine/m5stack-core2.md
@@ -257,6 +257,14 @@ CPUFrequency returns the current CPU frequency of the chip.
 Currently it is a fixed frequency but it may allow changing in the future.
 
 
+### func InitSerial
+
+```go
+func InitSerial()
+```
+
+
+
 ### func NewRingBuffer
 
 ```go

--- a/content/docs/reference/microcontrollers/machine/m5stack.md
+++ b/content/docs/reference/microcontrollers/machine/m5stack.md
@@ -276,6 +276,14 @@ CPUFrequency returns the current CPU frequency of the chip.
 Currently it is a fixed frequency but it may allow changing in the future.
 
 
+### func InitSerial
+
+```go
+func InitSerial()
+```
+
+
+
 ### func NewRingBuffer
 
 ```go

--- a/content/docs/reference/microcontrollers/machine/m5stamp-c3.md
+++ b/content/docs/reference/microcontrollers/machine/m5stamp-c3.md
@@ -200,6 +200,14 @@ CPUFrequency returns the current CPU frequency of the chip.
 Currently it is a fixed frequency but it may allow changing in the future.
 
 
+### func InitSerial
+
+```go
+func InitSerial()
+```
+
+
+
 ### func NewRingBuffer
 
 ```go

--- a/content/docs/reference/microcontrollers/machine/maixbit.md
+++ b/content/docs/reference/microcontrollers/machine/maixbit.md
@@ -590,6 +590,14 @@ func CPUFrequency() uint32
 
 
 
+### func InitSerial
+
+```go
+func InitSerial()
+```
+
+
+
 ### func NewRingBuffer
 
 ```go

--- a/content/docs/reference/microcontrollers/machine/matrixportal-m4.md
+++ b/content/docs/reference/microcontrollers/machine/matrixportal-m4.md
@@ -587,16 +587,6 @@ var (
 
 ```go
 var (
-	// USB is a USB CDC interface.
-	USB		= &USBCDC{Buffer: NewRingBuffer()}
-	waitHidTxc	bool
-)
-```
-
-
-
-```go
-var (
 	DAC0 = DAC{}
 )
 ```
@@ -625,10 +615,28 @@ var (
 
 
 ```go
-var Serial = USB
+var Serial Serialer
 ```
 
 Serial is implemented via USB (USB-CDC).
+
+
+```go
+var (
+	USBDev	= &USBDevice{}
+	USBCDC	Serialer
+)
+```
+
+
+
+```go
+var (
+	ErrUSBReadTimeout	= errors.New("USB read timeout")
+	ErrUSBBytesRead		= errors.New("USB invalid number of bytes read")
+)
+```
+
 
 
 
@@ -642,13 +650,40 @@ func CPUFrequency() uint32
 
 
 
+### func EnableCDC
+
+```go
+func EnableCDC(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
+```
+
+
+
 ### func EnableHID
 
 ```go
-func EnableHID(callback func())
+func EnableHID(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
 ```
 
 EnableHID enables HID. This function must be executed from the init().
+
+
+### func EnableMIDI
+
+```go
+func EnableMIDI(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
+```
+
+EnableMIDI enables MIDI. This function must be executed from the init().
+
+
+### func EnterBootloader
+
+```go
+func EnterBootloader()
+```
+
+EnterBootloader should perform a system reset in preparation
+to switch to the bootloader to flash new firmware.
 
 
 ### func GetRNG
@@ -669,6 +704,14 @@ func InitADC()
 InitADC initializes the ADC.
 
 
+### func InitSerial
+
+```go
+func InitSerial()
+```
+
+
+
 ### func NewRingBuffer
 
 ```go
@@ -678,23 +721,29 @@ func NewRingBuffer() *RingBuffer
 NewRingBuffer returns a new ring buffer.
 
 
-### func ResetProcessor
+### func ReceiveUSBControlPacket
 
 ```go
-func ResetProcessor()
+func ReceiveUSBControlPacket() ([cdcLineInfoSize]byte, error)
 ```
 
-ResetProcessor should perform a system reset in preparation
-to switch to the bootloader to flash new firmware.
 
 
-### func SendUSBHIDPacket
+### func SendUSBInPacket
 
 ```go
-func SendUSBHIDPacket(ep uint32, data []byte) bool
+func SendUSBInPacket(ep uint32, data []byte) bool
 ```
 
-SendUSBHIDPacket sends a packet for USBHID (interrupt / in).
+SendUSBInPacket sends a packet for USB (interrupt in / bulk in).
+
+
+### func SendZlp
+
+```go
+func SendZlp()
+```
+
 
 
 
@@ -1321,6 +1370,25 @@ SPIConfig is used to store config info for SPI.
 
 
 
+## type Serialer
+
+```go
+type Serialer interface {
+	WriteByte(c byte) error
+	Write(data []byte) (n int, err error)
+	Configure(config UARTConfig) error
+	Buffered() int
+	ReadByte() (byte, error)
+	DTR() bool
+	RTS() bool
+}
+```
+
+
+
+
+
+
 ## type TCC
 
 ```go
@@ -1554,143 +1622,24 @@ UARTParity is the parity setting to be used for UART communication.
 
 
 
-## type USBCDC
+## type USBDevice
 
 ```go
-type USBCDC struct {
-	Buffer			*RingBuffer
-	TxIdx			volatile.Register8
-	waitTxc			bool
-	waitTxcRetryCount	uint8
-	sent			bool
-	configured		bool
-}
-```
-
-USBCDC is the USB CDC aka serial over USB interface on the SAMD21.
-
-
-
-### func (*USBCDC) Buffered
-
-```go
-func (usbcdc *USBCDC) Buffered() int
-```
-
-Buffered returns the number of bytes currently stored in the RX buffer.
-
-
-### func (*USBCDC) Configure
-
-```go
-func (usbcdc *USBCDC) Configure(config UARTConfig)
-```
-
-Configure the USB CDC interface. The config is here for compatibility with the UART interface.
-
-
-### func (*USBCDC) Configured
-
-```go
-func (usbcdc *USBCDC) Configured() bool
-```
-
-Configured returns whether usbcdc is configured or not.
-
-
-### func (*USBCDC) DTR
-
-```go
-func (usbcdc *USBCDC) DTR() bool
-```
-
-
-
-### func (*USBCDC) Flush
-
-```go
-func (usbcdc *USBCDC) Flush() error
-```
-
-Flush flushes buffered data.
-
-
-### func (*USBCDC) RTS
-
-```go
-func (usbcdc *USBCDC) RTS() bool
-```
-
-
-
-### func (*USBCDC) Read
-
-```go
-func (usbcdc *USBCDC) Read(data []byte) (n int, err error)
-```
-
-Read from the RX buffer.
-
-
-### func (*USBCDC) ReadByte
-
-```go
-func (usbcdc *USBCDC) ReadByte() (byte, error)
-```
-
-ReadByte reads a single byte from the RX buffer.
-If there is no data in the buffer, returns an error.
-
-
-### func (*USBCDC) Receive
-
-```go
-func (usbcdc *USBCDC) Receive(data byte)
-```
-
-Receive handles adding data to the UART's data buffer.
-Usually called by the IRQ handler for a machine.
-
-
-### func (*USBCDC) Write
-
-```go
-func (usbcdc *USBCDC) Write(data []byte) (n int, err error)
-```
-
-Write data to the USBCDC.
-
-
-### func (*USBCDC) WriteByte
-
-```go
-func (usbcdc *USBCDC) WriteByte(c byte) error
-```
-
-WriteByte writes a byte of data to the USB CDC interface.
-
-
-
-
-## type USBDescriptor
-
-```go
-type USBDescriptor struct {
-	Device		[]byte
-	Configuration	[]byte
-	HID		map[uint16][]byte
+type USBDevice struct {
+	initcomplete bool
 }
 ```
 
 
 
 
-### func (*USBDescriptor) Configure
+### func (*USBDevice) Configure
 
 ```go
-func (d *USBDescriptor) Configure(idVendor, idProduct uint16)
+func (dev *USBDevice) Configure(config UARTConfig)
 ```
 
+Configure the USB peripheral. The config is here for compatibility with the UART interface.
 
 
 

--- a/content/docs/reference/microcontrollers/machine/metro-m4-airlift.md
+++ b/content/docs/reference/microcontrollers/machine/metro-m4-airlift.md
@@ -515,16 +515,6 @@ var (
 
 ```go
 var (
-	// USB is a USB CDC interface.
-	USB		= &USBCDC{Buffer: NewRingBuffer()}
-	waitHidTxc	bool
-)
-```
-
-
-
-```go
-var (
 	DAC0 = DAC{}
 )
 ```
@@ -553,10 +543,28 @@ var (
 
 
 ```go
-var Serial = USB
+var Serial Serialer
 ```
 
 Serial is implemented via USB (USB-CDC).
+
+
+```go
+var (
+	USBDev	= &USBDevice{}
+	USBCDC	Serialer
+)
+```
+
+
+
+```go
+var (
+	ErrUSBReadTimeout	= errors.New("USB read timeout")
+	ErrUSBBytesRead		= errors.New("USB invalid number of bytes read")
+)
+```
+
 
 
 
@@ -570,13 +578,40 @@ func CPUFrequency() uint32
 
 
 
+### func EnableCDC
+
+```go
+func EnableCDC(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
+```
+
+
+
 ### func EnableHID
 
 ```go
-func EnableHID(callback func())
+func EnableHID(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
 ```
 
 EnableHID enables HID. This function must be executed from the init().
+
+
+### func EnableMIDI
+
+```go
+func EnableMIDI(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
+```
+
+EnableMIDI enables MIDI. This function must be executed from the init().
+
+
+### func EnterBootloader
+
+```go
+func EnterBootloader()
+```
+
+EnterBootloader should perform a system reset in preparation
+to switch to the bootloader to flash new firmware.
 
 
 ### func GetRNG
@@ -597,6 +632,14 @@ func InitADC()
 InitADC initializes the ADC.
 
 
+### func InitSerial
+
+```go
+func InitSerial()
+```
+
+
+
 ### func NewRingBuffer
 
 ```go
@@ -606,23 +649,29 @@ func NewRingBuffer() *RingBuffer
 NewRingBuffer returns a new ring buffer.
 
 
-### func ResetProcessor
+### func ReceiveUSBControlPacket
 
 ```go
-func ResetProcessor()
+func ReceiveUSBControlPacket() ([cdcLineInfoSize]byte, error)
 ```
 
-ResetProcessor should perform a system reset in preparation
-to switch to the bootloader to flash new firmware.
 
 
-### func SendUSBHIDPacket
+### func SendUSBInPacket
 
 ```go
-func SendUSBHIDPacket(ep uint32, data []byte) bool
+func SendUSBInPacket(ep uint32, data []byte) bool
 ```
 
-SendUSBHIDPacket sends a packet for USBHID (interrupt / in).
+SendUSBInPacket sends a packet for USB (interrupt in / bulk in).
+
+
+### func SendZlp
+
+```go
+func SendZlp()
+```
+
 
 
 
@@ -1249,6 +1298,25 @@ SPIConfig is used to store config info for SPI.
 
 
 
+## type Serialer
+
+```go
+type Serialer interface {
+	WriteByte(c byte) error
+	Write(data []byte) (n int, err error)
+	Configure(config UARTConfig) error
+	Buffered() int
+	ReadByte() (byte, error)
+	DTR() bool
+	RTS() bool
+}
+```
+
+
+
+
+
+
 ## type TCC
 
 ```go
@@ -1482,143 +1550,24 @@ UARTParity is the parity setting to be used for UART communication.
 
 
 
-## type USBCDC
+## type USBDevice
 
 ```go
-type USBCDC struct {
-	Buffer			*RingBuffer
-	TxIdx			volatile.Register8
-	waitTxc			bool
-	waitTxcRetryCount	uint8
-	sent			bool
-	configured		bool
-}
-```
-
-USBCDC is the USB CDC aka serial over USB interface on the SAMD21.
-
-
-
-### func (*USBCDC) Buffered
-
-```go
-func (usbcdc *USBCDC) Buffered() int
-```
-
-Buffered returns the number of bytes currently stored in the RX buffer.
-
-
-### func (*USBCDC) Configure
-
-```go
-func (usbcdc *USBCDC) Configure(config UARTConfig)
-```
-
-Configure the USB CDC interface. The config is here for compatibility with the UART interface.
-
-
-### func (*USBCDC) Configured
-
-```go
-func (usbcdc *USBCDC) Configured() bool
-```
-
-Configured returns whether usbcdc is configured or not.
-
-
-### func (*USBCDC) DTR
-
-```go
-func (usbcdc *USBCDC) DTR() bool
-```
-
-
-
-### func (*USBCDC) Flush
-
-```go
-func (usbcdc *USBCDC) Flush() error
-```
-
-Flush flushes buffered data.
-
-
-### func (*USBCDC) RTS
-
-```go
-func (usbcdc *USBCDC) RTS() bool
-```
-
-
-
-### func (*USBCDC) Read
-
-```go
-func (usbcdc *USBCDC) Read(data []byte) (n int, err error)
-```
-
-Read from the RX buffer.
-
-
-### func (*USBCDC) ReadByte
-
-```go
-func (usbcdc *USBCDC) ReadByte() (byte, error)
-```
-
-ReadByte reads a single byte from the RX buffer.
-If there is no data in the buffer, returns an error.
-
-
-### func (*USBCDC) Receive
-
-```go
-func (usbcdc *USBCDC) Receive(data byte)
-```
-
-Receive handles adding data to the UART's data buffer.
-Usually called by the IRQ handler for a machine.
-
-
-### func (*USBCDC) Write
-
-```go
-func (usbcdc *USBCDC) Write(data []byte) (n int, err error)
-```
-
-Write data to the USBCDC.
-
-
-### func (*USBCDC) WriteByte
-
-```go
-func (usbcdc *USBCDC) WriteByte(c byte) error
-```
-
-WriteByte writes a byte of data to the USB CDC interface.
-
-
-
-
-## type USBDescriptor
-
-```go
-type USBDescriptor struct {
-	Device		[]byte
-	Configuration	[]byte
-	HID		map[uint16][]byte
+type USBDevice struct {
+	initcomplete bool
 }
 ```
 
 
 
 
-### func (*USBDescriptor) Configure
+### func (*USBDevice) Configure
 
 ```go
-func (d *USBDescriptor) Configure(idVendor, idProduct uint16)
+func (dev *USBDevice) Configure(config UARTConfig)
 ```
 
+Configure the USB peripheral. The config is here for compatibility with the UART interface.
 
 
 

--- a/content/docs/reference/microcontrollers/machine/microbit.md
+++ b/content/docs/reference/microcontrollers/machine/microbit.md
@@ -269,6 +269,14 @@ func CPUFrequency() uint32
 
 
 
+### func InitSerial
+
+```go
+func InitSerial()
+```
+
+
+
 ### func NewRingBuffer
 
 ```go

--- a/content/docs/reference/microcontrollers/machine/nano-33-ble.md
+++ b/content/docs/reference/microcontrollers/machine/nano-33-ble.md
@@ -232,7 +232,11 @@ Pin change interrupt constants for SetInterrupt.
 
 
 ```go
-const DFU_MAGIC_SERIAL_ONLY_RESET = 0xb0
+const (
+	DFU_MAGIC_SERIAL_ONLY_RESET	= 0x4e
+	DFU_MAGIC_UF2_RESET		= 0x57
+	DFU_MAGIC_OTA_RESET		= 0xA8
+)
 ```
 
 
@@ -316,40 +320,6 @@ PWM
 
 ```go
 var (
-	USB		= &_USB
-	_USB		= USBCDC{Buffer: NewRingBuffer()}
-	waitHidTxc	bool
-
-	usbEndpointDescriptors	[8]usbDeviceDescriptor
-
-	udd_ep_in_cache_buffer	[7][128]uint8
-	udd_ep_out_cache_buffer	[7][128]uint8
-
-	sendOnEP0DATADONE	struct {
-		ptr	*byte
-		count	int
-	}
-	isEndpointHalt		= false
-	isRemoteWakeUpEnabled	= false
-	endPoints		= []uint32{usb_ENDPOINT_TYPE_CONTROL,
-		(usb_ENDPOINT_TYPE_INTERRUPT | usbEndpointIn),
-		(usb_ENDPOINT_TYPE_BULK | usbEndpointOut),
-		(usb_ENDPOINT_TYPE_BULK | usbEndpointIn)}
-
-	usbConfiguration		uint8
-	usbSetInterface			uint8
-	usbLineInfo			= cdcLineInfo{115200, 0x00, 0x00, 0x08, 0x00}
-	epinen				uint32
-	epouten				uint32
-	easyDMABusy			volatile.Register8
-	epout0data_setlinecoding	bool
-)
-```
-
-
-
-```go
-var (
 	SPI0	= SPI{Bus: nrf.SPIM0, buf: new([1]byte)}
 	SPI1	= SPI{Bus: nrf.SPIM1, buf: new([1]byte)}
 	SPI2	= SPI{Bus: nrf.SPIM2, buf: new([1]byte)}
@@ -368,10 +338,28 @@ var (
 
 
 ```go
-var Serial = USB
+var Serial Serialer
 ```
 
 Serial is implemented via USB (USB-CDC).
+
+
+```go
+var (
+	USBDev	= &USBDevice{}
+	USBCDC	Serialer
+)
+```
+
+
+
+```go
+var (
+	ErrUSBReadTimeout	= errors.New("USB read timeout")
+	ErrUSBBytesRead		= errors.New("USB invalid number of bytes read")
+)
+```
+
 
 
 
@@ -385,13 +373,50 @@ func CPUFrequency() uint32
 
 
 
+### func EnableCDC
+
+```go
+func EnableCDC(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
+```
+
+
+
 ### func EnableHID
 
 ```go
-func EnableHID(callback func())
+func EnableHID(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
 ```
 
 EnableHID enables HID. This function must be executed from the init().
+
+
+### func EnableMIDI
+
+```go
+func EnableMIDI(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
+```
+
+EnableMIDI enables MIDI. This function must be executed from the init().
+
+
+### func EnterBootloader
+
+```go
+func EnterBootloader()
+```
+
+EnterBootloader resets the chip into the serial bootloader. After
+reset, it can be flashed using serial/nrfutil.
+
+
+### func EnterOTABootloader
+
+```go
+func EnterOTABootloader()
+```
+
+EnterOTABootloader resets the chip into the bootloader so that it can be
+flashed via an OTA update
 
 
 ### func EnterSerialBootloader
@@ -404,6 +429,16 @@ EnterSerialBootloader resets the chip into the serial bootloader. After
 reset, it can be flashed using serial/nrfutil.
 
 
+### func EnterUF2Bootloader
+
+```go
+func EnterUF2Bootloader()
+```
+
+EnterUF2Bootloader resets the chip into the UF2 bootloader. After reset, it
+can be flashed via nrfutil or by copying a UF2 file to the mass storage device
+
+
 ### func InitADC
 
 ```go
@@ -411,6 +446,14 @@ func InitADC()
 ```
 
 InitADC initializes the registers needed for ADC.
+
+
+### func InitSerial
+
+```go
+func InitSerial()
+```
+
 
 
 ### func NewRingBuffer
@@ -422,13 +465,29 @@ func NewRingBuffer() *RingBuffer
 NewRingBuffer returns a new ring buffer.
 
 
-### func SendUSBHIDPacket
+### func ReceiveUSBControlPacket
 
 ```go
-func SendUSBHIDPacket(ep uint32, data []byte) bool
+func ReceiveUSBControlPacket() ([cdcLineInfoSize]byte, error)
 ```
 
-SendUSBHIDPacket sends a packet for USBHID (interrupt / in).
+
+
+### func SendUSBInPacket
+
+```go
+func SendUSBInPacket(ep uint32, data []byte) bool
+```
+
+SendUSBInPacket sends a packet for USBHID (interrupt in / bulk in).
+
+
+### func SendZlp
+
+```go
+func SendZlp()
+```
+
 
 
 
@@ -1005,6 +1064,25 @@ SPIConfig is used to store config info for SPI.
 
 
 
+## type Serialer
+
+```go
+type Serialer interface {
+	WriteByte(c byte) error
+	Write(data []byte) (n int, err error)
+	Configure(config UARTConfig) error
+	Buffered() int
+	ReadByte() (byte, error)
+	DTR() bool
+	RTS() bool
+}
+```
+
+
+
+
+
+
 ## type UART
 
 ```go
@@ -1123,135 +1201,24 @@ UARTParity is the parity setting to be used for UART communication.
 
 
 
-## type USBCDC
+## type USBDevice
 
 ```go
-type USBCDC struct {
-	Buffer			*RingBuffer
-	interrupt		interrupt.Interrupt
-	initcomplete		bool
-	TxIdx			volatile.Register8
-	waitTxc			bool
-	waitTxcRetryCount	uint8
-	sent			bool
-}
-```
-
-USBCDC is the USB CDC aka serial over USB interface on the nRF52840
-
-
-
-### func (*USBCDC) Buffered
-
-```go
-func (usbcdc *USBCDC) Buffered() int
-```
-
-Buffered returns the number of bytes currently stored in the RX buffer.
-
-
-### func (*USBCDC) Configure
-
-```go
-func (usbcdc *USBCDC) Configure(config UARTConfig)
-```
-
-Configure the USB CDC interface. The config is here for compatibility with the UART interface.
-
-
-### func (*USBCDC) DTR
-
-```go
-func (usbcdc *USBCDC) DTR() bool
-```
-
-
-
-### func (*USBCDC) Flush
-
-```go
-func (usbcdc *USBCDC) Flush() error
-```
-
-Flush flushes buffered data.
-
-
-### func (*USBCDC) RTS
-
-```go
-func (usbcdc *USBCDC) RTS() bool
-```
-
-
-
-### func (*USBCDC) Read
-
-```go
-func (usbcdc *USBCDC) Read(data []byte) (n int, err error)
-```
-
-Read from the RX buffer.
-
-
-### func (*USBCDC) ReadByte
-
-```go
-func (usbcdc *USBCDC) ReadByte() (byte, error)
-```
-
-ReadByte reads a single byte from the RX buffer.
-If there is no data in the buffer, returns an error.
-
-
-### func (*USBCDC) Receive
-
-```go
-func (usbcdc *USBCDC) Receive(data byte)
-```
-
-Receive handles adding data to the UART's data buffer.
-Usually called by the IRQ handler for a machine.
-
-
-### func (*USBCDC) Write
-
-```go
-func (usbcdc *USBCDC) Write(data []byte) (n int, err error)
-```
-
-Write data to the USBCDC.
-
-
-### func (*USBCDC) WriteByte
-
-```go
-func (usbcdc *USBCDC) WriteByte(c byte) error
-```
-
-WriteByte writes a byte of data to the USB CDC interface.
-
-
-
-
-## type USBDescriptor
-
-```go
-type USBDescriptor struct {
-	Device		[]byte
-	Configuration	[]byte
-	HID		map[uint16][]byte
+type USBDevice struct {
+	initcomplete bool
 }
 ```
 
 
 
 
-### func (*USBDescriptor) Configure
+### func (*USBDevice) Configure
 
 ```go
-func (d *USBDescriptor) Configure(idVendor, idProduct uint16)
+func (dev *USBDevice) Configure(config UARTConfig)
 ```
 
+Configure the USB peripheral. The config is here for compatibility with the UART interface.
 
 
 

--- a/content/docs/reference/microcontrollers/machine/nano-rp2040.md
+++ b/content/docs/reference/microcontrollers/machine/nano-rp2040.md
@@ -103,6 +103,18 @@ NINA-W102 Pins
 
 ```go
 const (
+	UART0_TX_PIN	= GPIO0
+	UART0_RX_PIN	= GPIO1
+	UART_TX_PIN	= UART0_TX_PIN
+	UART_RX_PIN	= UART0_RX_PIN
+)
+```
+
+UART pins
+
+
+```go
+const (
 	TWI_FREQ_100KHZ	= 100000
 	TWI_FREQ_400KHZ	= 400000
 )
@@ -176,20 +188,6 @@ const (
 
 ```go
 const (
-	UART_TX_PIN	= UART0_TX_PIN
-	UART_RX_PIN	= UART0_RX_PIN
-	UART0_TX_PIN	= GPIO0
-	UART0_RX_PIN	= GPIO1
-	UART1_TX_PIN	= GPIO8
-	UART1_RX_PIN	= GPIO9
-)
-```
-
-UART pins
-
-
-```go
-const (
 	adc0_CH	ADCChannel	= iota
 	adc1_CH
 	adc2_CH
@@ -253,6 +251,47 @@ TODO: This field is not available in the device file.
 
 ```go
 const (
+	// DPRAM : Endpoint control register
+	usbEpControlEnable			= 0x80000000
+	usbEpControlDoubleBuffered		= 0x40000000
+	usbEpControlInterruptPerBuff		= 0x20000000
+	usbEpControlInterruptPerDoubleBuff	= 0x10000000
+	usbEpControlEndpointType		= 0x0c000000
+	usbEpControlInterruptOnStall		= 0x00020000
+	usbEpControlInterruptOnNak		= 0x00010000
+	usbEpControlBufferAddress		= 0x0000ffff
+
+	usbEpControlEndpointTypeControl		= 0x00000000
+	usbEpControlEndpointTypeISO		= 0x04000000
+	usbEpControlEndpointTypeBulk		= 0x08000000
+	usbEpControlEndpointTypeInterrupt	= 0x0c000000
+
+	// Endpoint buffer control bits
+	usbBuf1CtrlFull		= 0x80000000
+	usbBuf1CtrlLast		= 0x40000000
+	usbBuf1CtrlData0Pid	= 0x20000000
+	usbBuf1CtrlData1Pid	= 0x00000000
+	usbBuf1CtrlSel		= 0x10000000
+	usbBuf1CtrlStall	= 0x08000000
+	usbBuf1CtrlAvail	= 0x04000000
+	usbBuf1CtrlLenMask	= 0x03FF0000
+	usbBuf0CtrlFull		= 0x00008000
+	usbBuf0CtrlLast		= 0x00004000
+	usbBuf0CtrlData0Pid	= 0x00000000
+	usbBuf0CtrlData1Pid	= 0x00002000
+	usbBuf0CtrlSel		= 0x00001000
+	usbBuf0CtrlStall	= 0x00000800
+	usbBuf0CtrlAvail	= 0x00000400
+	usbBuf0CtrlLenMask	= 0x000003FF
+
+	USBBufferLen	= 64
+)
+```
+
+
+
+```go
+const (
 	// ParityNone means to not use any parity checking. This is
 	// the most common setting.
 	ParityNone	UARTParity	= 0
@@ -284,29 +323,10 @@ var (
 
 ```go
 var (
-	ErrTimeoutRNG		= errors.New("machine: RNG Timeout")
-	ErrInvalidInputPin	= errors.New("machine: invalid input pin")
-	ErrInvalidOutputPin	= errors.New("machine: invalid output pin")
-	ErrInvalidClockPin	= errors.New("machine: invalid clock pin")
-	ErrInvalidDataPin	= errors.New("machine: invalid data pin")
-	ErrNoPinChangeChannel	= errors.New("machine: no channel available for pin interrupt")
-)
-```
-
-
-
-```go
-var (
 	UART0	= &_UART0
 	_UART0	= UART{
 		Buffer:	NewRingBuffer(),
 		Bus:	rp.UART0,
-	}
-
-	UART1	= &_UART1
-	_UART1	= UART{
-		Buffer:	NewRingBuffer(),
-		Bus:	rp.UART1,
 	}
 )
 ```
@@ -316,6 +336,19 @@ UART on the RP2040
 
 ```go
 var DefaultUART = UART0
+```
+
+
+
+```go
+var (
+	ErrTimeoutRNG		= errors.New("machine: RNG Timeout")
+	ErrInvalidInputPin	= errors.New("machine: invalid input pin")
+	ErrInvalidOutputPin	= errors.New("machine: invalid output pin")
+	ErrInvalidClockPin	= errors.New("machine: invalid clock pin")
+	ErrInvalidDataPin	= errors.New("machine: invalid data pin")
+	ErrNoPinChangeChannel	= errors.New("machine: no channel available for pin interrupt")
+)
 ```
 
 
@@ -421,10 +454,28 @@ var (
 
 
 ```go
-var Serial = DefaultUART
+var Serial Serialer
 ```
 
-Serial is implemented via the default (usually the first) UART on the chip.
+Serial is implemented via USB (USB-CDC).
+
+
+```go
+var (
+	USBDev	= &USBDevice{}
+	USBCDC	Serialer
+)
+```
+
+
+
+```go
+var (
+	ErrUSBReadTimeout	= errors.New("USB read timeout")
+	ErrUSBBytesRead		= errors.New("USB invalid number of bytes read")
+)
+```
+
 
 
 
@@ -447,6 +498,32 @@ func CurrentCore() int
 CurrentCore returns the core number the call was made from.
 
 
+### func EnableCDC
+
+```go
+func EnableCDC(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
+```
+
+
+
+### func EnableHID
+
+```go
+func EnableHID(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
+```
+
+EnableHID enables HID. This function must be executed from the init().
+
+
+### func EnableMIDI
+
+```go
+func EnableMIDI(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
+```
+
+EnableMIDI enables MIDI. This function must be executed from the init().
+
+
 ### func InitADC
 
 ```go
@@ -454,6 +531,14 @@ func InitADC()
 ```
 
 InitADC resets the ADC peripheral.
+
+
+### func InitSerial
+
+```go
+func InitSerial()
+```
+
 
 
 ### func NewRingBuffer
@@ -483,6 +568,31 @@ func PWMPeripheral(pin Pin) (sliceNum uint8, err error)
 Peripheral returns the RP2040 PWM peripheral which ranges from 0 to 7. Each
 PWM peripheral has 2 channels, A and B which correspond to 0 and 1 in the program.
 This number corresponds to the package's PWM0 throughout PWM7 handles
+
+
+### func ReceiveUSBControlPacket
+
+```go
+func ReceiveUSBControlPacket() ([cdcLineInfoSize]byte, error)
+```
+
+
+
+### func SendUSBInPacket
+
+```go
+func SendUSBInPacket(ep uint32, data []byte) bool
+```
+
+SendUSBInPacket sends a packet for USB (interrupt in / bulk in).
+
+
+### func SendZlp
+
+```go
+func SendZlp()
+```
+
 
 
 
@@ -1087,6 +1197,25 @@ SPIConfig is used to store config info for SPI.
 
 
 
+## type Serialer
+
+```go
+type Serialer interface {
+	WriteByte(c byte) error
+	Write(data []byte) (n int, err error)
+	Configure(config UARTConfig) error
+	Buffered() int
+	ReadByte() (byte, error)
+	DTR() bool
+	RTS() bool
+}
+```
+
+
+
+
+
+
 ## type UART
 
 ```go
@@ -1211,6 +1340,88 @@ type UARTParity int
 ```
 
 UARTParity is the parity setting to be used for UART communication.
+
+
+
+
+
+## type USBBuffer
+
+```go
+type USBBuffer struct {
+	Buffer0	[USBBufferLen]byte
+	Buffer1	[USBBufferLen]byte
+}
+```
+
+
+
+
+
+
+## type USBBufferControlRegister
+
+```go
+type USBBufferControlRegister struct {
+	In	volatile.Register32
+	Out	volatile.Register32
+}
+```
+
+
+
+
+
+
+## type USBDPSRAM
+
+```go
+type USBDPSRAM struct {
+	// Note that EPxControl[0] is not EP0Control but 8-byte setup data.
+	EPxControl	[16]USBEndpointControlRegister
+
+	EPxBufferControl	[16]USBBufferControlRegister
+
+	EPxBuffer	[16]USBBuffer
+}
+```
+
+
+
+
+
+
+## type USBDevice
+
+```go
+type USBDevice struct {
+	initcomplete bool
+}
+```
+
+
+
+
+### func (*USBDevice) Configure
+
+```go
+func (dev *USBDevice) Configure(config UARTConfig)
+```
+
+Configure the USB peripheral. The config is here for compatibility with the UART interface.
+
+
+
+
+## type USBEndpointControlRegister
+
+```go
+type USBEndpointControlRegister struct {
+	In	volatile.Register32
+	Out	volatile.Register32
+}
+```
+
 
 
 

--- a/content/docs/reference/microcontrollers/machine/nicenano.md
+++ b/content/docs/reference/microcontrollers/machine/nicenano.md
@@ -295,40 +295,6 @@ PWM
 
 ```go
 var (
-	USB		= &_USB
-	_USB		= USBCDC{Buffer: NewRingBuffer()}
-	waitHidTxc	bool
-
-	usbEndpointDescriptors	[8]usbDeviceDescriptor
-
-	udd_ep_in_cache_buffer	[7][128]uint8
-	udd_ep_out_cache_buffer	[7][128]uint8
-
-	sendOnEP0DATADONE	struct {
-		ptr	*byte
-		count	int
-	}
-	isEndpointHalt		= false
-	isRemoteWakeUpEnabled	= false
-	endPoints		= []uint32{usb_ENDPOINT_TYPE_CONTROL,
-		(usb_ENDPOINT_TYPE_INTERRUPT | usbEndpointIn),
-		(usb_ENDPOINT_TYPE_BULK | usbEndpointOut),
-		(usb_ENDPOINT_TYPE_BULK | usbEndpointIn)}
-
-	usbConfiguration		uint8
-	usbSetInterface			uint8
-	usbLineInfo			= cdcLineInfo{115200, 0x00, 0x00, 0x08, 0x00}
-	epinen				uint32
-	epouten				uint32
-	easyDMABusy			volatile.Register8
-	epout0data_setlinecoding	bool
-)
-```
-
-
-
-```go
-var (
 	SPI0	= SPI{Bus: nrf.SPIM0, buf: new([1]byte)}
 	SPI1	= SPI{Bus: nrf.SPIM1, buf: new([1]byte)}
 	SPI2	= SPI{Bus: nrf.SPIM2, buf: new([1]byte)}
@@ -347,10 +313,28 @@ var (
 
 
 ```go
-var Serial = USB
+var Serial Serialer
 ```
 
 Serial is implemented via USB (USB-CDC).
+
+
+```go
+var (
+	USBDev	= &USBDevice{}
+	USBCDC	Serialer
+)
+```
+
+
+
+```go
+var (
+	ErrUSBReadTimeout	= errors.New("USB read timeout")
+	ErrUSBBytesRead		= errors.New("USB invalid number of bytes read")
+)
+```
+
 
 
 
@@ -364,13 +348,40 @@ func CPUFrequency() uint32
 
 
 
+### func EnableCDC
+
+```go
+func EnableCDC(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
+```
+
+
+
 ### func EnableHID
 
 ```go
-func EnableHID(callback func())
+func EnableHID(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
 ```
 
 EnableHID enables HID. This function must be executed from the init().
+
+
+### func EnableMIDI
+
+```go
+func EnableMIDI(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
+```
+
+EnableMIDI enables MIDI. This function must be executed from the init().
+
+
+### func EnterBootloader
+
+```go
+func EnterBootloader()
+```
+
+EnterBootloader resets the chip into the UF2 bootloader. After reset, it
+can be flashed via nrfutil or by copying a UF2 file to the mass storage device
 
 
 ### func EnterOTABootloader
@@ -412,6 +423,14 @@ func InitADC()
 InitADC initializes the registers needed for ADC.
 
 
+### func InitSerial
+
+```go
+func InitSerial()
+```
+
+
+
 ### func NewRingBuffer
 
 ```go
@@ -421,13 +440,29 @@ func NewRingBuffer() *RingBuffer
 NewRingBuffer returns a new ring buffer.
 
 
-### func SendUSBHIDPacket
+### func ReceiveUSBControlPacket
 
 ```go
-func SendUSBHIDPacket(ep uint32, data []byte) bool
+func ReceiveUSBControlPacket() ([cdcLineInfoSize]byte, error)
 ```
 
-SendUSBHIDPacket sends a packet for USBHID (interrupt / in).
+
+
+### func SendUSBInPacket
+
+```go
+func SendUSBInPacket(ep uint32, data []byte) bool
+```
+
+SendUSBInPacket sends a packet for USBHID (interrupt in / bulk in).
+
+
+### func SendZlp
+
+```go
+func SendZlp()
+```
+
 
 
 
@@ -1004,6 +1039,25 @@ SPIConfig is used to store config info for SPI.
 
 
 
+## type Serialer
+
+```go
+type Serialer interface {
+	WriteByte(c byte) error
+	Write(data []byte) (n int, err error)
+	Configure(config UARTConfig) error
+	Buffered() int
+	ReadByte() (byte, error)
+	DTR() bool
+	RTS() bool
+}
+```
+
+
+
+
+
+
 ## type UART
 
 ```go
@@ -1122,135 +1176,24 @@ UARTParity is the parity setting to be used for UART communication.
 
 
 
-## type USBCDC
+## type USBDevice
 
 ```go
-type USBCDC struct {
-	Buffer			*RingBuffer
-	interrupt		interrupt.Interrupt
-	initcomplete		bool
-	TxIdx			volatile.Register8
-	waitTxc			bool
-	waitTxcRetryCount	uint8
-	sent			bool
-}
-```
-
-USBCDC is the USB CDC aka serial over USB interface on the nRF52840
-
-
-
-### func (*USBCDC) Buffered
-
-```go
-func (usbcdc *USBCDC) Buffered() int
-```
-
-Buffered returns the number of bytes currently stored in the RX buffer.
-
-
-### func (*USBCDC) Configure
-
-```go
-func (usbcdc *USBCDC) Configure(config UARTConfig)
-```
-
-Configure the USB CDC interface. The config is here for compatibility with the UART interface.
-
-
-### func (*USBCDC) DTR
-
-```go
-func (usbcdc *USBCDC) DTR() bool
-```
-
-
-
-### func (*USBCDC) Flush
-
-```go
-func (usbcdc *USBCDC) Flush() error
-```
-
-Flush flushes buffered data.
-
-
-### func (*USBCDC) RTS
-
-```go
-func (usbcdc *USBCDC) RTS() bool
-```
-
-
-
-### func (*USBCDC) Read
-
-```go
-func (usbcdc *USBCDC) Read(data []byte) (n int, err error)
-```
-
-Read from the RX buffer.
-
-
-### func (*USBCDC) ReadByte
-
-```go
-func (usbcdc *USBCDC) ReadByte() (byte, error)
-```
-
-ReadByte reads a single byte from the RX buffer.
-If there is no data in the buffer, returns an error.
-
-
-### func (*USBCDC) Receive
-
-```go
-func (usbcdc *USBCDC) Receive(data byte)
-```
-
-Receive handles adding data to the UART's data buffer.
-Usually called by the IRQ handler for a machine.
-
-
-### func (*USBCDC) Write
-
-```go
-func (usbcdc *USBCDC) Write(data []byte) (n int, err error)
-```
-
-Write data to the USBCDC.
-
-
-### func (*USBCDC) WriteByte
-
-```go
-func (usbcdc *USBCDC) WriteByte(c byte) error
-```
-
-WriteByte writes a byte of data to the USB CDC interface.
-
-
-
-
-## type USBDescriptor
-
-```go
-type USBDescriptor struct {
-	Device		[]byte
-	Configuration	[]byte
-	HID		map[uint16][]byte
+type USBDevice struct {
+	initcomplete bool
 }
 ```
 
 
 
 
-### func (*USBDescriptor) Configure
+### func (*USBDevice) Configure
 
 ```go
-func (d *USBDescriptor) Configure(idVendor, idProduct uint16)
+func (dev *USBDevice) Configure(config UARTConfig)
 ```
 
+Configure the USB peripheral. The config is here for compatibility with the UART interface.
 
 
 

--- a/content/docs/reference/microcontrollers/machine/nodemcu.md
+++ b/content/docs/reference/microcontrollers/machine/nodemcu.md
@@ -165,6 +165,14 @@ func CPUFrequency() uint32
 
 
 
+### func InitSerial
+
+```go
+func InitSerial()
+```
+
+
+
 ### func NewRingBuffer
 
 ```go

--- a/content/docs/reference/microcontrollers/machine/nrf52840-mdk-usb-dongle.md
+++ b/content/docs/reference/microcontrollers/machine/nrf52840-mdk-usb-dongle.md
@@ -260,40 +260,6 @@ PWM
 
 ```go
 var (
-	USB		= &_USB
-	_USB		= USBCDC{Buffer: NewRingBuffer()}
-	waitHidTxc	bool
-
-	usbEndpointDescriptors	[8]usbDeviceDescriptor
-
-	udd_ep_in_cache_buffer	[7][128]uint8
-	udd_ep_out_cache_buffer	[7][128]uint8
-
-	sendOnEP0DATADONE	struct {
-		ptr	*byte
-		count	int
-	}
-	isEndpointHalt		= false
-	isRemoteWakeUpEnabled	= false
-	endPoints		= []uint32{usb_ENDPOINT_TYPE_CONTROL,
-		(usb_ENDPOINT_TYPE_INTERRUPT | usbEndpointIn),
-		(usb_ENDPOINT_TYPE_BULK | usbEndpointOut),
-		(usb_ENDPOINT_TYPE_BULK | usbEndpointIn)}
-
-	usbConfiguration		uint8
-	usbSetInterface			uint8
-	usbLineInfo			= cdcLineInfo{115200, 0x00, 0x00, 0x08, 0x00}
-	epinen				uint32
-	epouten				uint32
-	easyDMABusy			volatile.Register8
-	epout0data_setlinecoding	bool
-)
-```
-
-
-
-```go
-var (
 	SPI0	= SPI{Bus: nrf.SPIM0, buf: new([1]byte)}
 	SPI1	= SPI{Bus: nrf.SPIM1, buf: new([1]byte)}
 	SPI2	= SPI{Bus: nrf.SPIM2, buf: new([1]byte)}
@@ -312,10 +278,28 @@ var (
 
 
 ```go
-var Serial = USB
+var Serial Serialer
 ```
 
 Serial is implemented via USB (USB-CDC).
+
+
+```go
+var (
+	USBDev	= &USBDevice{}
+	USBCDC	Serialer
+)
+```
+
+
+
+```go
+var (
+	ErrUSBReadTimeout	= errors.New("USB read timeout")
+	ErrUSBBytesRead		= errors.New("USB invalid number of bytes read")
+)
+```
+
 
 
 
@@ -329,13 +313,40 @@ func CPUFrequency() uint32
 
 
 
+### func EnableCDC
+
+```go
+func EnableCDC(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
+```
+
+
+
 ### func EnableHID
 
 ```go
-func EnableHID(callback func())
+func EnableHID(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
 ```
 
 EnableHID enables HID. This function must be executed from the init().
+
+
+### func EnableMIDI
+
+```go
+func EnableMIDI(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
+```
+
+EnableMIDI enables MIDI. This function must be executed from the init().
+
+
+### func EnterBootloader
+
+```go
+func EnterBootloader()
+```
+
+EnterBootloader resets the chip into the UF2 bootloader. After reset, it
+can be flashed via nrfutil or by copying a UF2 file to the mass storage device
 
 
 ### func EnterOTABootloader
@@ -377,6 +388,14 @@ func InitADC()
 InitADC initializes the registers needed for ADC.
 
 
+### func InitSerial
+
+```go
+func InitSerial()
+```
+
+
+
 ### func NewRingBuffer
 
 ```go
@@ -386,13 +405,29 @@ func NewRingBuffer() *RingBuffer
 NewRingBuffer returns a new ring buffer.
 
 
-### func SendUSBHIDPacket
+### func ReceiveUSBControlPacket
 
 ```go
-func SendUSBHIDPacket(ep uint32, data []byte) bool
+func ReceiveUSBControlPacket() ([cdcLineInfoSize]byte, error)
 ```
 
-SendUSBHIDPacket sends a packet for USBHID (interrupt / in).
+
+
+### func SendUSBInPacket
+
+```go
+func SendUSBInPacket(ep uint32, data []byte) bool
+```
+
+SendUSBInPacket sends a packet for USBHID (interrupt in / bulk in).
+
+
+### func SendZlp
+
+```go
+func SendZlp()
+```
+
 
 
 
@@ -969,6 +1004,25 @@ SPIConfig is used to store config info for SPI.
 
 
 
+## type Serialer
+
+```go
+type Serialer interface {
+	WriteByte(c byte) error
+	Write(data []byte) (n int, err error)
+	Configure(config UARTConfig) error
+	Buffered() int
+	ReadByte() (byte, error)
+	DTR() bool
+	RTS() bool
+}
+```
+
+
+
+
+
+
 ## type UART
 
 ```go
@@ -1087,135 +1141,24 @@ UARTParity is the parity setting to be used for UART communication.
 
 
 
-## type USBCDC
+## type USBDevice
 
 ```go
-type USBCDC struct {
-	Buffer			*RingBuffer
-	interrupt		interrupt.Interrupt
-	initcomplete		bool
-	TxIdx			volatile.Register8
-	waitTxc			bool
-	waitTxcRetryCount	uint8
-	sent			bool
-}
-```
-
-USBCDC is the USB CDC aka serial over USB interface on the nRF52840
-
-
-
-### func (*USBCDC) Buffered
-
-```go
-func (usbcdc *USBCDC) Buffered() int
-```
-
-Buffered returns the number of bytes currently stored in the RX buffer.
-
-
-### func (*USBCDC) Configure
-
-```go
-func (usbcdc *USBCDC) Configure(config UARTConfig)
-```
-
-Configure the USB CDC interface. The config is here for compatibility with the UART interface.
-
-
-### func (*USBCDC) DTR
-
-```go
-func (usbcdc *USBCDC) DTR() bool
-```
-
-
-
-### func (*USBCDC) Flush
-
-```go
-func (usbcdc *USBCDC) Flush() error
-```
-
-Flush flushes buffered data.
-
-
-### func (*USBCDC) RTS
-
-```go
-func (usbcdc *USBCDC) RTS() bool
-```
-
-
-
-### func (*USBCDC) Read
-
-```go
-func (usbcdc *USBCDC) Read(data []byte) (n int, err error)
-```
-
-Read from the RX buffer.
-
-
-### func (*USBCDC) ReadByte
-
-```go
-func (usbcdc *USBCDC) ReadByte() (byte, error)
-```
-
-ReadByte reads a single byte from the RX buffer.
-If there is no data in the buffer, returns an error.
-
-
-### func (*USBCDC) Receive
-
-```go
-func (usbcdc *USBCDC) Receive(data byte)
-```
-
-Receive handles adding data to the UART's data buffer.
-Usually called by the IRQ handler for a machine.
-
-
-### func (*USBCDC) Write
-
-```go
-func (usbcdc *USBCDC) Write(data []byte) (n int, err error)
-```
-
-Write data to the USBCDC.
-
-
-### func (*USBCDC) WriteByte
-
-```go
-func (usbcdc *USBCDC) WriteByte(c byte) error
-```
-
-WriteByte writes a byte of data to the USB CDC interface.
-
-
-
-
-## type USBDescriptor
-
-```go
-type USBDescriptor struct {
-	Device		[]byte
-	Configuration	[]byte
-	HID		map[uint16][]byte
+type USBDevice struct {
+	initcomplete bool
 }
 ```
 
 
 
 
-### func (*USBDescriptor) Configure
+### func (*USBDevice) Configure
 
 ```go
-func (d *USBDescriptor) Configure(idVendor, idProduct uint16)
+func (dev *USBDevice) Configure(config UARTConfig)
 ```
 
+Configure the USB peripheral. The config is here for compatibility with the UART interface.
 
 
 

--- a/content/docs/reference/microcontrollers/machine/nrf52840-mdk.md
+++ b/content/docs/reference/microcontrollers/machine/nrf52840-mdk.md
@@ -164,6 +164,16 @@ Pin change interrupt constants for SetInterrupt.
 
 ```go
 const (
+	DFU_MAGIC_SERIAL_ONLY_RESET	= 0x4e
+	DFU_MAGIC_UF2_RESET		= 0x57
+	DFU_MAGIC_OTA_RESET		= 0xA8
+)
+```
+
+
+
+```go
+const (
 	// ParityNone means to not use any parity checking. This is
 	// the most common setting.
 	ParityNone	UARTParity	= 0
@@ -241,40 +251,6 @@ PWM
 
 ```go
 var (
-	USB		= &_USB
-	_USB		= USBCDC{Buffer: NewRingBuffer()}
-	waitHidTxc	bool
-
-	usbEndpointDescriptors	[8]usbDeviceDescriptor
-
-	udd_ep_in_cache_buffer	[7][128]uint8
-	udd_ep_out_cache_buffer	[7][128]uint8
-
-	sendOnEP0DATADONE	struct {
-		ptr	*byte
-		count	int
-	}
-	isEndpointHalt		= false
-	isRemoteWakeUpEnabled	= false
-	endPoints		= []uint32{usb_ENDPOINT_TYPE_CONTROL,
-		(usb_ENDPOINT_TYPE_INTERRUPT | usbEndpointIn),
-		(usb_ENDPOINT_TYPE_BULK | usbEndpointOut),
-		(usb_ENDPOINT_TYPE_BULK | usbEndpointIn)}
-
-	usbConfiguration		uint8
-	usbSetInterface			uint8
-	usbLineInfo			= cdcLineInfo{115200, 0x00, 0x00, 0x08, 0x00}
-	epinen				uint32
-	epouten				uint32
-	easyDMABusy			volatile.Register8
-	epout0data_setlinecoding	bool
-)
-```
-
-
-
-```go
-var (
 	SPI0	= SPI{Bus: nrf.SPIM0, buf: new([1]byte)}
 	SPI1	= SPI{Bus: nrf.SPIM1, buf: new([1]byte)}
 	SPI2	= SPI{Bus: nrf.SPIM2, buf: new([1]byte)}
@@ -293,10 +269,28 @@ var (
 
 
 ```go
-var Serial = USB
+var Serial Serialer
 ```
 
 Serial is implemented via USB (USB-CDC).
+
+
+```go
+var (
+	USBDev	= &USBDevice{}
+	USBCDC	Serialer
+)
+```
+
+
+
+```go
+var (
+	ErrUSBReadTimeout	= errors.New("USB read timeout")
+	ErrUSBBytesRead		= errors.New("USB invalid number of bytes read")
+)
+```
+
 
 
 
@@ -310,13 +304,69 @@ func CPUFrequency() uint32
 
 
 
+### func EnableCDC
+
+```go
+func EnableCDC(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
+```
+
+
+
 ### func EnableHID
 
 ```go
-func EnableHID(callback func())
+func EnableHID(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
 ```
 
 EnableHID enables HID. This function must be executed from the init().
+
+
+### func EnableMIDI
+
+```go
+func EnableMIDI(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
+```
+
+EnableMIDI enables MIDI. This function must be executed from the init().
+
+
+### func EnterBootloader
+
+```go
+func EnterBootloader()
+```
+
+EnterBootloader resets the chip into the serial bootloader.
+
+
+### func EnterOTABootloader
+
+```go
+func EnterOTABootloader()
+```
+
+EnterOTABootloader resets the chip into the bootloader so that it can be
+flashed via an OTA update
+
+
+### func EnterSerialBootloader
+
+```go
+func EnterSerialBootloader()
+```
+
+EnterSerialBootloader resets the chip into the serial bootloader. After
+reset, it can be flashed using serial/nrfutil.
+
+
+### func EnterUF2Bootloader
+
+```go
+func EnterUF2Bootloader()
+```
+
+EnterUF2Bootloader resets the chip into the UF2 bootloader. After reset, it
+can be flashed via nrfutil or by copying a UF2 file to the mass storage device
 
 
 ### func InitADC
@@ -328,6 +378,14 @@ func InitADC()
 InitADC initializes the registers needed for ADC.
 
 
+### func InitSerial
+
+```go
+func InitSerial()
+```
+
+
+
 ### func NewRingBuffer
 
 ```go
@@ -337,13 +395,29 @@ func NewRingBuffer() *RingBuffer
 NewRingBuffer returns a new ring buffer.
 
 
-### func SendUSBHIDPacket
+### func ReceiveUSBControlPacket
 
 ```go
-func SendUSBHIDPacket(ep uint32, data []byte) bool
+func ReceiveUSBControlPacket() ([cdcLineInfoSize]byte, error)
 ```
 
-SendUSBHIDPacket sends a packet for USBHID (interrupt / in).
+
+
+### func SendUSBInPacket
+
+```go
+func SendUSBInPacket(ep uint32, data []byte) bool
+```
+
+SendUSBInPacket sends a packet for USBHID (interrupt in / bulk in).
+
+
+### func SendZlp
+
+```go
+func SendZlp()
+```
+
 
 
 
@@ -920,6 +994,25 @@ SPIConfig is used to store config info for SPI.
 
 
 
+## type Serialer
+
+```go
+type Serialer interface {
+	WriteByte(c byte) error
+	Write(data []byte) (n int, err error)
+	Configure(config UARTConfig) error
+	Buffered() int
+	ReadByte() (byte, error)
+	DTR() bool
+	RTS() bool
+}
+```
+
+
+
+
+
+
 ## type UART
 
 ```go
@@ -1038,135 +1131,24 @@ UARTParity is the parity setting to be used for UART communication.
 
 
 
-## type USBCDC
+## type USBDevice
 
 ```go
-type USBCDC struct {
-	Buffer			*RingBuffer
-	interrupt		interrupt.Interrupt
-	initcomplete		bool
-	TxIdx			volatile.Register8
-	waitTxc			bool
-	waitTxcRetryCount	uint8
-	sent			bool
-}
-```
-
-USBCDC is the USB CDC aka serial over USB interface on the nRF52840
-
-
-
-### func (*USBCDC) Buffered
-
-```go
-func (usbcdc *USBCDC) Buffered() int
-```
-
-Buffered returns the number of bytes currently stored in the RX buffer.
-
-
-### func (*USBCDC) Configure
-
-```go
-func (usbcdc *USBCDC) Configure(config UARTConfig)
-```
-
-Configure the USB CDC interface. The config is here for compatibility with the UART interface.
-
-
-### func (*USBCDC) DTR
-
-```go
-func (usbcdc *USBCDC) DTR() bool
-```
-
-
-
-### func (*USBCDC) Flush
-
-```go
-func (usbcdc *USBCDC) Flush() error
-```
-
-Flush flushes buffered data.
-
-
-### func (*USBCDC) RTS
-
-```go
-func (usbcdc *USBCDC) RTS() bool
-```
-
-
-
-### func (*USBCDC) Read
-
-```go
-func (usbcdc *USBCDC) Read(data []byte) (n int, err error)
-```
-
-Read from the RX buffer.
-
-
-### func (*USBCDC) ReadByte
-
-```go
-func (usbcdc *USBCDC) ReadByte() (byte, error)
-```
-
-ReadByte reads a single byte from the RX buffer.
-If there is no data in the buffer, returns an error.
-
-
-### func (*USBCDC) Receive
-
-```go
-func (usbcdc *USBCDC) Receive(data byte)
-```
-
-Receive handles adding data to the UART's data buffer.
-Usually called by the IRQ handler for a machine.
-
-
-### func (*USBCDC) Write
-
-```go
-func (usbcdc *USBCDC) Write(data []byte) (n int, err error)
-```
-
-Write data to the USBCDC.
-
-
-### func (*USBCDC) WriteByte
-
-```go
-func (usbcdc *USBCDC) WriteByte(c byte) error
-```
-
-WriteByte writes a byte of data to the USB CDC interface.
-
-
-
-
-## type USBDescriptor
-
-```go
-type USBDescriptor struct {
-	Device		[]byte
-	Configuration	[]byte
-	HID		map[uint16][]byte
+type USBDevice struct {
+	initcomplete bool
 }
 ```
 
 
 
 
-### func (*USBDescriptor) Configure
+### func (*USBDevice) Configure
 
 ```go
-func (d *USBDescriptor) Configure(idVendor, idProduct uint16)
+func (dev *USBDevice) Configure(config UARTConfig)
 ```
 
+Configure the USB peripheral. The config is here for compatibility with the UART interface.
 
 
 

--- a/content/docs/reference/microcontrollers/machine/nucleo-f103rb.md
+++ b/content/docs/reference/microcontrollers/machine/nucleo-f103rb.md
@@ -606,6 +606,14 @@ func InitADC()
 InitADC initializes the registers needed for ADC1.
 
 
+### func InitSerial
+
+```go
+func InitSerial()
+```
+
+
+
 ### func NewRingBuffer
 
 ```go

--- a/content/docs/reference/microcontrollers/machine/nucleo-f722ze.md
+++ b/content/docs/reference/microcontrollers/machine/nucleo-f722ze.md
@@ -755,6 +755,14 @@ func GetRNG() (uint32, error)
 GetRNG returns 32 bits of cryptographically secure random data
 
 
+### func InitSerial
+
+```go
+func InitSerial()
+```
+
+
+
 ### func NewRingBuffer
 
 ```go

--- a/content/docs/reference/microcontrollers/machine/nucleo-l031k6.md
+++ b/content/docs/reference/microcontrollers/machine/nucleo-l031k6.md
@@ -508,6 +508,14 @@ func CPUFrequency() uint32
 
 
 
+### func InitSerial
+
+```go
+func InitSerial()
+```
+
+
+
 ### func NewRingBuffer
 
 ```go

--- a/content/docs/reference/microcontrollers/machine/nucleo-l432kc.md
+++ b/content/docs/reference/microcontrollers/machine/nucleo-l432kc.md
@@ -567,6 +567,14 @@ func GetRNG() (uint32, error)
 GetRNG returns 32 bits of cryptographically secure random data
 
 
+### func InitSerial
+
+```go
+func InitSerial()
+```
+
+
+
 ### func NewRingBuffer
 
 ```go

--- a/content/docs/reference/microcontrollers/machine/nucleo-l552ze.md
+++ b/content/docs/reference/microcontrollers/machine/nucleo-l552ze.md
@@ -575,6 +575,14 @@ func GetRNG() (uint32, error)
 GetRNG returns 32 bits of cryptographically secure random data
 
 
+### func InitSerial
+
+```go
+func InitSerial()
+```
+
+
+
 ### func NewRingBuffer
 
 ```go

--- a/content/docs/reference/microcontrollers/machine/nucleo-wl55jc.md
+++ b/content/docs/reference/microcontrollers/machine/nucleo-wl55jc.md
@@ -441,6 +441,14 @@ func GetRNG() (uint32, error)
 GetRNG returns 32 bits of cryptographically secure random data
 
 
+### func InitSerial
+
+```go
+func InitSerial()
+```
+
+
+
 ### func NewRingBuffer
 
 ```go

--- a/content/docs/reference/microcontrollers/machine/p1am-100.md
+++ b/content/docs/reference/microcontrollers/machine/p1am-100.md
@@ -422,15 +422,6 @@ The SAM D21 has three TCC peripherals, which have PWM as one feature.
 
 ```go
 var (
-	USB		= &USBCDC{Buffer: NewRingBuffer()}
-	waitHidTxc	bool
-)
-```
-
-
-
-```go
-var (
 	DAC0 = DAC{}
 )
 ```
@@ -446,10 +437,28 @@ var (
 
 
 ```go
-var Serial = USB
+var Serial Serialer
 ```
 
 Serial is implemented via USB (USB-CDC).
+
+
+```go
+var (
+	USBDev	= &USBDevice{}
+	USBCDC	Serialer
+)
+```
+
+
+
+```go
+var (
+	ErrUSBReadTimeout	= errors.New("USB read timeout")
+	ErrUSBBytesRead		= errors.New("USB invalid number of bytes read")
+)
+```
+
 
 
 
@@ -464,13 +473,40 @@ func CPUFrequency() uint32
 Return the current CPU frequency in hertz.
 
 
+### func EnableCDC
+
+```go
+func EnableCDC(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
+```
+
+
+
 ### func EnableHID
 
 ```go
-func EnableHID(callback func())
+func EnableHID(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
 ```
 
 EnableHID enables HID. This function must be executed from the init().
+
+
+### func EnableMIDI
+
+```go
+func EnableMIDI(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
+```
+
+EnableMIDI enables MIDI. This function must be executed from the init().
+
+
+### func EnterBootloader
+
+```go
+func EnterBootloader()
+```
+
+EnterBootloader should perform a system reset in preperation
+to switch to the bootloader to flash new firmware.
 
 
 ### func InitADC
@@ -482,6 +518,14 @@ func InitADC()
 InitADC initializes the ADC.
 
 
+### func InitSerial
+
+```go
+func InitSerial()
+```
+
+
+
 ### func NewRingBuffer
 
 ```go
@@ -491,23 +535,29 @@ func NewRingBuffer() *RingBuffer
 NewRingBuffer returns a new ring buffer.
 
 
-### func ResetProcessor
+### func ReceiveUSBControlPacket
 
 ```go
-func ResetProcessor()
+func ReceiveUSBControlPacket() ([cdcLineInfoSize]byte, error)
 ```
 
-ResetProcessor should perform a system reset in preperation
-to switch to the bootloader to flash new firmware.
 
 
-### func SendUSBHIDPacket
+### func SendUSBInPacket
 
 ```go
-func SendUSBHIDPacket(ep uint32, data []byte) bool
+func SendUSBInPacket(ep uint32, data []byte) bool
 ```
 
-SendUSBHIDPacket sends a packet for USBHID (interrupt / in).
+SendUSBInPacket sends a packet for USB (interrupt in / bulk in).
+
+
+### func SendZlp
+
+```go
+func SendZlp()
+```
+
 
 
 
@@ -1177,6 +1227,25 @@ SPIConfig is used to store config info for SPI.
 
 
 
+## type Serialer
+
+```go
+type Serialer interface {
+	WriteByte(c byte) error
+	Write(data []byte) (n int, err error)
+	Configure(config UARTConfig) error
+	Buffered() int
+	ReadByte() (byte, error)
+	DTR() bool
+	RTS() bool
+}
+```
+
+
+
+
+
+
 ## type TCC
 
 ```go
@@ -1411,143 +1480,24 @@ UARTParity is the parity setting to be used for UART communication.
 
 
 
-## type USBCDC
+## type USBDevice
 
 ```go
-type USBCDC struct {
-	Buffer			*RingBuffer
-	TxIdx			volatile.Register8
-	waitTxc			bool
-	waitTxcRetryCount	uint8
-	sent			bool
-	configured		bool
-}
-```
-
-USBCDC is the USB CDC aka serial over USB interface on the SAMD21.
-
-
-
-### func (*USBCDC) Buffered
-
-```go
-func (usbcdc *USBCDC) Buffered() int
-```
-
-Buffered returns the number of bytes currently stored in the RX buffer.
-
-
-### func (*USBCDC) Configure
-
-```go
-func (usbcdc *USBCDC) Configure(config UARTConfig)
-```
-
-Configure the USB CDC interface. The config is here for compatibility with the UART interface.
-
-
-### func (*USBCDC) Configured
-
-```go
-func (usbcdc *USBCDC) Configured() bool
-```
-
-Configured returns whether usbcdc is configured or not.
-
-
-### func (*USBCDC) DTR
-
-```go
-func (usbcdc *USBCDC) DTR() bool
-```
-
-
-
-### func (*USBCDC) Flush
-
-```go
-func (usbcdc *USBCDC) Flush() error
-```
-
-Flush flushes buffered data.
-
-
-### func (*USBCDC) RTS
-
-```go
-func (usbcdc *USBCDC) RTS() bool
-```
-
-
-
-### func (*USBCDC) Read
-
-```go
-func (usbcdc *USBCDC) Read(data []byte) (n int, err error)
-```
-
-Read from the RX buffer.
-
-
-### func (*USBCDC) ReadByte
-
-```go
-func (usbcdc *USBCDC) ReadByte() (byte, error)
-```
-
-ReadByte reads a single byte from the RX buffer.
-If there is no data in the buffer, returns an error.
-
-
-### func (*USBCDC) Receive
-
-```go
-func (usbcdc *USBCDC) Receive(data byte)
-```
-
-Receive handles adding data to the UART's data buffer.
-Usually called by the IRQ handler for a machine.
-
-
-### func (*USBCDC) Write
-
-```go
-func (usbcdc *USBCDC) Write(data []byte) (n int, err error)
-```
-
-Write data to the USBCDC.
-
-
-### func (*USBCDC) WriteByte
-
-```go
-func (usbcdc *USBCDC) WriteByte(c byte) error
-```
-
-WriteByte writes a byte of data to the USB CDC interface.
-
-
-
-
-## type USBDescriptor
-
-```go
-type USBDescriptor struct {
-	Device		[]byte
-	Configuration	[]byte
-	HID		map[uint16][]byte
+type USBDevice struct {
+	initcomplete bool
 }
 ```
 
 
 
 
-### func (*USBDescriptor) Configure
+### func (*USBDevice) Configure
 
 ```go
-func (d *USBDescriptor) Configure(idVendor, idProduct uint16)
+func (dev *USBDevice) Configure(config UARTConfig)
 ```
 
+Configure the USB peripheral. The config is here for compatibility with the UART interface.
 
 
 

--- a/content/docs/reference/microcontrollers/machine/particle-argon.md
+++ b/content/docs/reference/microcontrollers/machine/particle-argon.md
@@ -235,6 +235,16 @@ Pin change interrupt constants for SetInterrupt.
 
 ```go
 const (
+	DFU_MAGIC_SERIAL_ONLY_RESET	= 0x4e
+	DFU_MAGIC_UF2_RESET		= 0x57
+	DFU_MAGIC_OTA_RESET		= 0xA8
+)
+```
+
+
+
+```go
+const (
 	// ParityNone means to not use any parity checking. This is
 	// the most common setting.
 	ParityNone	UARTParity	= 0
@@ -321,40 +331,6 @@ PWM
 
 ```go
 var (
-	USB		= &_USB
-	_USB		= USBCDC{Buffer: NewRingBuffer()}
-	waitHidTxc	bool
-
-	usbEndpointDescriptors	[8]usbDeviceDescriptor
-
-	udd_ep_in_cache_buffer	[7][128]uint8
-	udd_ep_out_cache_buffer	[7][128]uint8
-
-	sendOnEP0DATADONE	struct {
-		ptr	*byte
-		count	int
-	}
-	isEndpointHalt		= false
-	isRemoteWakeUpEnabled	= false
-	endPoints		= []uint32{usb_ENDPOINT_TYPE_CONTROL,
-		(usb_ENDPOINT_TYPE_INTERRUPT | usbEndpointIn),
-		(usb_ENDPOINT_TYPE_BULK | usbEndpointOut),
-		(usb_ENDPOINT_TYPE_BULK | usbEndpointIn)}
-
-	usbConfiguration		uint8
-	usbSetInterface			uint8
-	usbLineInfo			= cdcLineInfo{115200, 0x00, 0x00, 0x08, 0x00}
-	epinen				uint32
-	epouten				uint32
-	easyDMABusy			volatile.Register8
-	epout0data_setlinecoding	bool
-)
-```
-
-
-
-```go
-var (
 	SPI0	= SPI{Bus: nrf.SPIM0, buf: new([1]byte)}
 	SPI1	= SPI{Bus: nrf.SPIM1, buf: new([1]byte)}
 	SPI2	= SPI{Bus: nrf.SPIM2, buf: new([1]byte)}
@@ -379,6 +355,24 @@ var Serial = DefaultUART
 Serial is implemented via the default (usually the first) UART on the chip.
 
 
+```go
+var (
+	USBDev	= &USBDevice{}
+	USBCDC	Serialer
+)
+```
+
+
+
+```go
+var (
+	ErrUSBReadTimeout	= errors.New("USB read timeout")
+	ErrUSBBytesRead		= errors.New("USB invalid number of bytes read")
+)
+```
+
+
+
 
 
 
@@ -390,13 +384,69 @@ func CPUFrequency() uint32
 
 
 
+### func EnableCDC
+
+```go
+func EnableCDC(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
+```
+
+
+
 ### func EnableHID
 
 ```go
-func EnableHID(callback func())
+func EnableHID(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
 ```
 
 EnableHID enables HID. This function must be executed from the init().
+
+
+### func EnableMIDI
+
+```go
+func EnableMIDI(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
+```
+
+EnableMIDI enables MIDI. This function must be executed from the init().
+
+
+### func EnterBootloader
+
+```go
+func EnterBootloader()
+```
+
+EnterBootloader resets the chip into the serial bootloader.
+
+
+### func EnterOTABootloader
+
+```go
+func EnterOTABootloader()
+```
+
+EnterOTABootloader resets the chip into the bootloader so that it can be
+flashed via an OTA update
+
+
+### func EnterSerialBootloader
+
+```go
+func EnterSerialBootloader()
+```
+
+EnterSerialBootloader resets the chip into the serial bootloader. After
+reset, it can be flashed using serial/nrfutil.
+
+
+### func EnterUF2Bootloader
+
+```go
+func EnterUF2Bootloader()
+```
+
+EnterUF2Bootloader resets the chip into the UF2 bootloader. After reset, it
+can be flashed via nrfutil or by copying a UF2 file to the mass storage device
 
 
 ### func InitADC
@@ -408,6 +458,14 @@ func InitADC()
 InitADC initializes the registers needed for ADC.
 
 
+### func InitSerial
+
+```go
+func InitSerial()
+```
+
+
+
 ### func NewRingBuffer
 
 ```go
@@ -417,13 +475,29 @@ func NewRingBuffer() *RingBuffer
 NewRingBuffer returns a new ring buffer.
 
 
-### func SendUSBHIDPacket
+### func ReceiveUSBControlPacket
 
 ```go
-func SendUSBHIDPacket(ep uint32, data []byte) bool
+func ReceiveUSBControlPacket() ([cdcLineInfoSize]byte, error)
 ```
 
-SendUSBHIDPacket sends a packet for USBHID (interrupt / in).
+
+
+### func SendUSBInPacket
+
+```go
+func SendUSBInPacket(ep uint32, data []byte) bool
+```
+
+SendUSBInPacket sends a packet for USBHID (interrupt in / bulk in).
+
+
+### func SendZlp
+
+```go
+func SendZlp()
+```
+
 
 
 
@@ -1000,6 +1074,25 @@ SPIConfig is used to store config info for SPI.
 
 
 
+## type Serialer
+
+```go
+type Serialer interface {
+	WriteByte(c byte) error
+	Write(data []byte) (n int, err error)
+	Configure(config UARTConfig) error
+	Buffered() int
+	ReadByte() (byte, error)
+	DTR() bool
+	RTS() bool
+}
+```
+
+
+
+
+
+
 ## type UART
 
 ```go
@@ -1118,135 +1211,24 @@ UARTParity is the parity setting to be used for UART communication.
 
 
 
-## type USBCDC
+## type USBDevice
 
 ```go
-type USBCDC struct {
-	Buffer			*RingBuffer
-	interrupt		interrupt.Interrupt
-	initcomplete		bool
-	TxIdx			volatile.Register8
-	waitTxc			bool
-	waitTxcRetryCount	uint8
-	sent			bool
-}
-```
-
-USBCDC is the USB CDC aka serial over USB interface on the nRF52840
-
-
-
-### func (*USBCDC) Buffered
-
-```go
-func (usbcdc *USBCDC) Buffered() int
-```
-
-Buffered returns the number of bytes currently stored in the RX buffer.
-
-
-### func (*USBCDC) Configure
-
-```go
-func (usbcdc *USBCDC) Configure(config UARTConfig)
-```
-
-Configure the USB CDC interface. The config is here for compatibility with the UART interface.
-
-
-### func (*USBCDC) DTR
-
-```go
-func (usbcdc *USBCDC) DTR() bool
-```
-
-
-
-### func (*USBCDC) Flush
-
-```go
-func (usbcdc *USBCDC) Flush() error
-```
-
-Flush flushes buffered data.
-
-
-### func (*USBCDC) RTS
-
-```go
-func (usbcdc *USBCDC) RTS() bool
-```
-
-
-
-### func (*USBCDC) Read
-
-```go
-func (usbcdc *USBCDC) Read(data []byte) (n int, err error)
-```
-
-Read from the RX buffer.
-
-
-### func (*USBCDC) ReadByte
-
-```go
-func (usbcdc *USBCDC) ReadByte() (byte, error)
-```
-
-ReadByte reads a single byte from the RX buffer.
-If there is no data in the buffer, returns an error.
-
-
-### func (*USBCDC) Receive
-
-```go
-func (usbcdc *USBCDC) Receive(data byte)
-```
-
-Receive handles adding data to the UART's data buffer.
-Usually called by the IRQ handler for a machine.
-
-
-### func (*USBCDC) Write
-
-```go
-func (usbcdc *USBCDC) Write(data []byte) (n int, err error)
-```
-
-Write data to the USBCDC.
-
-
-### func (*USBCDC) WriteByte
-
-```go
-func (usbcdc *USBCDC) WriteByte(c byte) error
-```
-
-WriteByte writes a byte of data to the USB CDC interface.
-
-
-
-
-## type USBDescriptor
-
-```go
-type USBDescriptor struct {
-	Device		[]byte
-	Configuration	[]byte
-	HID		map[uint16][]byte
+type USBDevice struct {
+	initcomplete bool
 }
 ```
 
 
 
 
-### func (*USBDescriptor) Configure
+### func (*USBDevice) Configure
 
 ```go
-func (d *USBDescriptor) Configure(idVendor, idProduct uint16)
+func (dev *USBDevice) Configure(config UARTConfig)
 ```
 
+Configure the USB peripheral. The config is here for compatibility with the UART interface.
 
 
 

--- a/content/docs/reference/microcontrollers/machine/particle-boron.md
+++ b/content/docs/reference/microcontrollers/machine/particle-boron.md
@@ -238,6 +238,16 @@ Pin change interrupt constants for SetInterrupt.
 
 ```go
 const (
+	DFU_MAGIC_SERIAL_ONLY_RESET	= 0x4e
+	DFU_MAGIC_UF2_RESET		= 0x57
+	DFU_MAGIC_OTA_RESET		= 0xA8
+)
+```
+
+
+
+```go
+const (
 	// ParityNone means to not use any parity checking. This is
 	// the most common setting.
 	ParityNone	UARTParity	= 0
@@ -324,40 +334,6 @@ PWM
 
 ```go
 var (
-	USB		= &_USB
-	_USB		= USBCDC{Buffer: NewRingBuffer()}
-	waitHidTxc	bool
-
-	usbEndpointDescriptors	[8]usbDeviceDescriptor
-
-	udd_ep_in_cache_buffer	[7][128]uint8
-	udd_ep_out_cache_buffer	[7][128]uint8
-
-	sendOnEP0DATADONE	struct {
-		ptr	*byte
-		count	int
-	}
-	isEndpointHalt		= false
-	isRemoteWakeUpEnabled	= false
-	endPoints		= []uint32{usb_ENDPOINT_TYPE_CONTROL,
-		(usb_ENDPOINT_TYPE_INTERRUPT | usbEndpointIn),
-		(usb_ENDPOINT_TYPE_BULK | usbEndpointOut),
-		(usb_ENDPOINT_TYPE_BULK | usbEndpointIn)}
-
-	usbConfiguration		uint8
-	usbSetInterface			uint8
-	usbLineInfo			= cdcLineInfo{115200, 0x00, 0x00, 0x08, 0x00}
-	epinen				uint32
-	epouten				uint32
-	easyDMABusy			volatile.Register8
-	epout0data_setlinecoding	bool
-)
-```
-
-
-
-```go
-var (
 	SPI0	= SPI{Bus: nrf.SPIM0, buf: new([1]byte)}
 	SPI1	= SPI{Bus: nrf.SPIM1, buf: new([1]byte)}
 	SPI2	= SPI{Bus: nrf.SPIM2, buf: new([1]byte)}
@@ -382,6 +358,24 @@ var Serial = DefaultUART
 Serial is implemented via the default (usually the first) UART on the chip.
 
 
+```go
+var (
+	USBDev	= &USBDevice{}
+	USBCDC	Serialer
+)
+```
+
+
+
+```go
+var (
+	ErrUSBReadTimeout	= errors.New("USB read timeout")
+	ErrUSBBytesRead		= errors.New("USB invalid number of bytes read")
+)
+```
+
+
+
 
 
 
@@ -393,13 +387,69 @@ func CPUFrequency() uint32
 
 
 
+### func EnableCDC
+
+```go
+func EnableCDC(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
+```
+
+
+
 ### func EnableHID
 
 ```go
-func EnableHID(callback func())
+func EnableHID(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
 ```
 
 EnableHID enables HID. This function must be executed from the init().
+
+
+### func EnableMIDI
+
+```go
+func EnableMIDI(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
+```
+
+EnableMIDI enables MIDI. This function must be executed from the init().
+
+
+### func EnterBootloader
+
+```go
+func EnterBootloader()
+```
+
+EnterBootloader resets the chip into the serial bootloader.
+
+
+### func EnterOTABootloader
+
+```go
+func EnterOTABootloader()
+```
+
+EnterOTABootloader resets the chip into the bootloader so that it can be
+flashed via an OTA update
+
+
+### func EnterSerialBootloader
+
+```go
+func EnterSerialBootloader()
+```
+
+EnterSerialBootloader resets the chip into the serial bootloader. After
+reset, it can be flashed using serial/nrfutil.
+
+
+### func EnterUF2Bootloader
+
+```go
+func EnterUF2Bootloader()
+```
+
+EnterUF2Bootloader resets the chip into the UF2 bootloader. After reset, it
+can be flashed via nrfutil or by copying a UF2 file to the mass storage device
 
 
 ### func InitADC
@@ -411,6 +461,14 @@ func InitADC()
 InitADC initializes the registers needed for ADC.
 
 
+### func InitSerial
+
+```go
+func InitSerial()
+```
+
+
+
 ### func NewRingBuffer
 
 ```go
@@ -420,13 +478,29 @@ func NewRingBuffer() *RingBuffer
 NewRingBuffer returns a new ring buffer.
 
 
-### func SendUSBHIDPacket
+### func ReceiveUSBControlPacket
 
 ```go
-func SendUSBHIDPacket(ep uint32, data []byte) bool
+func ReceiveUSBControlPacket() ([cdcLineInfoSize]byte, error)
 ```
 
-SendUSBHIDPacket sends a packet for USBHID (interrupt / in).
+
+
+### func SendUSBInPacket
+
+```go
+func SendUSBInPacket(ep uint32, data []byte) bool
+```
+
+SendUSBInPacket sends a packet for USBHID (interrupt in / bulk in).
+
+
+### func SendZlp
+
+```go
+func SendZlp()
+```
+
 
 
 
@@ -1003,6 +1077,25 @@ SPIConfig is used to store config info for SPI.
 
 
 
+## type Serialer
+
+```go
+type Serialer interface {
+	WriteByte(c byte) error
+	Write(data []byte) (n int, err error)
+	Configure(config UARTConfig) error
+	Buffered() int
+	ReadByte() (byte, error)
+	DTR() bool
+	RTS() bool
+}
+```
+
+
+
+
+
+
 ## type UART
 
 ```go
@@ -1121,135 +1214,24 @@ UARTParity is the parity setting to be used for UART communication.
 
 
 
-## type USBCDC
+## type USBDevice
 
 ```go
-type USBCDC struct {
-	Buffer			*RingBuffer
-	interrupt		interrupt.Interrupt
-	initcomplete		bool
-	TxIdx			volatile.Register8
-	waitTxc			bool
-	waitTxcRetryCount	uint8
-	sent			bool
-}
-```
-
-USBCDC is the USB CDC aka serial over USB interface on the nRF52840
-
-
-
-### func (*USBCDC) Buffered
-
-```go
-func (usbcdc *USBCDC) Buffered() int
-```
-
-Buffered returns the number of bytes currently stored in the RX buffer.
-
-
-### func (*USBCDC) Configure
-
-```go
-func (usbcdc *USBCDC) Configure(config UARTConfig)
-```
-
-Configure the USB CDC interface. The config is here for compatibility with the UART interface.
-
-
-### func (*USBCDC) DTR
-
-```go
-func (usbcdc *USBCDC) DTR() bool
-```
-
-
-
-### func (*USBCDC) Flush
-
-```go
-func (usbcdc *USBCDC) Flush() error
-```
-
-Flush flushes buffered data.
-
-
-### func (*USBCDC) RTS
-
-```go
-func (usbcdc *USBCDC) RTS() bool
-```
-
-
-
-### func (*USBCDC) Read
-
-```go
-func (usbcdc *USBCDC) Read(data []byte) (n int, err error)
-```
-
-Read from the RX buffer.
-
-
-### func (*USBCDC) ReadByte
-
-```go
-func (usbcdc *USBCDC) ReadByte() (byte, error)
-```
-
-ReadByte reads a single byte from the RX buffer.
-If there is no data in the buffer, returns an error.
-
-
-### func (*USBCDC) Receive
-
-```go
-func (usbcdc *USBCDC) Receive(data byte)
-```
-
-Receive handles adding data to the UART's data buffer.
-Usually called by the IRQ handler for a machine.
-
-
-### func (*USBCDC) Write
-
-```go
-func (usbcdc *USBCDC) Write(data []byte) (n int, err error)
-```
-
-Write data to the USBCDC.
-
-
-### func (*USBCDC) WriteByte
-
-```go
-func (usbcdc *USBCDC) WriteByte(c byte) error
-```
-
-WriteByte writes a byte of data to the USB CDC interface.
-
-
-
-
-## type USBDescriptor
-
-```go
-type USBDescriptor struct {
-	Device		[]byte
-	Configuration	[]byte
-	HID		map[uint16][]byte
+type USBDevice struct {
+	initcomplete bool
 }
 ```
 
 
 
 
-### func (*USBDescriptor) Configure
+### func (*USBDevice) Configure
 
 ```go
-func (d *USBDescriptor) Configure(idVendor, idProduct uint16)
+func (dev *USBDevice) Configure(config UARTConfig)
 ```
 
+Configure the USB peripheral. The config is here for compatibility with the UART interface.
 
 
 

--- a/content/docs/reference/microcontrollers/machine/particle-xenon.md
+++ b/content/docs/reference/microcontrollers/machine/particle-xenon.md
@@ -220,6 +220,16 @@ Pin change interrupt constants for SetInterrupt.
 
 ```go
 const (
+	DFU_MAGIC_SERIAL_ONLY_RESET	= 0x4e
+	DFU_MAGIC_UF2_RESET		= 0x57
+	DFU_MAGIC_OTA_RESET		= 0xA8
+)
+```
+
+
+
+```go
+const (
 	// ParityNone means to not use any parity checking. This is
 	// the most common setting.
 	ParityNone	UARTParity	= 0
@@ -306,40 +316,6 @@ PWM
 
 ```go
 var (
-	USB		= &_USB
-	_USB		= USBCDC{Buffer: NewRingBuffer()}
-	waitHidTxc	bool
-
-	usbEndpointDescriptors	[8]usbDeviceDescriptor
-
-	udd_ep_in_cache_buffer	[7][128]uint8
-	udd_ep_out_cache_buffer	[7][128]uint8
-
-	sendOnEP0DATADONE	struct {
-		ptr	*byte
-		count	int
-	}
-	isEndpointHalt		= false
-	isRemoteWakeUpEnabled	= false
-	endPoints		= []uint32{usb_ENDPOINT_TYPE_CONTROL,
-		(usb_ENDPOINT_TYPE_INTERRUPT | usbEndpointIn),
-		(usb_ENDPOINT_TYPE_BULK | usbEndpointOut),
-		(usb_ENDPOINT_TYPE_BULK | usbEndpointIn)}
-
-	usbConfiguration		uint8
-	usbSetInterface			uint8
-	usbLineInfo			= cdcLineInfo{115200, 0x00, 0x00, 0x08, 0x00}
-	epinen				uint32
-	epouten				uint32
-	easyDMABusy			volatile.Register8
-	epout0data_setlinecoding	bool
-)
-```
-
-
-
-```go
-var (
 	SPI0	= SPI{Bus: nrf.SPIM0, buf: new([1]byte)}
 	SPI1	= SPI{Bus: nrf.SPIM1, buf: new([1]byte)}
 	SPI2	= SPI{Bus: nrf.SPIM2, buf: new([1]byte)}
@@ -364,6 +340,24 @@ var Serial = DefaultUART
 Serial is implemented via the default (usually the first) UART on the chip.
 
 
+```go
+var (
+	USBDev	= &USBDevice{}
+	USBCDC	Serialer
+)
+```
+
+
+
+```go
+var (
+	ErrUSBReadTimeout	= errors.New("USB read timeout")
+	ErrUSBBytesRead		= errors.New("USB invalid number of bytes read")
+)
+```
+
+
+
 
 
 
@@ -375,13 +369,69 @@ func CPUFrequency() uint32
 
 
 
+### func EnableCDC
+
+```go
+func EnableCDC(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
+```
+
+
+
 ### func EnableHID
 
 ```go
-func EnableHID(callback func())
+func EnableHID(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
 ```
 
 EnableHID enables HID. This function must be executed from the init().
+
+
+### func EnableMIDI
+
+```go
+func EnableMIDI(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
+```
+
+EnableMIDI enables MIDI. This function must be executed from the init().
+
+
+### func EnterBootloader
+
+```go
+func EnterBootloader()
+```
+
+EnterBootloader resets the chip into the serial bootloader.
+
+
+### func EnterOTABootloader
+
+```go
+func EnterOTABootloader()
+```
+
+EnterOTABootloader resets the chip into the bootloader so that it can be
+flashed via an OTA update
+
+
+### func EnterSerialBootloader
+
+```go
+func EnterSerialBootloader()
+```
+
+EnterSerialBootloader resets the chip into the serial bootloader. After
+reset, it can be flashed using serial/nrfutil.
+
+
+### func EnterUF2Bootloader
+
+```go
+func EnterUF2Bootloader()
+```
+
+EnterUF2Bootloader resets the chip into the UF2 bootloader. After reset, it
+can be flashed via nrfutil or by copying a UF2 file to the mass storage device
 
 
 ### func InitADC
@@ -393,6 +443,14 @@ func InitADC()
 InitADC initializes the registers needed for ADC.
 
 
+### func InitSerial
+
+```go
+func InitSerial()
+```
+
+
+
 ### func NewRingBuffer
 
 ```go
@@ -402,13 +460,29 @@ func NewRingBuffer() *RingBuffer
 NewRingBuffer returns a new ring buffer.
 
 
-### func SendUSBHIDPacket
+### func ReceiveUSBControlPacket
 
 ```go
-func SendUSBHIDPacket(ep uint32, data []byte) bool
+func ReceiveUSBControlPacket() ([cdcLineInfoSize]byte, error)
 ```
 
-SendUSBHIDPacket sends a packet for USBHID (interrupt / in).
+
+
+### func SendUSBInPacket
+
+```go
+func SendUSBInPacket(ep uint32, data []byte) bool
+```
+
+SendUSBInPacket sends a packet for USBHID (interrupt in / bulk in).
+
+
+### func SendZlp
+
+```go
+func SendZlp()
+```
+
 
 
 
@@ -985,6 +1059,25 @@ SPIConfig is used to store config info for SPI.
 
 
 
+## type Serialer
+
+```go
+type Serialer interface {
+	WriteByte(c byte) error
+	Write(data []byte) (n int, err error)
+	Configure(config UARTConfig) error
+	Buffered() int
+	ReadByte() (byte, error)
+	DTR() bool
+	RTS() bool
+}
+```
+
+
+
+
+
+
 ## type UART
 
 ```go
@@ -1103,135 +1196,24 @@ UARTParity is the parity setting to be used for UART communication.
 
 
 
-## type USBCDC
+## type USBDevice
 
 ```go
-type USBCDC struct {
-	Buffer			*RingBuffer
-	interrupt		interrupt.Interrupt
-	initcomplete		bool
-	TxIdx			volatile.Register8
-	waitTxc			bool
-	waitTxcRetryCount	uint8
-	sent			bool
-}
-```
-
-USBCDC is the USB CDC aka serial over USB interface on the nRF52840
-
-
-
-### func (*USBCDC) Buffered
-
-```go
-func (usbcdc *USBCDC) Buffered() int
-```
-
-Buffered returns the number of bytes currently stored in the RX buffer.
-
-
-### func (*USBCDC) Configure
-
-```go
-func (usbcdc *USBCDC) Configure(config UARTConfig)
-```
-
-Configure the USB CDC interface. The config is here for compatibility with the UART interface.
-
-
-### func (*USBCDC) DTR
-
-```go
-func (usbcdc *USBCDC) DTR() bool
-```
-
-
-
-### func (*USBCDC) Flush
-
-```go
-func (usbcdc *USBCDC) Flush() error
-```
-
-Flush flushes buffered data.
-
-
-### func (*USBCDC) RTS
-
-```go
-func (usbcdc *USBCDC) RTS() bool
-```
-
-
-
-### func (*USBCDC) Read
-
-```go
-func (usbcdc *USBCDC) Read(data []byte) (n int, err error)
-```
-
-Read from the RX buffer.
-
-
-### func (*USBCDC) ReadByte
-
-```go
-func (usbcdc *USBCDC) ReadByte() (byte, error)
-```
-
-ReadByte reads a single byte from the RX buffer.
-If there is no data in the buffer, returns an error.
-
-
-### func (*USBCDC) Receive
-
-```go
-func (usbcdc *USBCDC) Receive(data byte)
-```
-
-Receive handles adding data to the UART's data buffer.
-Usually called by the IRQ handler for a machine.
-
-
-### func (*USBCDC) Write
-
-```go
-func (usbcdc *USBCDC) Write(data []byte) (n int, err error)
-```
-
-Write data to the USBCDC.
-
-
-### func (*USBCDC) WriteByte
-
-```go
-func (usbcdc *USBCDC) WriteByte(c byte) error
-```
-
-WriteByte writes a byte of data to the USB CDC interface.
-
-
-
-
-## type USBDescriptor
-
-```go
-type USBDescriptor struct {
-	Device		[]byte
-	Configuration	[]byte
-	HID		map[uint16][]byte
+type USBDevice struct {
+	initcomplete bool
 }
 ```
 
 
 
 
-### func (*USBDescriptor) Configure
+### func (*USBDevice) Configure
 
 ```go
-func (d *USBDescriptor) Configure(idVendor, idProduct uint16)
+func (dev *USBDevice) Configure(config UARTConfig)
 ```
 
+Configure the USB peripheral. The config is here for compatibility with the UART interface.
 
 
 

--- a/content/docs/reference/microcontrollers/machine/pca10031.md
+++ b/content/docs/reference/microcontrollers/machine/pca10031.md
@@ -217,6 +217,14 @@ func CPUFrequency() uint32
 
 
 
+### func InitSerial
+
+```go
+func InitSerial()
+```
+
+
+
 ### func NewRingBuffer
 
 ```go

--- a/content/docs/reference/microcontrollers/machine/pca10040.md
+++ b/content/docs/reference/microcontrollers/machine/pca10040.md
@@ -303,6 +303,14 @@ func InitADC()
 InitADC initializes the registers needed for ADC.
 
 
+### func InitSerial
+
+```go
+func InitSerial()
+```
+
+
+
 ### func NewRingBuffer
 
 ```go

--- a/content/docs/reference/microcontrollers/machine/pca10056.md
+++ b/content/docs/reference/microcontrollers/machine/pca10056.md
@@ -192,6 +192,16 @@ Pin change interrupt constants for SetInterrupt.
 
 ```go
 const (
+	DFU_MAGIC_SERIAL_ONLY_RESET	= 0x4e
+	DFU_MAGIC_UF2_RESET		= 0x57
+	DFU_MAGIC_OTA_RESET		= 0xA8
+)
+```
+
+
+
+```go
+const (
 	// ParityNone means to not use any parity checking. This is
 	// the most common setting.
 	ParityNone	UARTParity	= 0
@@ -275,40 +285,6 @@ PWM
 
 ```go
 var (
-	USB		= &_USB
-	_USB		= USBCDC{Buffer: NewRingBuffer()}
-	waitHidTxc	bool
-
-	usbEndpointDescriptors	[8]usbDeviceDescriptor
-
-	udd_ep_in_cache_buffer	[7][128]uint8
-	udd_ep_out_cache_buffer	[7][128]uint8
-
-	sendOnEP0DATADONE	struct {
-		ptr	*byte
-		count	int
-	}
-	isEndpointHalt		= false
-	isRemoteWakeUpEnabled	= false
-	endPoints		= []uint32{usb_ENDPOINT_TYPE_CONTROL,
-		(usb_ENDPOINT_TYPE_INTERRUPT | usbEndpointIn),
-		(usb_ENDPOINT_TYPE_BULK | usbEndpointOut),
-		(usb_ENDPOINT_TYPE_BULK | usbEndpointIn)}
-
-	usbConfiguration		uint8
-	usbSetInterface			uint8
-	usbLineInfo			= cdcLineInfo{115200, 0x00, 0x00, 0x08, 0x00}
-	epinen				uint32
-	epouten				uint32
-	easyDMABusy			volatile.Register8
-	epout0data_setlinecoding	bool
-)
-```
-
-
-
-```go
-var (
 	SPI0	= SPI{Bus: nrf.SPIM0, buf: new([1]byte)}
 	SPI1	= SPI{Bus: nrf.SPIM1, buf: new([1]byte)}
 	SPI2	= SPI{Bus: nrf.SPIM2, buf: new([1]byte)}
@@ -333,6 +309,24 @@ var Serial = DefaultUART
 Serial is implemented via the default (usually the first) UART on the chip.
 
 
+```go
+var (
+	USBDev	= &USBDevice{}
+	USBCDC	Serialer
+)
+```
+
+
+
+```go
+var (
+	ErrUSBReadTimeout	= errors.New("USB read timeout")
+	ErrUSBBytesRead		= errors.New("USB invalid number of bytes read")
+)
+```
+
+
+
 
 
 
@@ -344,13 +338,69 @@ func CPUFrequency() uint32
 
 
 
+### func EnableCDC
+
+```go
+func EnableCDC(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
+```
+
+
+
 ### func EnableHID
 
 ```go
-func EnableHID(callback func())
+func EnableHID(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
 ```
 
 EnableHID enables HID. This function must be executed from the init().
+
+
+### func EnableMIDI
+
+```go
+func EnableMIDI(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
+```
+
+EnableMIDI enables MIDI. This function must be executed from the init().
+
+
+### func EnterBootloader
+
+```go
+func EnterBootloader()
+```
+
+EnterBootloader resets the chip into the serial bootloader.
+
+
+### func EnterOTABootloader
+
+```go
+func EnterOTABootloader()
+```
+
+EnterOTABootloader resets the chip into the bootloader so that it can be
+flashed via an OTA update
+
+
+### func EnterSerialBootloader
+
+```go
+func EnterSerialBootloader()
+```
+
+EnterSerialBootloader resets the chip into the serial bootloader. After
+reset, it can be flashed using serial/nrfutil.
+
+
+### func EnterUF2Bootloader
+
+```go
+func EnterUF2Bootloader()
+```
+
+EnterUF2Bootloader resets the chip into the UF2 bootloader. After reset, it
+can be flashed via nrfutil or by copying a UF2 file to the mass storage device
 
 
 ### func InitADC
@@ -362,6 +412,14 @@ func InitADC()
 InitADC initializes the registers needed for ADC.
 
 
+### func InitSerial
+
+```go
+func InitSerial()
+```
+
+
+
 ### func NewRingBuffer
 
 ```go
@@ -371,13 +429,29 @@ func NewRingBuffer() *RingBuffer
 NewRingBuffer returns a new ring buffer.
 
 
-### func SendUSBHIDPacket
+### func ReceiveUSBControlPacket
 
 ```go
-func SendUSBHIDPacket(ep uint32, data []byte) bool
+func ReceiveUSBControlPacket() ([cdcLineInfoSize]byte, error)
 ```
 
-SendUSBHIDPacket sends a packet for USBHID (interrupt / in).
+
+
+### func SendUSBInPacket
+
+```go
+func SendUSBInPacket(ep uint32, data []byte) bool
+```
+
+SendUSBInPacket sends a packet for USBHID (interrupt in / bulk in).
+
+
+### func SendZlp
+
+```go
+func SendZlp()
+```
+
 
 
 
@@ -954,6 +1028,25 @@ SPIConfig is used to store config info for SPI.
 
 
 
+## type Serialer
+
+```go
+type Serialer interface {
+	WriteByte(c byte) error
+	Write(data []byte) (n int, err error)
+	Configure(config UARTConfig) error
+	Buffered() int
+	ReadByte() (byte, error)
+	DTR() bool
+	RTS() bool
+}
+```
+
+
+
+
+
+
 ## type UART
 
 ```go
@@ -1072,135 +1165,24 @@ UARTParity is the parity setting to be used for UART communication.
 
 
 
-## type USBCDC
+## type USBDevice
 
 ```go
-type USBCDC struct {
-	Buffer			*RingBuffer
-	interrupt		interrupt.Interrupt
-	initcomplete		bool
-	TxIdx			volatile.Register8
-	waitTxc			bool
-	waitTxcRetryCount	uint8
-	sent			bool
-}
-```
-
-USBCDC is the USB CDC aka serial over USB interface on the nRF52840
-
-
-
-### func (*USBCDC) Buffered
-
-```go
-func (usbcdc *USBCDC) Buffered() int
-```
-
-Buffered returns the number of bytes currently stored in the RX buffer.
-
-
-### func (*USBCDC) Configure
-
-```go
-func (usbcdc *USBCDC) Configure(config UARTConfig)
-```
-
-Configure the USB CDC interface. The config is here for compatibility with the UART interface.
-
-
-### func (*USBCDC) DTR
-
-```go
-func (usbcdc *USBCDC) DTR() bool
-```
-
-
-
-### func (*USBCDC) Flush
-
-```go
-func (usbcdc *USBCDC) Flush() error
-```
-
-Flush flushes buffered data.
-
-
-### func (*USBCDC) RTS
-
-```go
-func (usbcdc *USBCDC) RTS() bool
-```
-
-
-
-### func (*USBCDC) Read
-
-```go
-func (usbcdc *USBCDC) Read(data []byte) (n int, err error)
-```
-
-Read from the RX buffer.
-
-
-### func (*USBCDC) ReadByte
-
-```go
-func (usbcdc *USBCDC) ReadByte() (byte, error)
-```
-
-ReadByte reads a single byte from the RX buffer.
-If there is no data in the buffer, returns an error.
-
-
-### func (*USBCDC) Receive
-
-```go
-func (usbcdc *USBCDC) Receive(data byte)
-```
-
-Receive handles adding data to the UART's data buffer.
-Usually called by the IRQ handler for a machine.
-
-
-### func (*USBCDC) Write
-
-```go
-func (usbcdc *USBCDC) Write(data []byte) (n int, err error)
-```
-
-Write data to the USBCDC.
-
-
-### func (*USBCDC) WriteByte
-
-```go
-func (usbcdc *USBCDC) WriteByte(c byte) error
-```
-
-WriteByte writes a byte of data to the USB CDC interface.
-
-
-
-
-## type USBDescriptor
-
-```go
-type USBDescriptor struct {
-	Device		[]byte
-	Configuration	[]byte
-	HID		map[uint16][]byte
+type USBDevice struct {
+	initcomplete bool
 }
 ```
 
 
 
 
-### func (*USBDescriptor) Configure
+### func (*USBDevice) Configure
 
 ```go
-func (d *USBDescriptor) Configure(idVendor, idProduct uint16)
+func (dev *USBDevice) Configure(config UARTConfig)
 ```
 
+Configure the USB peripheral. The config is here for compatibility with the UART interface.
 
 
 

--- a/content/docs/reference/microcontrollers/machine/pca10059.md
+++ b/content/docs/reference/microcontrollers/machine/pca10059.md
@@ -188,6 +188,16 @@ Pin change interrupt constants for SetInterrupt.
 
 ```go
 const (
+	DFU_MAGIC_SERIAL_ONLY_RESET	= 0x4e
+	DFU_MAGIC_UF2_RESET		= 0x57
+	DFU_MAGIC_OTA_RESET		= 0xA8
+)
+```
+
+
+
+```go
+const (
 	// ParityNone means to not use any parity checking. This is
 	// the most common setting.
 	ParityNone	UARTParity	= 0
@@ -265,40 +275,6 @@ PWM
 
 ```go
 var (
-	USB		= &_USB
-	_USB		= USBCDC{Buffer: NewRingBuffer()}
-	waitHidTxc	bool
-
-	usbEndpointDescriptors	[8]usbDeviceDescriptor
-
-	udd_ep_in_cache_buffer	[7][128]uint8
-	udd_ep_out_cache_buffer	[7][128]uint8
-
-	sendOnEP0DATADONE	struct {
-		ptr	*byte
-		count	int
-	}
-	isEndpointHalt		= false
-	isRemoteWakeUpEnabled	= false
-	endPoints		= []uint32{usb_ENDPOINT_TYPE_CONTROL,
-		(usb_ENDPOINT_TYPE_INTERRUPT | usbEndpointIn),
-		(usb_ENDPOINT_TYPE_BULK | usbEndpointOut),
-		(usb_ENDPOINT_TYPE_BULK | usbEndpointIn)}
-
-	usbConfiguration		uint8
-	usbSetInterface			uint8
-	usbLineInfo			= cdcLineInfo{115200, 0x00, 0x00, 0x08, 0x00}
-	epinen				uint32
-	epouten				uint32
-	easyDMABusy			volatile.Register8
-	epout0data_setlinecoding	bool
-)
-```
-
-
-
-```go
-var (
 	SPI0	= SPI{Bus: nrf.SPIM0, buf: new([1]byte)}
 	SPI1	= SPI{Bus: nrf.SPIM1, buf: new([1]byte)}
 	SPI2	= SPI{Bus: nrf.SPIM2, buf: new([1]byte)}
@@ -317,10 +293,28 @@ var (
 
 
 ```go
-var Serial = USB
+var Serial Serialer
 ```
 
 Serial is implemented via USB (USB-CDC).
+
+
+```go
+var (
+	USBDev	= &USBDevice{}
+	USBCDC	Serialer
+)
+```
+
+
+
+```go
+var (
+	ErrUSBReadTimeout	= errors.New("USB read timeout")
+	ErrUSBBytesRead		= errors.New("USB invalid number of bytes read")
+)
+```
+
 
 
 
@@ -334,13 +328,69 @@ func CPUFrequency() uint32
 
 
 
+### func EnableCDC
+
+```go
+func EnableCDC(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
+```
+
+
+
 ### func EnableHID
 
 ```go
-func EnableHID(callback func())
+func EnableHID(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
 ```
 
 EnableHID enables HID. This function must be executed from the init().
+
+
+### func EnableMIDI
+
+```go
+func EnableMIDI(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
+```
+
+EnableMIDI enables MIDI. This function must be executed from the init().
+
+
+### func EnterBootloader
+
+```go
+func EnterBootloader()
+```
+
+EnterBootloader resets the chip into the serial bootloader.
+
+
+### func EnterOTABootloader
+
+```go
+func EnterOTABootloader()
+```
+
+EnterOTABootloader resets the chip into the bootloader so that it can be
+flashed via an OTA update
+
+
+### func EnterSerialBootloader
+
+```go
+func EnterSerialBootloader()
+```
+
+EnterSerialBootloader resets the chip into the serial bootloader. After
+reset, it can be flashed using serial/nrfutil.
+
+
+### func EnterUF2Bootloader
+
+```go
+func EnterUF2Bootloader()
+```
+
+EnterUF2Bootloader resets the chip into the UF2 bootloader. After reset, it
+can be flashed via nrfutil or by copying a UF2 file to the mass storage device
 
 
 ### func InitADC
@@ -352,6 +402,14 @@ func InitADC()
 InitADC initializes the registers needed for ADC.
 
 
+### func InitSerial
+
+```go
+func InitSerial()
+```
+
+
+
 ### func NewRingBuffer
 
 ```go
@@ -361,13 +419,29 @@ func NewRingBuffer() *RingBuffer
 NewRingBuffer returns a new ring buffer.
 
 
-### func SendUSBHIDPacket
+### func ReceiveUSBControlPacket
 
 ```go
-func SendUSBHIDPacket(ep uint32, data []byte) bool
+func ReceiveUSBControlPacket() ([cdcLineInfoSize]byte, error)
 ```
 
-SendUSBHIDPacket sends a packet for USBHID (interrupt / in).
+
+
+### func SendUSBInPacket
+
+```go
+func SendUSBInPacket(ep uint32, data []byte) bool
+```
+
+SendUSBInPacket sends a packet for USBHID (interrupt in / bulk in).
+
+
+### func SendZlp
+
+```go
+func SendZlp()
+```
+
 
 
 
@@ -944,6 +1018,25 @@ SPIConfig is used to store config info for SPI.
 
 
 
+## type Serialer
+
+```go
+type Serialer interface {
+	WriteByte(c byte) error
+	Write(data []byte) (n int, err error)
+	Configure(config UARTConfig) error
+	Buffered() int
+	ReadByte() (byte, error)
+	DTR() bool
+	RTS() bool
+}
+```
+
+
+
+
+
+
 ## type UART
 
 ```go
@@ -1062,135 +1155,24 @@ UARTParity is the parity setting to be used for UART communication.
 
 
 
-## type USBCDC
+## type USBDevice
 
 ```go
-type USBCDC struct {
-	Buffer			*RingBuffer
-	interrupt		interrupt.Interrupt
-	initcomplete		bool
-	TxIdx			volatile.Register8
-	waitTxc			bool
-	waitTxcRetryCount	uint8
-	sent			bool
-}
-```
-
-USBCDC is the USB CDC aka serial over USB interface on the nRF52840
-
-
-
-### func (*USBCDC) Buffered
-
-```go
-func (usbcdc *USBCDC) Buffered() int
-```
-
-Buffered returns the number of bytes currently stored in the RX buffer.
-
-
-### func (*USBCDC) Configure
-
-```go
-func (usbcdc *USBCDC) Configure(config UARTConfig)
-```
-
-Configure the USB CDC interface. The config is here for compatibility with the UART interface.
-
-
-### func (*USBCDC) DTR
-
-```go
-func (usbcdc *USBCDC) DTR() bool
-```
-
-
-
-### func (*USBCDC) Flush
-
-```go
-func (usbcdc *USBCDC) Flush() error
-```
-
-Flush flushes buffered data.
-
-
-### func (*USBCDC) RTS
-
-```go
-func (usbcdc *USBCDC) RTS() bool
-```
-
-
-
-### func (*USBCDC) Read
-
-```go
-func (usbcdc *USBCDC) Read(data []byte) (n int, err error)
-```
-
-Read from the RX buffer.
-
-
-### func (*USBCDC) ReadByte
-
-```go
-func (usbcdc *USBCDC) ReadByte() (byte, error)
-```
-
-ReadByte reads a single byte from the RX buffer.
-If there is no data in the buffer, returns an error.
-
-
-### func (*USBCDC) Receive
-
-```go
-func (usbcdc *USBCDC) Receive(data byte)
-```
-
-Receive handles adding data to the UART's data buffer.
-Usually called by the IRQ handler for a machine.
-
-
-### func (*USBCDC) Write
-
-```go
-func (usbcdc *USBCDC) Write(data []byte) (n int, err error)
-```
-
-Write data to the USBCDC.
-
-
-### func (*USBCDC) WriteByte
-
-```go
-func (usbcdc *USBCDC) WriteByte(c byte) error
-```
-
-WriteByte writes a byte of data to the USB CDC interface.
-
-
-
-
-## type USBDescriptor
-
-```go
-type USBDescriptor struct {
-	Device		[]byte
-	Configuration	[]byte
-	HID		map[uint16][]byte
+type USBDevice struct {
+	initcomplete bool
 }
 ```
 
 
 
 
-### func (*USBDescriptor) Configure
+### func (*USBDevice) Configure
 
 ```go
-func (d *USBDescriptor) Configure(idVendor, idProduct uint16)
+func (dev *USBDevice) Configure(config UARTConfig)
 ```
 
+Configure the USB peripheral. The config is here for compatibility with the UART interface.
 
 
 

--- a/content/docs/reference/microcontrollers/machine/pinetime-devkit0.md
+++ b/content/docs/reference/microcontrollers/machine/pinetime-devkit0.md
@@ -312,6 +312,14 @@ func InitADC()
 InitADC initializes the registers needed for ADC.
 
 
+### func InitSerial
+
+```go
+func InitSerial()
+```
+
+
+
 ### func NewRingBuffer
 
 ```go

--- a/content/docs/reference/microcontrollers/machine/pybadge.md
+++ b/content/docs/reference/microcontrollers/machine/pybadge.md
@@ -523,16 +523,6 @@ var (
 
 ```go
 var (
-	// USB is a USB CDC interface.
-	USB		= &USBCDC{Buffer: NewRingBuffer()}
-	waitHidTxc	bool
-)
-```
-
-
-
-```go
-var (
 	DAC0 = DAC{}
 )
 ```
@@ -561,10 +551,28 @@ var (
 
 
 ```go
-var Serial = USB
+var Serial Serialer
 ```
 
 Serial is implemented via USB (USB-CDC).
+
+
+```go
+var (
+	USBDev	= &USBDevice{}
+	USBCDC	Serialer
+)
+```
+
+
+
+```go
+var (
+	ErrUSBReadTimeout	= errors.New("USB read timeout")
+	ErrUSBBytesRead		= errors.New("USB invalid number of bytes read")
+)
+```
+
 
 
 
@@ -578,13 +586,40 @@ func CPUFrequency() uint32
 
 
 
+### func EnableCDC
+
+```go
+func EnableCDC(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
+```
+
+
+
 ### func EnableHID
 
 ```go
-func EnableHID(callback func())
+func EnableHID(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
 ```
 
 EnableHID enables HID. This function must be executed from the init().
+
+
+### func EnableMIDI
+
+```go
+func EnableMIDI(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
+```
+
+EnableMIDI enables MIDI. This function must be executed from the init().
+
+
+### func EnterBootloader
+
+```go
+func EnterBootloader()
+```
+
+EnterBootloader should perform a system reset in preparation
+to switch to the bootloader to flash new firmware.
 
 
 ### func GetRNG
@@ -605,6 +640,14 @@ func InitADC()
 InitADC initializes the ADC.
 
 
+### func InitSerial
+
+```go
+func InitSerial()
+```
+
+
+
 ### func NewRingBuffer
 
 ```go
@@ -614,23 +657,29 @@ func NewRingBuffer() *RingBuffer
 NewRingBuffer returns a new ring buffer.
 
 
-### func ResetProcessor
+### func ReceiveUSBControlPacket
 
 ```go
-func ResetProcessor()
+func ReceiveUSBControlPacket() ([cdcLineInfoSize]byte, error)
 ```
 
-ResetProcessor should perform a system reset in preparation
-to switch to the bootloader to flash new firmware.
 
 
-### func SendUSBHIDPacket
+### func SendUSBInPacket
 
 ```go
-func SendUSBHIDPacket(ep uint32, data []byte) bool
+func SendUSBInPacket(ep uint32, data []byte) bool
 ```
 
-SendUSBHIDPacket sends a packet for USBHID (interrupt / in).
+SendUSBInPacket sends a packet for USB (interrupt in / bulk in).
+
+
+### func SendZlp
+
+```go
+func SendZlp()
+```
+
 
 
 
@@ -1257,6 +1306,25 @@ SPIConfig is used to store config info for SPI.
 
 
 
+## type Serialer
+
+```go
+type Serialer interface {
+	WriteByte(c byte) error
+	Write(data []byte) (n int, err error)
+	Configure(config UARTConfig) error
+	Buffered() int
+	ReadByte() (byte, error)
+	DTR() bool
+	RTS() bool
+}
+```
+
+
+
+
+
+
 ## type TCC
 
 ```go
@@ -1490,143 +1558,24 @@ UARTParity is the parity setting to be used for UART communication.
 
 
 
-## type USBCDC
+## type USBDevice
 
 ```go
-type USBCDC struct {
-	Buffer			*RingBuffer
-	TxIdx			volatile.Register8
-	waitTxc			bool
-	waitTxcRetryCount	uint8
-	sent			bool
-	configured		bool
-}
-```
-
-USBCDC is the USB CDC aka serial over USB interface on the SAMD21.
-
-
-
-### func (*USBCDC) Buffered
-
-```go
-func (usbcdc *USBCDC) Buffered() int
-```
-
-Buffered returns the number of bytes currently stored in the RX buffer.
-
-
-### func (*USBCDC) Configure
-
-```go
-func (usbcdc *USBCDC) Configure(config UARTConfig)
-```
-
-Configure the USB CDC interface. The config is here for compatibility with the UART interface.
-
-
-### func (*USBCDC) Configured
-
-```go
-func (usbcdc *USBCDC) Configured() bool
-```
-
-Configured returns whether usbcdc is configured or not.
-
-
-### func (*USBCDC) DTR
-
-```go
-func (usbcdc *USBCDC) DTR() bool
-```
-
-
-
-### func (*USBCDC) Flush
-
-```go
-func (usbcdc *USBCDC) Flush() error
-```
-
-Flush flushes buffered data.
-
-
-### func (*USBCDC) RTS
-
-```go
-func (usbcdc *USBCDC) RTS() bool
-```
-
-
-
-### func (*USBCDC) Read
-
-```go
-func (usbcdc *USBCDC) Read(data []byte) (n int, err error)
-```
-
-Read from the RX buffer.
-
-
-### func (*USBCDC) ReadByte
-
-```go
-func (usbcdc *USBCDC) ReadByte() (byte, error)
-```
-
-ReadByte reads a single byte from the RX buffer.
-If there is no data in the buffer, returns an error.
-
-
-### func (*USBCDC) Receive
-
-```go
-func (usbcdc *USBCDC) Receive(data byte)
-```
-
-Receive handles adding data to the UART's data buffer.
-Usually called by the IRQ handler for a machine.
-
-
-### func (*USBCDC) Write
-
-```go
-func (usbcdc *USBCDC) Write(data []byte) (n int, err error)
-```
-
-Write data to the USBCDC.
-
-
-### func (*USBCDC) WriteByte
-
-```go
-func (usbcdc *USBCDC) WriteByte(c byte) error
-```
-
-WriteByte writes a byte of data to the USB CDC interface.
-
-
-
-
-## type USBDescriptor
-
-```go
-type USBDescriptor struct {
-	Device		[]byte
-	Configuration	[]byte
-	HID		map[uint16][]byte
+type USBDevice struct {
+	initcomplete bool
 }
 ```
 
 
 
 
-### func (*USBDescriptor) Configure
+### func (*USBDevice) Configure
 
 ```go
-func (d *USBDescriptor) Configure(idVendor, idProduct uint16)
+func (dev *USBDevice) Configure(config UARTConfig)
 ```
 
+Configure the USB peripheral. The config is here for compatibility with the UART interface.
 
 
 

--- a/content/docs/reference/microcontrollers/machine/pygamer.md
+++ b/content/docs/reference/microcontrollers/machine/pygamer.md
@@ -516,16 +516,6 @@ var (
 
 ```go
 var (
-	// USB is a USB CDC interface.
-	USB		= &USBCDC{Buffer: NewRingBuffer()}
-	waitHidTxc	bool
-)
-```
-
-
-
-```go
-var (
 	DAC0 = DAC{}
 )
 ```
@@ -554,10 +544,28 @@ var (
 
 
 ```go
-var Serial = USB
+var Serial Serialer
 ```
 
 Serial is implemented via USB (USB-CDC).
+
+
+```go
+var (
+	USBDev	= &USBDevice{}
+	USBCDC	Serialer
+)
+```
+
+
+
+```go
+var (
+	ErrUSBReadTimeout	= errors.New("USB read timeout")
+	ErrUSBBytesRead		= errors.New("USB invalid number of bytes read")
+)
+```
+
 
 
 
@@ -571,13 +579,40 @@ func CPUFrequency() uint32
 
 
 
+### func EnableCDC
+
+```go
+func EnableCDC(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
+```
+
+
+
 ### func EnableHID
 
 ```go
-func EnableHID(callback func())
+func EnableHID(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
 ```
 
 EnableHID enables HID. This function must be executed from the init().
+
+
+### func EnableMIDI
+
+```go
+func EnableMIDI(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
+```
+
+EnableMIDI enables MIDI. This function must be executed from the init().
+
+
+### func EnterBootloader
+
+```go
+func EnterBootloader()
+```
+
+EnterBootloader should perform a system reset in preparation
+to switch to the bootloader to flash new firmware.
 
 
 ### func GetRNG
@@ -598,6 +633,14 @@ func InitADC()
 InitADC initializes the ADC.
 
 
+### func InitSerial
+
+```go
+func InitSerial()
+```
+
+
+
 ### func NewRingBuffer
 
 ```go
@@ -607,23 +650,29 @@ func NewRingBuffer() *RingBuffer
 NewRingBuffer returns a new ring buffer.
 
 
-### func ResetProcessor
+### func ReceiveUSBControlPacket
 
 ```go
-func ResetProcessor()
+func ReceiveUSBControlPacket() ([cdcLineInfoSize]byte, error)
 ```
 
-ResetProcessor should perform a system reset in preparation
-to switch to the bootloader to flash new firmware.
 
 
-### func SendUSBHIDPacket
+### func SendUSBInPacket
 
 ```go
-func SendUSBHIDPacket(ep uint32, data []byte) bool
+func SendUSBInPacket(ep uint32, data []byte) bool
 ```
 
-SendUSBHIDPacket sends a packet for USBHID (interrupt / in).
+SendUSBInPacket sends a packet for USB (interrupt in / bulk in).
+
+
+### func SendZlp
+
+```go
+func SendZlp()
+```
+
 
 
 
@@ -1250,6 +1299,25 @@ SPIConfig is used to store config info for SPI.
 
 
 
+## type Serialer
+
+```go
+type Serialer interface {
+	WriteByte(c byte) error
+	Write(data []byte) (n int, err error)
+	Configure(config UARTConfig) error
+	Buffered() int
+	ReadByte() (byte, error)
+	DTR() bool
+	RTS() bool
+}
+```
+
+
+
+
+
+
 ## type TCC
 
 ```go
@@ -1483,143 +1551,24 @@ UARTParity is the parity setting to be used for UART communication.
 
 
 
-## type USBCDC
+## type USBDevice
 
 ```go
-type USBCDC struct {
-	Buffer			*RingBuffer
-	TxIdx			volatile.Register8
-	waitTxc			bool
-	waitTxcRetryCount	uint8
-	sent			bool
-	configured		bool
-}
-```
-
-USBCDC is the USB CDC aka serial over USB interface on the SAMD21.
-
-
-
-### func (*USBCDC) Buffered
-
-```go
-func (usbcdc *USBCDC) Buffered() int
-```
-
-Buffered returns the number of bytes currently stored in the RX buffer.
-
-
-### func (*USBCDC) Configure
-
-```go
-func (usbcdc *USBCDC) Configure(config UARTConfig)
-```
-
-Configure the USB CDC interface. The config is here for compatibility with the UART interface.
-
-
-### func (*USBCDC) Configured
-
-```go
-func (usbcdc *USBCDC) Configured() bool
-```
-
-Configured returns whether usbcdc is configured or not.
-
-
-### func (*USBCDC) DTR
-
-```go
-func (usbcdc *USBCDC) DTR() bool
-```
-
-
-
-### func (*USBCDC) Flush
-
-```go
-func (usbcdc *USBCDC) Flush() error
-```
-
-Flush flushes buffered data.
-
-
-### func (*USBCDC) RTS
-
-```go
-func (usbcdc *USBCDC) RTS() bool
-```
-
-
-
-### func (*USBCDC) Read
-
-```go
-func (usbcdc *USBCDC) Read(data []byte) (n int, err error)
-```
-
-Read from the RX buffer.
-
-
-### func (*USBCDC) ReadByte
-
-```go
-func (usbcdc *USBCDC) ReadByte() (byte, error)
-```
-
-ReadByte reads a single byte from the RX buffer.
-If there is no data in the buffer, returns an error.
-
-
-### func (*USBCDC) Receive
-
-```go
-func (usbcdc *USBCDC) Receive(data byte)
-```
-
-Receive handles adding data to the UART's data buffer.
-Usually called by the IRQ handler for a machine.
-
-
-### func (*USBCDC) Write
-
-```go
-func (usbcdc *USBCDC) Write(data []byte) (n int, err error)
-```
-
-Write data to the USBCDC.
-
-
-### func (*USBCDC) WriteByte
-
-```go
-func (usbcdc *USBCDC) WriteByte(c byte) error
-```
-
-WriteByte writes a byte of data to the USB CDC interface.
-
-
-
-
-## type USBDescriptor
-
-```go
-type USBDescriptor struct {
-	Device		[]byte
-	Configuration	[]byte
-	HID		map[uint16][]byte
+type USBDevice struct {
+	initcomplete bool
 }
 ```
 
 
 
 
-### func (*USBDescriptor) Configure
+### func (*USBDevice) Configure
 
 ```go
-func (d *USBDescriptor) Configure(idVendor, idProduct uint16)
+func (dev *USBDevice) Configure(config UARTConfig)
 ```
 
+Configure the USB peripheral. The config is here for compatibility with the UART interface.
 
 
 

--- a/content/docs/reference/microcontrollers/machine/qtpy.md
+++ b/content/docs/reference/microcontrollers/machine/qtpy.md
@@ -382,15 +382,6 @@ The SAM D21 has three TCC peripherals, which have PWM as one feature.
 
 ```go
 var (
-	USB		= &USBCDC{Buffer: NewRingBuffer()}
-	waitHidTxc	bool
-)
-```
-
-
-
-```go
-var (
 	DAC0 = DAC{}
 )
 ```
@@ -406,10 +397,28 @@ var (
 
 
 ```go
-var Serial = USB
+var Serial Serialer
 ```
 
 Serial is implemented via USB (USB-CDC).
+
+
+```go
+var (
+	USBDev	= &USBDevice{}
+	USBCDC	Serialer
+)
+```
+
+
+
+```go
+var (
+	ErrUSBReadTimeout	= errors.New("USB read timeout")
+	ErrUSBBytesRead		= errors.New("USB invalid number of bytes read")
+)
+```
+
 
 
 
@@ -424,13 +433,40 @@ func CPUFrequency() uint32
 Return the current CPU frequency in hertz.
 
 
+### func EnableCDC
+
+```go
+func EnableCDC(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
+```
+
+
+
 ### func EnableHID
 
 ```go
-func EnableHID(callback func())
+func EnableHID(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
 ```
 
 EnableHID enables HID. This function must be executed from the init().
+
+
+### func EnableMIDI
+
+```go
+func EnableMIDI(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
+```
+
+EnableMIDI enables MIDI. This function must be executed from the init().
+
+
+### func EnterBootloader
+
+```go
+func EnterBootloader()
+```
+
+EnterBootloader should perform a system reset in preperation
+to switch to the bootloader to flash new firmware.
 
 
 ### func InitADC
@@ -442,6 +478,14 @@ func InitADC()
 InitADC initializes the ADC.
 
 
+### func InitSerial
+
+```go
+func InitSerial()
+```
+
+
+
 ### func NewRingBuffer
 
 ```go
@@ -451,23 +495,29 @@ func NewRingBuffer() *RingBuffer
 NewRingBuffer returns a new ring buffer.
 
 
-### func ResetProcessor
+### func ReceiveUSBControlPacket
 
 ```go
-func ResetProcessor()
+func ReceiveUSBControlPacket() ([cdcLineInfoSize]byte, error)
 ```
 
-ResetProcessor should perform a system reset in preperation
-to switch to the bootloader to flash new firmware.
 
 
-### func SendUSBHIDPacket
+### func SendUSBInPacket
 
 ```go
-func SendUSBHIDPacket(ep uint32, data []byte) bool
+func SendUSBInPacket(ep uint32, data []byte) bool
 ```
 
-SendUSBHIDPacket sends a packet for USBHID (interrupt / in).
+SendUSBInPacket sends a packet for USB (interrupt in / bulk in).
+
+
+### func SendZlp
+
+```go
+func SendZlp()
+```
+
 
 
 
@@ -1137,6 +1187,25 @@ SPIConfig is used to store config info for SPI.
 
 
 
+## type Serialer
+
+```go
+type Serialer interface {
+	WriteByte(c byte) error
+	Write(data []byte) (n int, err error)
+	Configure(config UARTConfig) error
+	Buffered() int
+	ReadByte() (byte, error)
+	DTR() bool
+	RTS() bool
+}
+```
+
+
+
+
+
+
 ## type TCC
 
 ```go
@@ -1371,143 +1440,24 @@ UARTParity is the parity setting to be used for UART communication.
 
 
 
-## type USBCDC
+## type USBDevice
 
 ```go
-type USBCDC struct {
-	Buffer			*RingBuffer
-	TxIdx			volatile.Register8
-	waitTxc			bool
-	waitTxcRetryCount	uint8
-	sent			bool
-	configured		bool
-}
-```
-
-USBCDC is the USB CDC aka serial over USB interface on the SAMD21.
-
-
-
-### func (*USBCDC) Buffered
-
-```go
-func (usbcdc *USBCDC) Buffered() int
-```
-
-Buffered returns the number of bytes currently stored in the RX buffer.
-
-
-### func (*USBCDC) Configure
-
-```go
-func (usbcdc *USBCDC) Configure(config UARTConfig)
-```
-
-Configure the USB CDC interface. The config is here for compatibility with the UART interface.
-
-
-### func (*USBCDC) Configured
-
-```go
-func (usbcdc *USBCDC) Configured() bool
-```
-
-Configured returns whether usbcdc is configured or not.
-
-
-### func (*USBCDC) DTR
-
-```go
-func (usbcdc *USBCDC) DTR() bool
-```
-
-
-
-### func (*USBCDC) Flush
-
-```go
-func (usbcdc *USBCDC) Flush() error
-```
-
-Flush flushes buffered data.
-
-
-### func (*USBCDC) RTS
-
-```go
-func (usbcdc *USBCDC) RTS() bool
-```
-
-
-
-### func (*USBCDC) Read
-
-```go
-func (usbcdc *USBCDC) Read(data []byte) (n int, err error)
-```
-
-Read from the RX buffer.
-
-
-### func (*USBCDC) ReadByte
-
-```go
-func (usbcdc *USBCDC) ReadByte() (byte, error)
-```
-
-ReadByte reads a single byte from the RX buffer.
-If there is no data in the buffer, returns an error.
-
-
-### func (*USBCDC) Receive
-
-```go
-func (usbcdc *USBCDC) Receive(data byte)
-```
-
-Receive handles adding data to the UART's data buffer.
-Usually called by the IRQ handler for a machine.
-
-
-### func (*USBCDC) Write
-
-```go
-func (usbcdc *USBCDC) Write(data []byte) (n int, err error)
-```
-
-Write data to the USBCDC.
-
-
-### func (*USBCDC) WriteByte
-
-```go
-func (usbcdc *USBCDC) WriteByte(c byte) error
-```
-
-WriteByte writes a byte of data to the USB CDC interface.
-
-
-
-
-## type USBDescriptor
-
-```go
-type USBDescriptor struct {
-	Device		[]byte
-	Configuration	[]byte
-	HID		map[uint16][]byte
+type USBDevice struct {
+	initcomplete bool
 }
 ```
 
 
 
 
-### func (*USBDescriptor) Configure
+### func (*USBDevice) Configure
 
 ```go
-func (d *USBDescriptor) Configure(idVendor, idProduct uint16)
+func (dev *USBDevice) Configure(config UARTConfig)
 ```
 
+Configure the USB peripheral. The config is here for compatibility with the UART interface.
 
 
 

--- a/content/docs/reference/microcontrollers/machine/reelboard.md
+++ b/content/docs/reference/microcontrollers/machine/reelboard.md
@@ -185,6 +185,16 @@ Pin change interrupt constants for SetInterrupt.
 
 ```go
 const (
+	DFU_MAGIC_SERIAL_ONLY_RESET	= 0x4e
+	DFU_MAGIC_UF2_RESET		= 0x57
+	DFU_MAGIC_OTA_RESET		= 0xA8
+)
+```
+
+
+
+```go
+const (
 	// ParityNone means to not use any parity checking. This is
 	// the most common setting.
 	ParityNone	UARTParity	= 0
@@ -268,40 +278,6 @@ PWM
 
 ```go
 var (
-	USB		= &_USB
-	_USB		= USBCDC{Buffer: NewRingBuffer()}
-	waitHidTxc	bool
-
-	usbEndpointDescriptors	[8]usbDeviceDescriptor
-
-	udd_ep_in_cache_buffer	[7][128]uint8
-	udd_ep_out_cache_buffer	[7][128]uint8
-
-	sendOnEP0DATADONE	struct {
-		ptr	*byte
-		count	int
-	}
-	isEndpointHalt		= false
-	isRemoteWakeUpEnabled	= false
-	endPoints		= []uint32{usb_ENDPOINT_TYPE_CONTROL,
-		(usb_ENDPOINT_TYPE_INTERRUPT | usbEndpointIn),
-		(usb_ENDPOINT_TYPE_BULK | usbEndpointOut),
-		(usb_ENDPOINT_TYPE_BULK | usbEndpointIn)}
-
-	usbConfiguration		uint8
-	usbSetInterface			uint8
-	usbLineInfo			= cdcLineInfo{115200, 0x00, 0x00, 0x08, 0x00}
-	epinen				uint32
-	epouten				uint32
-	easyDMABusy			volatile.Register8
-	epout0data_setlinecoding	bool
-)
-```
-
-
-
-```go
-var (
 	SPI0	= SPI{Bus: nrf.SPIM0, buf: new([1]byte)}
 	SPI1	= SPI{Bus: nrf.SPIM1, buf: new([1]byte)}
 	SPI2	= SPI{Bus: nrf.SPIM2, buf: new([1]byte)}
@@ -326,6 +302,24 @@ var Serial = DefaultUART
 Serial is implemented via the default (usually the first) UART on the chip.
 
 
+```go
+var (
+	USBDev	= &USBDevice{}
+	USBCDC	Serialer
+)
+```
+
+
+
+```go
+var (
+	ErrUSBReadTimeout	= errors.New("USB read timeout")
+	ErrUSBBytesRead		= errors.New("USB invalid number of bytes read")
+)
+```
+
+
+
 
 
 
@@ -337,13 +331,69 @@ func CPUFrequency() uint32
 
 
 
+### func EnableCDC
+
+```go
+func EnableCDC(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
+```
+
+
+
 ### func EnableHID
 
 ```go
-func EnableHID(callback func())
+func EnableHID(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
 ```
 
 EnableHID enables HID. This function must be executed from the init().
+
+
+### func EnableMIDI
+
+```go
+func EnableMIDI(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
+```
+
+EnableMIDI enables MIDI. This function must be executed from the init().
+
+
+### func EnterBootloader
+
+```go
+func EnterBootloader()
+```
+
+EnterBootloader resets the chip into the serial bootloader.
+
+
+### func EnterOTABootloader
+
+```go
+func EnterOTABootloader()
+```
+
+EnterOTABootloader resets the chip into the bootloader so that it can be
+flashed via an OTA update
+
+
+### func EnterSerialBootloader
+
+```go
+func EnterSerialBootloader()
+```
+
+EnterSerialBootloader resets the chip into the serial bootloader. After
+reset, it can be flashed using serial/nrfutil.
+
+
+### func EnterUF2Bootloader
+
+```go
+func EnterUF2Bootloader()
+```
+
+EnterUF2Bootloader resets the chip into the UF2 bootloader. After reset, it
+can be flashed via nrfutil or by copying a UF2 file to the mass storage device
 
 
 ### func InitADC
@@ -353,6 +403,14 @@ func InitADC()
 ```
 
 InitADC initializes the registers needed for ADC.
+
+
+### func InitSerial
+
+```go
+func InitSerial()
+```
+
 
 
 ### func NewRingBuffer
@@ -375,13 +433,29 @@ This controls the TPS610981 boost converter. You must turn the power supply acti
 other onboard peripherals.
 
 
-### func SendUSBHIDPacket
+### func ReceiveUSBControlPacket
 
 ```go
-func SendUSBHIDPacket(ep uint32, data []byte) bool
+func ReceiveUSBControlPacket() ([cdcLineInfoSize]byte, error)
 ```
 
-SendUSBHIDPacket sends a packet for USBHID (interrupt / in).
+
+
+### func SendUSBInPacket
+
+```go
+func SendUSBInPacket(ep uint32, data []byte) bool
+```
+
+SendUSBInPacket sends a packet for USBHID (interrupt in / bulk in).
+
+
+### func SendZlp
+
+```go
+func SendZlp()
+```
+
 
 
 
@@ -958,6 +1032,25 @@ SPIConfig is used to store config info for SPI.
 
 
 
+## type Serialer
+
+```go
+type Serialer interface {
+	WriteByte(c byte) error
+	Write(data []byte) (n int, err error)
+	Configure(config UARTConfig) error
+	Buffered() int
+	ReadByte() (byte, error)
+	DTR() bool
+	RTS() bool
+}
+```
+
+
+
+
+
+
 ## type UART
 
 ```go
@@ -1076,135 +1169,24 @@ UARTParity is the parity setting to be used for UART communication.
 
 
 
-## type USBCDC
+## type USBDevice
 
 ```go
-type USBCDC struct {
-	Buffer			*RingBuffer
-	interrupt		interrupt.Interrupt
-	initcomplete		bool
-	TxIdx			volatile.Register8
-	waitTxc			bool
-	waitTxcRetryCount	uint8
-	sent			bool
-}
-```
-
-USBCDC is the USB CDC aka serial over USB interface on the nRF52840
-
-
-
-### func (*USBCDC) Buffered
-
-```go
-func (usbcdc *USBCDC) Buffered() int
-```
-
-Buffered returns the number of bytes currently stored in the RX buffer.
-
-
-### func (*USBCDC) Configure
-
-```go
-func (usbcdc *USBCDC) Configure(config UARTConfig)
-```
-
-Configure the USB CDC interface. The config is here for compatibility with the UART interface.
-
-
-### func (*USBCDC) DTR
-
-```go
-func (usbcdc *USBCDC) DTR() bool
-```
-
-
-
-### func (*USBCDC) Flush
-
-```go
-func (usbcdc *USBCDC) Flush() error
-```
-
-Flush flushes buffered data.
-
-
-### func (*USBCDC) RTS
-
-```go
-func (usbcdc *USBCDC) RTS() bool
-```
-
-
-
-### func (*USBCDC) Read
-
-```go
-func (usbcdc *USBCDC) Read(data []byte) (n int, err error)
-```
-
-Read from the RX buffer.
-
-
-### func (*USBCDC) ReadByte
-
-```go
-func (usbcdc *USBCDC) ReadByte() (byte, error)
-```
-
-ReadByte reads a single byte from the RX buffer.
-If there is no data in the buffer, returns an error.
-
-
-### func (*USBCDC) Receive
-
-```go
-func (usbcdc *USBCDC) Receive(data byte)
-```
-
-Receive handles adding data to the UART's data buffer.
-Usually called by the IRQ handler for a machine.
-
-
-### func (*USBCDC) Write
-
-```go
-func (usbcdc *USBCDC) Write(data []byte) (n int, err error)
-```
-
-Write data to the USBCDC.
-
-
-### func (*USBCDC) WriteByte
-
-```go
-func (usbcdc *USBCDC) WriteByte(c byte) error
-```
-
-WriteByte writes a byte of data to the USB CDC interface.
-
-
-
-
-## type USBDescriptor
-
-```go
-type USBDescriptor struct {
-	Device		[]byte
-	Configuration	[]byte
-	HID		map[uint16][]byte
+type USBDevice struct {
+	initcomplete bool
 }
 ```
 
 
 
 
-### func (*USBDescriptor) Configure
+### func (*USBDevice) Configure
 
 ```go
-func (d *USBDescriptor) Configure(idVendor, idProduct uint16)
+func (dev *USBDevice) Configure(config UARTConfig)
 ```
 
+Configure the USB peripheral. The config is here for compatibility with the UART interface.
 
 
 

--- a/content/docs/reference/microcontrollers/machine/stm32f4disco.md
+++ b/content/docs/reference/microcontrollers/machine/stm32f4disco.md
@@ -745,6 +745,14 @@ func InitADC()
 InitADC initializes the registers needed for ADC1.
 
 
+### func InitSerial
+
+```go
+func InitSerial()
+```
+
+
+
 ### func NewRingBuffer
 
 ```go

--- a/content/docs/reference/microcontrollers/machine/swan.md
+++ b/content/docs/reference/microcontrollers/machine/swan.md
@@ -517,6 +517,14 @@ func GetRNG() (uint32, error)
 GetRNG returns 32 bits of cryptographically secure random data
 
 
+### func InitSerial
+
+```go
+func InitSerial()
+```
+
+
+
 ### func NewRingBuffer
 
 ```go

--- a/content/docs/reference/microcontrollers/machine/teensy36.md
+++ b/content/docs/reference/microcontrollers/machine/teensy36.md
@@ -387,6 +387,14 @@ func ClockFrequency() uint32
 ClockFrequency returns the frequency of the external oscillator (16MHz)
 
 
+### func InitSerial
+
+```go
+func InitSerial()
+```
+
+
+
 ### func NewRingBuffer
 
 ```go

--- a/content/docs/reference/microcontrollers/machine/teensy40.md
+++ b/content/docs/reference/microcontrollers/machine/teensy40.md
@@ -724,6 +724,14 @@ func InitADC()
 InitADC is not used by this machine. Use `(ADC).Configure()`.
 
 
+### func InitSerial
+
+```go
+func InitSerial()
+```
+
+
+
 ### func NewRingBuffer
 
 ```go

--- a/content/docs/reference/microcontrollers/machine/thingplus-rp2040.md
+++ b/content/docs/reference/microcontrollers/machine/thingplus-rp2040.md
@@ -105,6 +105,18 @@ SPI default pins
 
 ```go
 const (
+	UART0_TX_PIN	= GPIO0
+	UART0_RX_PIN	= GPIO1
+	UART_TX_PIN	= UART0_TX_PIN
+	UART_RX_PIN	= UART0_RX_PIN
+)
+```
+
+UART pins
+
+
+```go
+const (
 	TWI_FREQ_100KHZ	= 100000
 	TWI_FREQ_400KHZ	= 400000
 )
@@ -178,20 +190,6 @@ const (
 
 ```go
 const (
-	UART_TX_PIN	= UART0_TX_PIN
-	UART_RX_PIN	= UART0_RX_PIN
-	UART0_TX_PIN	= GPIO0
-	UART0_RX_PIN	= GPIO1
-	UART1_TX_PIN	= GPIO8
-	UART1_RX_PIN	= GPIO9
-)
-```
-
-UART pins
-
-
-```go
-const (
 	adc0_CH	ADCChannel	= iota
 	adc1_CH
 	adc2_CH
@@ -255,6 +253,47 @@ TODO: This field is not available in the device file.
 
 ```go
 const (
+	// DPRAM : Endpoint control register
+	usbEpControlEnable			= 0x80000000
+	usbEpControlDoubleBuffered		= 0x40000000
+	usbEpControlInterruptPerBuff		= 0x20000000
+	usbEpControlInterruptPerDoubleBuff	= 0x10000000
+	usbEpControlEndpointType		= 0x0c000000
+	usbEpControlInterruptOnStall		= 0x00020000
+	usbEpControlInterruptOnNak		= 0x00010000
+	usbEpControlBufferAddress		= 0x0000ffff
+
+	usbEpControlEndpointTypeControl		= 0x00000000
+	usbEpControlEndpointTypeISO		= 0x04000000
+	usbEpControlEndpointTypeBulk		= 0x08000000
+	usbEpControlEndpointTypeInterrupt	= 0x0c000000
+
+	// Endpoint buffer control bits
+	usbBuf1CtrlFull		= 0x80000000
+	usbBuf1CtrlLast		= 0x40000000
+	usbBuf1CtrlData0Pid	= 0x20000000
+	usbBuf1CtrlData1Pid	= 0x00000000
+	usbBuf1CtrlSel		= 0x10000000
+	usbBuf1CtrlStall	= 0x08000000
+	usbBuf1CtrlAvail	= 0x04000000
+	usbBuf1CtrlLenMask	= 0x03FF0000
+	usbBuf0CtrlFull		= 0x00008000
+	usbBuf0CtrlLast		= 0x00004000
+	usbBuf0CtrlData0Pid	= 0x00000000
+	usbBuf0CtrlData1Pid	= 0x00002000
+	usbBuf0CtrlSel		= 0x00001000
+	usbBuf0CtrlStall	= 0x00000800
+	usbBuf0CtrlAvail	= 0x00000400
+	usbBuf0CtrlLenMask	= 0x000003FF
+
+	USBBufferLen	= 64
+)
+```
+
+
+
+```go
+const (
 	// ParityNone means to not use any parity checking. This is
 	// the most common setting.
 	ParityNone	UARTParity	= 0
@@ -278,29 +317,10 @@ const (
 
 ```go
 var (
-	ErrTimeoutRNG		= errors.New("machine: RNG Timeout")
-	ErrInvalidInputPin	= errors.New("machine: invalid input pin")
-	ErrInvalidOutputPin	= errors.New("machine: invalid output pin")
-	ErrInvalidClockPin	= errors.New("machine: invalid clock pin")
-	ErrInvalidDataPin	= errors.New("machine: invalid data pin")
-	ErrNoPinChangeChannel	= errors.New("machine: no channel available for pin interrupt")
-)
-```
-
-
-
-```go
-var (
 	UART0	= &_UART0
 	_UART0	= UART{
 		Buffer:	NewRingBuffer(),
 		Bus:	rp.UART0,
-	}
-
-	UART1	= &_UART1
-	_UART1	= UART{
-		Buffer:	NewRingBuffer(),
-		Bus:	rp.UART1,
 	}
 )
 ```
@@ -310,6 +330,19 @@ UART on the RP2040
 
 ```go
 var DefaultUART = UART0
+```
+
+
+
+```go
+var (
+	ErrTimeoutRNG		= errors.New("machine: RNG Timeout")
+	ErrInvalidInputPin	= errors.New("machine: invalid input pin")
+	ErrInvalidOutputPin	= errors.New("machine: invalid output pin")
+	ErrInvalidClockPin	= errors.New("machine: invalid clock pin")
+	ErrInvalidDataPin	= errors.New("machine: invalid data pin")
+	ErrNoPinChangeChannel	= errors.New("machine: no channel available for pin interrupt")
+)
 ```
 
 
@@ -415,10 +448,28 @@ var (
 
 
 ```go
-var Serial = DefaultUART
+var Serial Serialer
 ```
 
-Serial is implemented via the default (usually the first) UART on the chip.
+Serial is implemented via USB (USB-CDC).
+
+
+```go
+var (
+	USBDev	= &USBDevice{}
+	USBCDC	Serialer
+)
+```
+
+
+
+```go
+var (
+	ErrUSBReadTimeout	= errors.New("USB read timeout")
+	ErrUSBBytesRead		= errors.New("USB invalid number of bytes read")
+)
+```
+
 
 
 
@@ -441,6 +492,32 @@ func CurrentCore() int
 CurrentCore returns the core number the call was made from.
 
 
+### func EnableCDC
+
+```go
+func EnableCDC(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
+```
+
+
+
+### func EnableHID
+
+```go
+func EnableHID(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
+```
+
+EnableHID enables HID. This function must be executed from the init().
+
+
+### func EnableMIDI
+
+```go
+func EnableMIDI(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
+```
+
+EnableMIDI enables MIDI. This function must be executed from the init().
+
+
 ### func InitADC
 
 ```go
@@ -448,6 +525,14 @@ func InitADC()
 ```
 
 InitADC resets the ADC peripheral.
+
+
+### func InitSerial
+
+```go
+func InitSerial()
+```
+
 
 
 ### func NewRingBuffer
@@ -477,6 +562,31 @@ func PWMPeripheral(pin Pin) (sliceNum uint8, err error)
 Peripheral returns the RP2040 PWM peripheral which ranges from 0 to 7. Each
 PWM peripheral has 2 channels, A and B which correspond to 0 and 1 in the program.
 This number corresponds to the package's PWM0 throughout PWM7 handles
+
+
+### func ReceiveUSBControlPacket
+
+```go
+func ReceiveUSBControlPacket() ([cdcLineInfoSize]byte, error)
+```
+
+
+
+### func SendUSBInPacket
+
+```go
+func SendUSBInPacket(ep uint32, data []byte) bool
+```
+
+SendUSBInPacket sends a packet for USB (interrupt in / bulk in).
+
+
+### func SendZlp
+
+```go
+func SendZlp()
+```
+
 
 
 
@@ -1081,6 +1191,25 @@ SPIConfig is used to store config info for SPI.
 
 
 
+## type Serialer
+
+```go
+type Serialer interface {
+	WriteByte(c byte) error
+	Write(data []byte) (n int, err error)
+	Configure(config UARTConfig) error
+	Buffered() int
+	ReadByte() (byte, error)
+	DTR() bool
+	RTS() bool
+}
+```
+
+
+
+
+
+
 ## type UART
 
 ```go
@@ -1205,6 +1334,88 @@ type UARTParity int
 ```
 
 UARTParity is the parity setting to be used for UART communication.
+
+
+
+
+
+## type USBBuffer
+
+```go
+type USBBuffer struct {
+	Buffer0	[USBBufferLen]byte
+	Buffer1	[USBBufferLen]byte
+}
+```
+
+
+
+
+
+
+## type USBBufferControlRegister
+
+```go
+type USBBufferControlRegister struct {
+	In	volatile.Register32
+	Out	volatile.Register32
+}
+```
+
+
+
+
+
+
+## type USBDPSRAM
+
+```go
+type USBDPSRAM struct {
+	// Note that EPxControl[0] is not EP0Control but 8-byte setup data.
+	EPxControl	[16]USBEndpointControlRegister
+
+	EPxBufferControl	[16]USBBufferControlRegister
+
+	EPxBuffer	[16]USBBuffer
+}
+```
+
+
+
+
+
+
+## type USBDevice
+
+```go
+type USBDevice struct {
+	initcomplete bool
+}
+```
+
+
+
+
+### func (*USBDevice) Configure
+
+```go
+func (dev *USBDevice) Configure(config UARTConfig)
+```
+
+Configure the USB peripheral. The config is here for compatibility with the UART interface.
+
+
+
+
+## type USBEndpointControlRegister
+
+```go
+type USBEndpointControlRegister struct {
+	In	volatile.Register32
+	Out	volatile.Register32
+}
+```
+
 
 
 

--- a/content/docs/reference/microcontrollers/machine/trinket-m0.md
+++ b/content/docs/reference/microcontrollers/machine/trinket-m0.md
@@ -368,15 +368,6 @@ The SAM D21 has three TCC peripherals, which have PWM as one feature.
 
 ```go
 var (
-	USB		= &USBCDC{Buffer: NewRingBuffer()}
-	waitHidTxc	bool
-)
-```
-
-
-
-```go
-var (
 	DAC0 = DAC{}
 )
 ```
@@ -392,10 +383,28 @@ var (
 
 
 ```go
-var Serial = USB
+var Serial Serialer
 ```
 
 Serial is implemented via USB (USB-CDC).
+
+
+```go
+var (
+	USBDev	= &USBDevice{}
+	USBCDC	Serialer
+)
+```
+
+
+
+```go
+var (
+	ErrUSBReadTimeout	= errors.New("USB read timeout")
+	ErrUSBBytesRead		= errors.New("USB invalid number of bytes read")
+)
+```
+
 
 
 
@@ -410,13 +419,40 @@ func CPUFrequency() uint32
 Return the current CPU frequency in hertz.
 
 
+### func EnableCDC
+
+```go
+func EnableCDC(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
+```
+
+
+
 ### func EnableHID
 
 ```go
-func EnableHID(callback func())
+func EnableHID(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
 ```
 
 EnableHID enables HID. This function must be executed from the init().
+
+
+### func EnableMIDI
+
+```go
+func EnableMIDI(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
+```
+
+EnableMIDI enables MIDI. This function must be executed from the init().
+
+
+### func EnterBootloader
+
+```go
+func EnterBootloader()
+```
+
+EnterBootloader should perform a system reset in preperation
+to switch to the bootloader to flash new firmware.
 
 
 ### func InitADC
@@ -428,6 +464,14 @@ func InitADC()
 InitADC initializes the ADC.
 
 
+### func InitSerial
+
+```go
+func InitSerial()
+```
+
+
+
 ### func NewRingBuffer
 
 ```go
@@ -437,23 +481,29 @@ func NewRingBuffer() *RingBuffer
 NewRingBuffer returns a new ring buffer.
 
 
-### func ResetProcessor
+### func ReceiveUSBControlPacket
 
 ```go
-func ResetProcessor()
+func ReceiveUSBControlPacket() ([cdcLineInfoSize]byte, error)
 ```
 
-ResetProcessor should perform a system reset in preperation
-to switch to the bootloader to flash new firmware.
 
 
-### func SendUSBHIDPacket
+### func SendUSBInPacket
 
 ```go
-func SendUSBHIDPacket(ep uint32, data []byte) bool
+func SendUSBInPacket(ep uint32, data []byte) bool
 ```
 
-SendUSBHIDPacket sends a packet for USBHID (interrupt / in).
+SendUSBInPacket sends a packet for USB (interrupt in / bulk in).
+
+
+### func SendZlp
+
+```go
+func SendZlp()
+```
+
 
 
 
@@ -1123,6 +1173,25 @@ SPIConfig is used to store config info for SPI.
 
 
 
+## type Serialer
+
+```go
+type Serialer interface {
+	WriteByte(c byte) error
+	Write(data []byte) (n int, err error)
+	Configure(config UARTConfig) error
+	Buffered() int
+	ReadByte() (byte, error)
+	DTR() bool
+	RTS() bool
+}
+```
+
+
+
+
+
+
 ## type TCC
 
 ```go
@@ -1357,143 +1426,24 @@ UARTParity is the parity setting to be used for UART communication.
 
 
 
-## type USBCDC
+## type USBDevice
 
 ```go
-type USBCDC struct {
-	Buffer			*RingBuffer
-	TxIdx			volatile.Register8
-	waitTxc			bool
-	waitTxcRetryCount	uint8
-	sent			bool
-	configured		bool
-}
-```
-
-USBCDC is the USB CDC aka serial over USB interface on the SAMD21.
-
-
-
-### func (*USBCDC) Buffered
-
-```go
-func (usbcdc *USBCDC) Buffered() int
-```
-
-Buffered returns the number of bytes currently stored in the RX buffer.
-
-
-### func (*USBCDC) Configure
-
-```go
-func (usbcdc *USBCDC) Configure(config UARTConfig)
-```
-
-Configure the USB CDC interface. The config is here for compatibility with the UART interface.
-
-
-### func (*USBCDC) Configured
-
-```go
-func (usbcdc *USBCDC) Configured() bool
-```
-
-Configured returns whether usbcdc is configured or not.
-
-
-### func (*USBCDC) DTR
-
-```go
-func (usbcdc *USBCDC) DTR() bool
-```
-
-
-
-### func (*USBCDC) Flush
-
-```go
-func (usbcdc *USBCDC) Flush() error
-```
-
-Flush flushes buffered data.
-
-
-### func (*USBCDC) RTS
-
-```go
-func (usbcdc *USBCDC) RTS() bool
-```
-
-
-
-### func (*USBCDC) Read
-
-```go
-func (usbcdc *USBCDC) Read(data []byte) (n int, err error)
-```
-
-Read from the RX buffer.
-
-
-### func (*USBCDC) ReadByte
-
-```go
-func (usbcdc *USBCDC) ReadByte() (byte, error)
-```
-
-ReadByte reads a single byte from the RX buffer.
-If there is no data in the buffer, returns an error.
-
-
-### func (*USBCDC) Receive
-
-```go
-func (usbcdc *USBCDC) Receive(data byte)
-```
-
-Receive handles adding data to the UART's data buffer.
-Usually called by the IRQ handler for a machine.
-
-
-### func (*USBCDC) Write
-
-```go
-func (usbcdc *USBCDC) Write(data []byte) (n int, err error)
-```
-
-Write data to the USBCDC.
-
-
-### func (*USBCDC) WriteByte
-
-```go
-func (usbcdc *USBCDC) WriteByte(c byte) error
-```
-
-WriteByte writes a byte of data to the USB CDC interface.
-
-
-
-
-## type USBDescriptor
-
-```go
-type USBDescriptor struct {
-	Device		[]byte
-	Configuration	[]byte
-	HID		map[uint16][]byte
+type USBDevice struct {
+	initcomplete bool
 }
 ```
 
 
 
 
-### func (*USBDescriptor) Configure
+### func (*USBDevice) Configure
 
 ```go
-func (d *USBDescriptor) Configure(idVendor, idProduct uint16)
+func (dev *USBDevice) Configure(config UARTConfig)
 ```
 
+Configure the USB peripheral. The config is here for compatibility with the UART interface.
 
 
 

--- a/content/docs/reference/microcontrollers/machine/wioterminal.md
+++ b/content/docs/reference/microcontrollers/machine/wioterminal.md
@@ -763,16 +763,6 @@ var (
 
 ```go
 var (
-	// USB is a USB CDC interface.
-	USB		= &USBCDC{Buffer: NewRingBuffer()}
-	waitHidTxc	bool
-)
-```
-
-
-
-```go
-var (
 	DAC0 = DAC{}
 )
 ```
@@ -801,10 +791,28 @@ var (
 
 
 ```go
-var Serial = USB
+var Serial Serialer
 ```
 
 Serial is implemented via USB (USB-CDC).
+
+
+```go
+var (
+	USBDev	= &USBDevice{}
+	USBCDC	Serialer
+)
+```
+
+
+
+```go
+var (
+	ErrUSBReadTimeout	= errors.New("USB read timeout")
+	ErrUSBBytesRead		= errors.New("USB invalid number of bytes read")
+)
+```
+
 
 
 
@@ -818,13 +826,40 @@ func CPUFrequency() uint32
 
 
 
+### func EnableCDC
+
+```go
+func EnableCDC(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
+```
+
+
+
 ### func EnableHID
 
 ```go
-func EnableHID(callback func())
+func EnableHID(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
 ```
 
 EnableHID enables HID. This function must be executed from the init().
+
+
+### func EnableMIDI
+
+```go
+func EnableMIDI(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
+```
+
+EnableMIDI enables MIDI. This function must be executed from the init().
+
+
+### func EnterBootloader
+
+```go
+func EnterBootloader()
+```
+
+EnterBootloader should perform a system reset in preparation
+to switch to the bootloader to flash new firmware.
 
 
 ### func GetRNG
@@ -845,6 +880,14 @@ func InitADC()
 InitADC initializes the ADC.
 
 
+### func InitSerial
+
+```go
+func InitSerial()
+```
+
+
+
 ### func NewRingBuffer
 
 ```go
@@ -854,23 +897,29 @@ func NewRingBuffer() *RingBuffer
 NewRingBuffer returns a new ring buffer.
 
 
-### func ResetProcessor
+### func ReceiveUSBControlPacket
 
 ```go
-func ResetProcessor()
+func ReceiveUSBControlPacket() ([cdcLineInfoSize]byte, error)
 ```
 
-ResetProcessor should perform a system reset in preparation
-to switch to the bootloader to flash new firmware.
 
 
-### func SendUSBHIDPacket
+### func SendUSBInPacket
 
 ```go
-func SendUSBHIDPacket(ep uint32, data []byte) bool
+func SendUSBInPacket(ep uint32, data []byte) bool
 ```
 
-SendUSBHIDPacket sends a packet for USBHID (interrupt / in).
+SendUSBInPacket sends a packet for USB (interrupt in / bulk in).
+
+
+### func SendZlp
+
+```go
+func SendZlp()
+```
+
 
 
 
@@ -1497,6 +1546,25 @@ SPIConfig is used to store config info for SPI.
 
 
 
+## type Serialer
+
+```go
+type Serialer interface {
+	WriteByte(c byte) error
+	Write(data []byte) (n int, err error)
+	Configure(config UARTConfig) error
+	Buffered() int
+	ReadByte() (byte, error)
+	DTR() bool
+	RTS() bool
+}
+```
+
+
+
+
+
+
 ## type TCC
 
 ```go
@@ -1730,143 +1798,24 @@ UARTParity is the parity setting to be used for UART communication.
 
 
 
-## type USBCDC
+## type USBDevice
 
 ```go
-type USBCDC struct {
-	Buffer			*RingBuffer
-	TxIdx			volatile.Register8
-	waitTxc			bool
-	waitTxcRetryCount	uint8
-	sent			bool
-	configured		bool
-}
-```
-
-USBCDC is the USB CDC aka serial over USB interface on the SAMD21.
-
-
-
-### func (*USBCDC) Buffered
-
-```go
-func (usbcdc *USBCDC) Buffered() int
-```
-
-Buffered returns the number of bytes currently stored in the RX buffer.
-
-
-### func (*USBCDC) Configure
-
-```go
-func (usbcdc *USBCDC) Configure(config UARTConfig)
-```
-
-Configure the USB CDC interface. The config is here for compatibility with the UART interface.
-
-
-### func (*USBCDC) Configured
-
-```go
-func (usbcdc *USBCDC) Configured() bool
-```
-
-Configured returns whether usbcdc is configured or not.
-
-
-### func (*USBCDC) DTR
-
-```go
-func (usbcdc *USBCDC) DTR() bool
-```
-
-
-
-### func (*USBCDC) Flush
-
-```go
-func (usbcdc *USBCDC) Flush() error
-```
-
-Flush flushes buffered data.
-
-
-### func (*USBCDC) RTS
-
-```go
-func (usbcdc *USBCDC) RTS() bool
-```
-
-
-
-### func (*USBCDC) Read
-
-```go
-func (usbcdc *USBCDC) Read(data []byte) (n int, err error)
-```
-
-Read from the RX buffer.
-
-
-### func (*USBCDC) ReadByte
-
-```go
-func (usbcdc *USBCDC) ReadByte() (byte, error)
-```
-
-ReadByte reads a single byte from the RX buffer.
-If there is no data in the buffer, returns an error.
-
-
-### func (*USBCDC) Receive
-
-```go
-func (usbcdc *USBCDC) Receive(data byte)
-```
-
-Receive handles adding data to the UART's data buffer.
-Usually called by the IRQ handler for a machine.
-
-
-### func (*USBCDC) Write
-
-```go
-func (usbcdc *USBCDC) Write(data []byte) (n int, err error)
-```
-
-Write data to the USBCDC.
-
-
-### func (*USBCDC) WriteByte
-
-```go
-func (usbcdc *USBCDC) WriteByte(c byte) error
-```
-
-WriteByte writes a byte of data to the USB CDC interface.
-
-
-
-
-## type USBDescriptor
-
-```go
-type USBDescriptor struct {
-	Device		[]byte
-	Configuration	[]byte
-	HID		map[uint16][]byte
+type USBDevice struct {
+	initcomplete bool
 }
 ```
 
 
 
 
-### func (*USBDescriptor) Configure
+### func (*USBDevice) Configure
 
 ```go
-func (d *USBDescriptor) Configure(idVendor, idProduct uint16)
+func (dev *USBDevice) Configure(config UARTConfig)
 ```
 
+Configure the USB peripheral. The config is here for compatibility with the UART interface.
 
 
 

--- a/content/docs/reference/microcontrollers/machine/x9pro.md
+++ b/content/docs/reference/microcontrollers/machine/x9pro.md
@@ -262,6 +262,14 @@ func InitADC()
 InitADC initializes the registers needed for ADC.
 
 
+### func InitSerial
+
+```go
+func InitSerial()
+```
+
+
+
 ### func NewRingBuffer
 
 ```go

--- a/content/docs/reference/microcontrollers/machine/xiao-ble.md
+++ b/content/docs/reference/microcontrollers/machine/xiao-ble.md
@@ -224,6 +224,16 @@ Pin change interrupt constants for SetInterrupt.
 
 ```go
 const (
+	DFU_MAGIC_SERIAL_ONLY_RESET	= 0x4e
+	DFU_MAGIC_UF2_RESET		= 0x57
+	DFU_MAGIC_OTA_RESET		= 0xA8
+)
+```
+
+
+
+```go
+const (
 	// ParityNone means to not use any parity checking. This is
 	// the most common setting.
 	ParityNone	UARTParity	= 0
@@ -309,40 +319,6 @@ PWM
 
 ```go
 var (
-	USB		= &_USB
-	_USB		= USBCDC{Buffer: NewRingBuffer()}
-	waitHidTxc	bool
-
-	usbEndpointDescriptors	[8]usbDeviceDescriptor
-
-	udd_ep_in_cache_buffer	[7][128]uint8
-	udd_ep_out_cache_buffer	[7][128]uint8
-
-	sendOnEP0DATADONE	struct {
-		ptr	*byte
-		count	int
-	}
-	isEndpointHalt		= false
-	isRemoteWakeUpEnabled	= false
-	endPoints		= []uint32{usb_ENDPOINT_TYPE_CONTROL,
-		(usb_ENDPOINT_TYPE_INTERRUPT | usbEndpointIn),
-		(usb_ENDPOINT_TYPE_BULK | usbEndpointOut),
-		(usb_ENDPOINT_TYPE_BULK | usbEndpointIn)}
-
-	usbConfiguration		uint8
-	usbSetInterface			uint8
-	usbLineInfo			= cdcLineInfo{115200, 0x00, 0x00, 0x08, 0x00}
-	epinen				uint32
-	epouten				uint32
-	easyDMABusy			volatile.Register8
-	epout0data_setlinecoding	bool
-)
-```
-
-
-
-```go
-var (
 	SPI0	= SPI{Bus: nrf.SPIM0, buf: new([1]byte)}
 	SPI1	= SPI{Bus: nrf.SPIM1, buf: new([1]byte)}
 	SPI2	= SPI{Bus: nrf.SPIM2, buf: new([1]byte)}
@@ -367,6 +343,24 @@ var Serial = DefaultUART
 Serial is implemented via the default (usually the first) UART on the chip.
 
 
+```go
+var (
+	USBDev	= &USBDevice{}
+	USBCDC	Serialer
+)
+```
+
+
+
+```go
+var (
+	ErrUSBReadTimeout	= errors.New("USB read timeout")
+	ErrUSBBytesRead		= errors.New("USB invalid number of bytes read")
+)
+```
+
+
+
 
 
 
@@ -378,13 +372,69 @@ func CPUFrequency() uint32
 
 
 
+### func EnableCDC
+
+```go
+func EnableCDC(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
+```
+
+
+
 ### func EnableHID
 
 ```go
-func EnableHID(callback func())
+func EnableHID(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
 ```
 
 EnableHID enables HID. This function must be executed from the init().
+
+
+### func EnableMIDI
+
+```go
+func EnableMIDI(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
+```
+
+EnableMIDI enables MIDI. This function must be executed from the init().
+
+
+### func EnterBootloader
+
+```go
+func EnterBootloader()
+```
+
+EnterBootloader resets the chip into the serial bootloader.
+
+
+### func EnterOTABootloader
+
+```go
+func EnterOTABootloader()
+```
+
+EnterOTABootloader resets the chip into the bootloader so that it can be
+flashed via an OTA update
+
+
+### func EnterSerialBootloader
+
+```go
+func EnterSerialBootloader()
+```
+
+EnterSerialBootloader resets the chip into the serial bootloader. After
+reset, it can be flashed using serial/nrfutil.
+
+
+### func EnterUF2Bootloader
+
+```go
+func EnterUF2Bootloader()
+```
+
+EnterUF2Bootloader resets the chip into the UF2 bootloader. After reset, it
+can be flashed via nrfutil or by copying a UF2 file to the mass storage device
 
 
 ### func InitADC
@@ -396,6 +446,14 @@ func InitADC()
 InitADC initializes the registers needed for ADC.
 
 
+### func InitSerial
+
+```go
+func InitSerial()
+```
+
+
+
 ### func NewRingBuffer
 
 ```go
@@ -405,13 +463,29 @@ func NewRingBuffer() *RingBuffer
 NewRingBuffer returns a new ring buffer.
 
 
-### func SendUSBHIDPacket
+### func ReceiveUSBControlPacket
 
 ```go
-func SendUSBHIDPacket(ep uint32, data []byte) bool
+func ReceiveUSBControlPacket() ([cdcLineInfoSize]byte, error)
 ```
 
-SendUSBHIDPacket sends a packet for USBHID (interrupt / in).
+
+
+### func SendUSBInPacket
+
+```go
+func SendUSBInPacket(ep uint32, data []byte) bool
+```
+
+SendUSBInPacket sends a packet for USBHID (interrupt in / bulk in).
+
+
+### func SendZlp
+
+```go
+func SendZlp()
+```
+
 
 
 
@@ -988,6 +1062,25 @@ SPIConfig is used to store config info for SPI.
 
 
 
+## type Serialer
+
+```go
+type Serialer interface {
+	WriteByte(c byte) error
+	Write(data []byte) (n int, err error)
+	Configure(config UARTConfig) error
+	Buffered() int
+	ReadByte() (byte, error)
+	DTR() bool
+	RTS() bool
+}
+```
+
+
+
+
+
+
 ## type UART
 
 ```go
@@ -1106,135 +1199,24 @@ UARTParity is the parity setting to be used for UART communication.
 
 
 
-## type USBCDC
+## type USBDevice
 
 ```go
-type USBCDC struct {
-	Buffer			*RingBuffer
-	interrupt		interrupt.Interrupt
-	initcomplete		bool
-	TxIdx			volatile.Register8
-	waitTxc			bool
-	waitTxcRetryCount	uint8
-	sent			bool
-}
-```
-
-USBCDC is the USB CDC aka serial over USB interface on the nRF52840
-
-
-
-### func (*USBCDC) Buffered
-
-```go
-func (usbcdc *USBCDC) Buffered() int
-```
-
-Buffered returns the number of bytes currently stored in the RX buffer.
-
-
-### func (*USBCDC) Configure
-
-```go
-func (usbcdc *USBCDC) Configure(config UARTConfig)
-```
-
-Configure the USB CDC interface. The config is here for compatibility with the UART interface.
-
-
-### func (*USBCDC) DTR
-
-```go
-func (usbcdc *USBCDC) DTR() bool
-```
-
-
-
-### func (*USBCDC) Flush
-
-```go
-func (usbcdc *USBCDC) Flush() error
-```
-
-Flush flushes buffered data.
-
-
-### func (*USBCDC) RTS
-
-```go
-func (usbcdc *USBCDC) RTS() bool
-```
-
-
-
-### func (*USBCDC) Read
-
-```go
-func (usbcdc *USBCDC) Read(data []byte) (n int, err error)
-```
-
-Read from the RX buffer.
-
-
-### func (*USBCDC) ReadByte
-
-```go
-func (usbcdc *USBCDC) ReadByte() (byte, error)
-```
-
-ReadByte reads a single byte from the RX buffer.
-If there is no data in the buffer, returns an error.
-
-
-### func (*USBCDC) Receive
-
-```go
-func (usbcdc *USBCDC) Receive(data byte)
-```
-
-Receive handles adding data to the UART's data buffer.
-Usually called by the IRQ handler for a machine.
-
-
-### func (*USBCDC) Write
-
-```go
-func (usbcdc *USBCDC) Write(data []byte) (n int, err error)
-```
-
-Write data to the USBCDC.
-
-
-### func (*USBCDC) WriteByte
-
-```go
-func (usbcdc *USBCDC) WriteByte(c byte) error
-```
-
-WriteByte writes a byte of data to the USB CDC interface.
-
-
-
-
-## type USBDescriptor
-
-```go
-type USBDescriptor struct {
-	Device		[]byte
-	Configuration	[]byte
-	HID		map[uint16][]byte
+type USBDevice struct {
+	initcomplete bool
 }
 ```
 
 
 
 
-### func (*USBDescriptor) Configure
+### func (*USBDevice) Configure
 
 ```go
-func (d *USBDescriptor) Configure(idVendor, idProduct uint16)
+func (dev *USBDevice) Configure(config UARTConfig)
 ```
 
+Configure the USB peripheral. The config is here for compatibility with the UART interface.
 
 
 

--- a/content/docs/reference/microcontrollers/machine/xiao.md
+++ b/content/docs/reference/microcontrollers/machine/xiao.md
@@ -375,15 +375,6 @@ The SAM D21 has three TCC peripherals, which have PWM as one feature.
 
 ```go
 var (
-	USB		= &USBCDC{Buffer: NewRingBuffer()}
-	waitHidTxc	bool
-)
-```
-
-
-
-```go
-var (
 	DAC0 = DAC{}
 )
 ```
@@ -399,10 +390,28 @@ var (
 
 
 ```go
-var Serial = USB
+var Serial Serialer
 ```
 
 Serial is implemented via USB (USB-CDC).
+
+
+```go
+var (
+	USBDev	= &USBDevice{}
+	USBCDC	Serialer
+)
+```
+
+
+
+```go
+var (
+	ErrUSBReadTimeout	= errors.New("USB read timeout")
+	ErrUSBBytesRead		= errors.New("USB invalid number of bytes read")
+)
+```
+
 
 
 
@@ -417,13 +426,40 @@ func CPUFrequency() uint32
 Return the current CPU frequency in hertz.
 
 
+### func EnableCDC
+
+```go
+func EnableCDC(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
+```
+
+
+
 ### func EnableHID
 
 ```go
-func EnableHID(callback func())
+func EnableHID(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
 ```
 
 EnableHID enables HID. This function must be executed from the init().
+
+
+### func EnableMIDI
+
+```go
+func EnableMIDI(txHandler func(), rxHandler func([]byte), setupHandler func(usb.Setup) bool)
+```
+
+EnableMIDI enables MIDI. This function must be executed from the init().
+
+
+### func EnterBootloader
+
+```go
+func EnterBootloader()
+```
+
+EnterBootloader should perform a system reset in preperation
+to switch to the bootloader to flash new firmware.
 
 
 ### func InitADC
@@ -435,6 +471,14 @@ func InitADC()
 InitADC initializes the ADC.
 
 
+### func InitSerial
+
+```go
+func InitSerial()
+```
+
+
+
 ### func NewRingBuffer
 
 ```go
@@ -444,23 +488,29 @@ func NewRingBuffer() *RingBuffer
 NewRingBuffer returns a new ring buffer.
 
 
-### func ResetProcessor
+### func ReceiveUSBControlPacket
 
 ```go
-func ResetProcessor()
+func ReceiveUSBControlPacket() ([cdcLineInfoSize]byte, error)
 ```
 
-ResetProcessor should perform a system reset in preperation
-to switch to the bootloader to flash new firmware.
 
 
-### func SendUSBHIDPacket
+### func SendUSBInPacket
 
 ```go
-func SendUSBHIDPacket(ep uint32, data []byte) bool
+func SendUSBInPacket(ep uint32, data []byte) bool
 ```
 
-SendUSBHIDPacket sends a packet for USBHID (interrupt / in).
+SendUSBInPacket sends a packet for USB (interrupt in / bulk in).
+
+
+### func SendZlp
+
+```go
+func SendZlp()
+```
+
 
 
 
@@ -1130,6 +1180,25 @@ SPIConfig is used to store config info for SPI.
 
 
 
+## type Serialer
+
+```go
+type Serialer interface {
+	WriteByte(c byte) error
+	Write(data []byte) (n int, err error)
+	Configure(config UARTConfig) error
+	Buffered() int
+	ReadByte() (byte, error)
+	DTR() bool
+	RTS() bool
+}
+```
+
+
+
+
+
+
 ## type TCC
 
 ```go
@@ -1364,143 +1433,24 @@ UARTParity is the parity setting to be used for UART communication.
 
 
 
-## type USBCDC
+## type USBDevice
 
 ```go
-type USBCDC struct {
-	Buffer			*RingBuffer
-	TxIdx			volatile.Register8
-	waitTxc			bool
-	waitTxcRetryCount	uint8
-	sent			bool
-	configured		bool
-}
-```
-
-USBCDC is the USB CDC aka serial over USB interface on the SAMD21.
-
-
-
-### func (*USBCDC) Buffered
-
-```go
-func (usbcdc *USBCDC) Buffered() int
-```
-
-Buffered returns the number of bytes currently stored in the RX buffer.
-
-
-### func (*USBCDC) Configure
-
-```go
-func (usbcdc *USBCDC) Configure(config UARTConfig)
-```
-
-Configure the USB CDC interface. The config is here for compatibility with the UART interface.
-
-
-### func (*USBCDC) Configured
-
-```go
-func (usbcdc *USBCDC) Configured() bool
-```
-
-Configured returns whether usbcdc is configured or not.
-
-
-### func (*USBCDC) DTR
-
-```go
-func (usbcdc *USBCDC) DTR() bool
-```
-
-
-
-### func (*USBCDC) Flush
-
-```go
-func (usbcdc *USBCDC) Flush() error
-```
-
-Flush flushes buffered data.
-
-
-### func (*USBCDC) RTS
-
-```go
-func (usbcdc *USBCDC) RTS() bool
-```
-
-
-
-### func (*USBCDC) Read
-
-```go
-func (usbcdc *USBCDC) Read(data []byte) (n int, err error)
-```
-
-Read from the RX buffer.
-
-
-### func (*USBCDC) ReadByte
-
-```go
-func (usbcdc *USBCDC) ReadByte() (byte, error)
-```
-
-ReadByte reads a single byte from the RX buffer.
-If there is no data in the buffer, returns an error.
-
-
-### func (*USBCDC) Receive
-
-```go
-func (usbcdc *USBCDC) Receive(data byte)
-```
-
-Receive handles adding data to the UART's data buffer.
-Usually called by the IRQ handler for a machine.
-
-
-### func (*USBCDC) Write
-
-```go
-func (usbcdc *USBCDC) Write(data []byte) (n int, err error)
-```
-
-Write data to the USBCDC.
-
-
-### func (*USBCDC) WriteByte
-
-```go
-func (usbcdc *USBCDC) WriteByte(c byte) error
-```
-
-WriteByte writes a byte of data to the USB CDC interface.
-
-
-
-
-## type USBDescriptor
-
-```go
-type USBDescriptor struct {
-	Device		[]byte
-	Configuration	[]byte
-	HID		map[uint16][]byte
+type USBDevice struct {
+	initcomplete bool
 }
 ```
 
 
 
 
-### func (*USBDescriptor) Configure
+### func (*USBDevice) Configure
 
 ```go
-func (d *USBDescriptor) Configure(idVendor, idProduct uint16)
+func (dev *USBDevice) Configure(config UARTConfig)
 ```
 
+Configure the USB peripheral. The config is here for compatibility with the UART interface.
 
 
 

--- a/content/docs/reference/microcontrollers/maixbit.md
+++ b/content/docs/reference/microcontrollers/maixbit.md
@@ -11,10 +11,11 @@ The [Sipeed MAix Bit](https://www.seeedstudio.com/Sipeed-MAix-BiT-for-RISC-V-AI-
 | --------- | ------------- | ----- |
 | GPIO      | YES | YES |
 | UART      | YES | YES |
-| SPI      | YES | YES |
-| I2C      | YES | YES |
-| ADC      | NO | NO |
-| PWM      | YES | Not yet |
+| SPI       | YES | YES |
+| I2C       | YES | YES |
+| ADC       | NO  | NO  |
+| PWM       | YES | Not yet |
+| USBDevice | ?   | ?   |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/matrixportal-m4.md
+++ b/content/docs/reference/microcontrollers/matrixportal-m4.md
@@ -11,10 +11,11 @@ The [Adafruit Matrix Portal M4](https://www.adafruit.com/product/4745) is an ARM
 | --------- | ------------- | ----- |
 | GPIO      | YES | YES |
 | UART      | YES | YES |
-| SPI      | YES | YES |
-| I2C      | YES | YES |
-| ADC      | YES | YES |
-| PWM      | YES | YES |
+| SPI       | YES | YES |
+| I2C       | YES | YES |
+| ADC       | YES | YES |
+| PWM       | YES | YES |
+| USBDevice | YES | YES |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/metro-m4-airlift.md
+++ b/content/docs/reference/microcontrollers/metro-m4-airlift.md
@@ -11,10 +11,11 @@ The [Adafruit Metro M4 Express AirLift](https://www.adafruit.com/product/4000) i
 | --------- | ------------- | ----- |
 | GPIO      | YES | YES |
 | UART      | YES | YES |
-| SPI      | YES | YES |
-| I2C      | YES | YES |
-| ADC      | YES | YES |
-| PWM      | YES | YES |
+| SPI       | YES | YES |
+| I2C       | YES | YES |
+| ADC       | YES | YES |
+| PWM       | YES | YES |
+| USBDevice | YES | YES |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/microbit.md
+++ b/content/docs/reference/microcontrollers/microbit.md
@@ -11,11 +11,12 @@ The BBC [micro:bit](https://microbit.org) is a tiny programmable computer design
 | --------- | ------------- | ----- |
 | GPIO      | YES | YES |
 | UART      | YES | YES |
-| SPI      | YES | YES |
-| I2C      | YES | YES |
-| ADC      | YES | Not yet |
-| PWM      | Software support | Not yet |
-| Bluetooth      | YES | YES |
+| SPI       | YES | YES |
+| I2C       | YES | YES |
+| ADC       | YES | Not yet |
+| PWM       | Software support | Not yet |
+| USBDevice | NO  | NO  |
+| Bluetooth | YES | YES |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/nano-33-ble.md
+++ b/content/docs/reference/microcontrollers/nano-33-ble.md
@@ -13,10 +13,11 @@ There is also the [Arduino Nano33 BLE Sense](nano-33-ble-sense) which is the exa
 | --------- | ------------- | ----- |
 | GPIO      | YES | YES |
 | UART      | YES | YES |
-| SPI      | YES | YES |
-| I2C      | YES | YES |
-| ADC      | YES | YES |
-| PWM      | YES | YES |
+| SPI       | YES | YES |
+| I2C       | YES | YES |
+| ADC       | YES | YES |
+| PWM       | YES | YES |
+| USBDevice | YES | YES |
 
 ## Onboard sensors
 

--- a/content/docs/reference/microcontrollers/nano-rp2040.md
+++ b/content/docs/reference/microcontrollers/nano-rp2040.md
@@ -16,10 +16,11 @@ Peripherals:
 | --------- | ------------- | ----- |
 | GPIO      | YES | YES |
 | UART      | YES | YES |
-| SPI      | YES | YES |
-| I2C      | YES | YES |
-| ADC      | YES | YES |
-| PWM      | YES | YES |
+| SPI       | YES | YES |
+| I2C       | YES | YES |
+| ADC       | YES | YES |
+| PWM       | YES | YES |
+| USBDevice | YES | YES |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/nicenano.md
+++ b/content/docs/reference/microcontrollers/nicenano.md
@@ -11,11 +11,12 @@ The [nice!nano](https://nicekeyboards.com/products/nice-nano-v1-0) is a wireless
 | --------- | ------------- | ----- |
 | GPIO      | YES | YES |
 | UART      | YES | YES |
-| SPI      | YES | YES |
-| I2C      | YES | YES |
-| ADC      | YES | YES |
-| PWM      | YES | YES |
-| Bluetooth      | YES | YES |
+| SPI       | YES | YES |
+| I2C       | YES | YES |
+| ADC       | YES | YES |
+| PWM       | YES | YES |
+| USBDevice | YES | YES |
+| Bluetooth | YES | YES |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/nintendoswitch.md
+++ b/content/docs/reference/microcontrollers/nintendoswitch.md
@@ -11,10 +11,11 @@ The [Nintendo Switch](https://en.wikipedia.org/wiki/Nintendo_Switch) is a handhe
 | --------- | ------------- | ----- |
 | GPIO      | ? | ? |
 | UART      | ? | ? |
-| SPI      | ? | ? |
-| I2C      | ? | ? |
-| ADC      | ? | ? |
-| PWM      | ? | ? |
+| SPI       | ? | ? |
+| I2C       | ? | ? |
+| ADC       | ? | ? |
+| PWM       | ? | ? |
+| USBDevice | ? | ? |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/nodemcu.md
+++ b/content/docs/reference/microcontrollers/nodemcu.md
@@ -11,10 +11,11 @@ The [Espressif ESP8266](https://www.espressif.com/en/products/socs/esp8266) Node
 | --------- | ------------- | ----- |
 | GPIO      | YES | YES |
 | UART      | YES | YES |
-| SPI      | YES | Not yet |
-| I2C      | NO (software only) | Not yet |
-| ADC      | YES | Not yet |
-| PWM      | YES | Not yet |
+| SPI       | YES | Not yet |
+| I2C       | NO (software only) | Not yet |
+| ADC       | YES | Not yet |
+| PWM       | YES | Not yet |
+| USBDevice | NO  | NO  |
 | WiFi      | YES | Not Yet |
 
 ## Machine Package Docs

--- a/content/docs/reference/microcontrollers/nrf52840-mdk-usb-dongle.md
+++ b/content/docs/reference/microcontrollers/nrf52840-mdk-usb-dongle.md
@@ -11,11 +11,12 @@ The [nRF52840 MDK USB Dongle](https://wiki.makerdiary.com/nrf52840-mdk-usb-dongl
 | --------- | ------------- | ----- |
 | GPIO      | YES | YES |
 | UART      | YES | YES |
-| SPI      | YES | YES |
-| I2C      | YES | YES |
-| ADC      | YES | YES |
-| PWM      | YES | YES |
-| Bluetooth      | YES | YES |
+| SPI       | YES | YES |
+| I2C       | YES | YES |
+| ADC       | YES | YES |
+| PWM       | YES | YES |
+| USBDevice | YES | YES |
+| Bluetooth | YES | YES |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/nrf52840-mdk.md
+++ b/content/docs/reference/microcontrollers/nrf52840-mdk.md
@@ -11,11 +11,12 @@ The [nRF52840-MDK](https://wiki.makerdiary.com/nrf52840-mdk/) (not to be confuse
 | --------- | ------------- | ----- |
 | GPIO      | YES | YES |
 | UART      | YES | YES |
-| SPI      | YES | YES |
-| I2C      | YES | YES |
-| ADC      | YES | YES |
-| PWM      | YES | YES |
-| Bluetooth      | YES | YES |
+| SPI       | YES | YES |
+| I2C       | YES | YES |
+| ADC       | YES | YES |
+| PWM       | YES | YES |
+| USBDevice | YES | YES |
+| Bluetooth | YES | YES |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/nucleo-f103rb.md
+++ b/content/docs/reference/microcontrollers/nucleo-f103rb.md
@@ -11,10 +11,11 @@ The [Nucleo F103RB](https://www.st.com/en/evaluation-tools/nucleo-f103rb.html) i
 | --------- | ------------- | ----- |
 | GPIO      | YES | YES |
 | UART      | YES | YES |
-| SPI      | YES | YES |
-| I2C      | YES | YES |
-| ADC      | YES | YES |
-| PWM      | YES | Not yet |
+| SPI       | YES | YES |
+| I2C       | YES | YES |
+| ADC       | YES | YES |
+| PWM       | YES | Not yet |
+| USBDevice | NO  | NO  |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/nucleo-f722ze.md
+++ b/content/docs/reference/microcontrollers/nucleo-f722ze.md
@@ -13,10 +13,11 @@ It has 2 user buttons, and 3 user LEDs.
 | --------- | ------------- | ----- |
 | GPIO      | YES | YES |
 | UART      | YES | YES |
-| SPI      | YES | Not yet |
-| I2C      | YES | YES |
-| ADC      | YES | Not yet |
-| PWM      | YES | Not yet |
+| SPI       | YES | Not yet |
+| I2C       | YES | YES |
+| ADC       | YES | Not yet |
+| PWM       | YES | Not yet |
+| USBDevice | YES | Not yet |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/nucleo-l031k6.md
+++ b/content/docs/reference/microcontrollers/nucleo-l031k6.md
@@ -13,10 +13,11 @@ It has 2 user buttons, and 3 user LEDs.
 | --------- | ------------- | ----- |
 | GPIO      | YES | YES |
 | UART      | YES | YES |
-| SPI      | YES | YES |
-| I2C      | YES | YES |
-| ADC      | YES | Not yet |
-| PWM      | YES | Not yet |
+| SPI       | YES | YES |
+| I2C       | YES | YES |
+| ADC       | YES | Not yet |
+| PWM       | YES | Not yet |
+| USBDevice | NO  | NO  |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/nucleo-l432kc.md
+++ b/content/docs/reference/microcontrollers/nucleo-l432kc.md
@@ -13,10 +13,11 @@ It has 2 user buttons, and 3 user LEDs.
 | --------- | ------------- | ----- |
 | GPIO      | YES | YES |
 | UART      | YES | YES |
-| SPI      | YES | YES |
-| I2C      | YES | YES |
-| ADC      | YES | Not yet |
-| PWM      | YES | Not yet |
+| SPI       | YES | YES |
+| I2C       | YES | YES |
+| ADC       | YES | Not yet |
+| PWM       | YES | Not yet |
+| USBDevice | NO  | NO  |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/nucleo-l552ze.md
+++ b/content/docs/reference/microcontrollers/nucleo-l552ze.md
@@ -13,10 +13,11 @@ It has onboard ethernet, 2 user buttons, and 3 user LEDs.
 | --------- | ------------- | ----- |
 | GPIO      | YES | YES |
 | UART      | YES | YES |
-| SPI      | YES | Not yet |
-| I2C      | YES | YES |
-| ADC      | YES | Not yet |
-| PWM      | YES | Not yet |
+| SPI       | YES | Not yet |
+| I2C       | YES | YES |
+| ADC       | YES | Not yet |
+| PWM       | YES | Not yet |
+| USBDevice | YES | Not yet |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/nucleo-wl55jc.md
+++ b/content/docs/reference/microcontrollers/nucleo-wl55jc.md
@@ -13,10 +13,11 @@ It has onboard LoRa®, (G)FSK, (G)MSK, and BPSK as well as 3 user LEDs, 3 user b
 | --------- | ------------- | ----- |
 | GPIO      | YES | YES |
 | UART      | YES | YES |
-| SPI      | YES | YES |
-| I2C      | YES | YES |
-| ADC      | YES | Not yet |
-| PWM      | YES | Not yet |
+| SPI       | YES | YES |
+| I2C       | YES | YES |
+| ADC       | YES | Not yet |
+| PWM       | YES | Not yet |
+| USBDevice | NO  | NO  |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/p1am-100.md
+++ b/content/docs/reference/microcontrollers/p1am-100.md
@@ -11,10 +11,11 @@ The [ProductivityOpen P1AM-100](https://facts-engineering.github.io/modules/P1AM
 | --------- | ------------- | ----- |
 | GPIO      | YES | YES |
 | UART      | YES | YES |
-| SPI      | YES | YES |
-| I2C      | YES | YES |
-| ADC      | YES | YES |
-| PWM      | YES | YES |
+| SPI       | YES | YES |
+| I2C       | YES | YES |
+| ADC       | YES | YES |
+| PWM       | YES | YES |
+| USBDevice | YES | YES |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/particle-argon.md
+++ b/content/docs/reference/microcontrollers/particle-argon.md
@@ -11,11 +11,12 @@ weight: 3
 | --------- | ------------- | ----- |
 | GPIO      | YES | YES |
 | UART      | YES | YES |
-| SPI      | YES | YES |
-| I2C      | YES | YES |
-| ADC      | YES | YES |
-| PWM      | YES | YES |
-| Bluetooth      | YES | YES |
+| SPI       | YES | YES |
+| I2C       | YES | YES |
+| ADC       | YES | YES |
+| PWM       | YES | YES |
+| USBDevice | YES | YES |
+| Bluetooth | YES | YES |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/particle-boron.md
+++ b/content/docs/reference/microcontrollers/particle-boron.md
@@ -11,11 +11,12 @@ weight: 3
 | --------- | ------------- | ----- |
 | GPIO      | YES | YES |
 | UART      | YES | YES |
-| SPI      | YES | YES |
-| I2C      | YES | YES |
-| ADC      | YES | YES |
-| PWM      | YES | YES |
-| Bluetooth      | YES | YES |
+| SPI       | YES | YES |
+| I2C       | YES | YES |
+| ADC       | YES | YES |
+| PWM       | YES | YES |
+| USBDevice | YES | YES |
+| Bluetooth | YES | YES |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/particle-xenon.md
+++ b/content/docs/reference/microcontrollers/particle-xenon.md
@@ -11,11 +11,12 @@ weight: 3
 | --------- | ------------- | ----- |
 | GPIO      | YES | YES |
 | UART      | YES | YES |
-| SPI      | YES | YES |
-| I2C      | YES | YES |
-| ADC      | YES | YES |
-| PWM      | YES | YES |
-| Bluetooth      | YES | YES |
+| SPI       | YES | YES |
+| I2C       | YES | YES |
+| ADC       | YES | YES |
+| PWM       | YES | YES |
+| USBDevice | YES | YES |
+| Bluetooth | YES | YES |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/pca10031.md
+++ b/content/docs/reference/microcontrollers/pca10031.md
@@ -11,11 +11,12 @@ The [Nordic Semiconductor PCA10031](https://www.nordicsemi.com/eng/Products/nRF5
 | --------- | ------------- | ----- |
 | GPIO      | YES | YES |
 | UART      | YES | YES |
-| SPI      | YES | YES |
-| I2C      | YES | YES |
-| ADC      | YES | Not yet |
-| PWM      | YES | Not yet |
-| Bluetooth      | YES | YES |
+| SPI       | YES | YES |
+| I2C       | YES | YES |
+| ADC       | YES | Not yet |
+| PWM       | YES | Not yet |
+| USBDevice | NO  | NO  |
+| Bluetooth | YES | YES |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/pca10040.md
+++ b/content/docs/reference/microcontrollers/pca10040.md
@@ -11,11 +11,12 @@ The [Nordic Semiconductor PCA10040](https://www.nordicsemi.com/eng/Products/Blue
 | --------- | ------------- | ----- |
 | GPIO      | YES | YES |
 | UART      | YES | YES |
-| SPI      | YES | YES |
-| I2C      | YES | YES |
-| ADC      | YES | YES |
-| PWM      | YES | YES |
-| Bluetooth      | YES | YES |
+| SPI       | YES | YES |
+| I2C       | YES | YES |
+| ADC       | YES | YES |
+| PWM       | YES | YES |
+| USBDevice | NO  | NO  |
+| Bluetooth | YES | YES |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/pca10056.md
+++ b/content/docs/reference/microcontrollers/pca10056.md
@@ -11,11 +11,12 @@ The [Nordic Semiconductor PCA10056](https://www.nordicsemi.com/Software-and-Tool
 | --------- | ------------- | ----- |
 | GPIO      | YES | YES |
 | UART      | YES | YES |
-| SPI      | YES | YES |
-| I2C      | YES | YES |
-| ADC      | YES | YES |
-| PWM      | YES | YES |
-| Bluetooth      | YES | YES |
+| SPI       | YES | YES |
+| I2C       | YES | YES |
+| ADC       | YES | YES |
+| PWM       | YES | YES |
+| USBDevice | YES | YES |
+| Bluetooth | YES | YES |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/pca10059.md
+++ b/content/docs/reference/microcontrollers/pca10059.md
@@ -11,11 +11,12 @@ The [Nordic Semiconductor PCA10059](https://www.nordicsemi.com/Software-and-tool
 | --------- | ------------- | ----- |
 | GPIO      | YES | YES |
 | UART      | YES | YES |
-| SPI      | YES | YES |
-| I2C      | YES | YES |
-| ADC      | YES | YES |
-| PWM      | YES | YES |
-| Bluetooth      | YES | YES |
+| SPI       | YES | YES |
+| I2C       | YES | YES |
+| ADC       | YES | YES |
+| PWM       | YES | YES |
+| USBDevice | YES | YES |
+| Bluetooth | YES | YES |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/pico.md
+++ b/content/docs/reference/microcontrollers/pico.md
@@ -11,10 +11,11 @@ The [Raspberry Pi Pico](https://www.raspberrypi.org/products/raspberry-pi-pico/)
 | --------- | ------------- | ----- |
 | GPIO      | YES | YES |
 | UART      | YES | YES |
-| SPI      | YES | YES |
-| I2C      | YES | YES |
-| ADC      | YES | YES |
-| PWM      | YES | YES |
+| SPI       | YES | YES |
+| I2C       | YES | YES |
+| ADC       | YES | YES |
+| PWM       | YES | YES |
+| USBDevice | YES | YES |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/pinetime-devkit0.md
+++ b/content/docs/reference/microcontrollers/pinetime-devkit0.md
@@ -11,10 +11,11 @@ The [PineTime](https://wiki.pine64.org/index.php/PineTime) is a smartwatch by [P
 | --------- | ------------- | ----- |
 | GPIO      | YES | YES |
 | UART      | YES | YES |
-| SPI      | YES | YES |
-| I2C      | YES | YES |
-| ADC      | YES | YES |
-| PWM      | YES | YES |
+| SPI       | YES | YES |
+| I2C       | YES | YES |
+| ADC       | YES | YES |
+| PWM       | YES | YES |
+| USBDevice | NO  | NO  |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/pybadge.md
+++ b/content/docs/reference/microcontrollers/pybadge.md
@@ -13,10 +13,11 @@ It has many built-in devices, such as a 1.8" 160x128 Color TFT Display, 8 x butt
 | --------- | ------------- | ----- |
 | GPIO      | YES | YES |
 | UART      | YES | YES |
-| SPI      | YES | YES |
-| I2C      | YES | YES |
-| ADC      | YES | YES |
-| PWM      | YES | YES |
+| SPI       | YES | YES |
+| I2C       | YES | YES |
+| ADC       | YES | YES |
+| PWM       | YES | YES |
+| USBDevice | YES | YES |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/pygamer.md
+++ b/content/docs/reference/microcontrollers/pygamer.md
@@ -13,10 +13,11 @@ It has many built-in devices, such as a 1.8" 160x128 Color TFT Display, a dual-p
 | --------- | ------------- | ----- |
 | GPIO      | YES | YES |
 | UART      | YES | YES |
-| SPI      | YES | YES |
-| I2C      | YES | YES |
-| ADC      | YES | YES |
-| PWM      | YES | YES |
+| SPI       | YES | YES |
+| I2C       | YES | YES |
+| ADC       | YES | YES |
+| PWM       | YES | YES |
+| USBDevice | YES | YES |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/pyportal.md
+++ b/content/docs/reference/microcontrollers/pyportal.md
@@ -13,10 +13,11 @@ The PyPortal also has an Espressif ESP32 Wi-Fi coprocessor with TLS/SSL support 
 | --------- | ------------- | ----- |
 | GPIO      | YES | YES |
 | UART      | YES | YES |
-| SPI      | YES | YES |
-| I2C      | YES | YES |
-| ADC      | YES | YES |
-| PWM      | YES | YES |
+| SPI       | YES | YES |
+| I2C       | YES | YES |
+| ADC       | YES | YES |
+| PWM       | YES | YES |
+| USBDevice | YES | YES |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/qtpy.md
+++ b/content/docs/reference/microcontrollers/qtpy.md
@@ -11,10 +11,11 @@ The [Adafruit QtPy](https://www.adafruit.com/product/4600) is a tiny ARM develop
 | --------- | ------------- | ----- |
 | GPIO      | YES | YES |
 | UART      | YES | YES |
-| SPI      | YES | YES |
-| I2C      | YES | YES |
-| ADC      | YES | YES |
-| PWM      | YES | YES |
+| SPI       | YES | YES |
+| I2C       | YES | YES |
+| ADC       | YES | YES |
+| PWM       | YES | YES |
+| USBDevice | YES | YES |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/reelboard.md
+++ b/content/docs/reference/microcontrollers/reelboard.md
@@ -13,11 +13,12 @@ It is equipped with an Electrophoretic (electronic ink) Display (EPD), along wit
 | --------- | ------------- | ----- |
 | GPIO      | YES | YES |
 | UART      | YES | YES |
-| SPI      | YES | YES |
-| I2C      | YES | YES |
-| ADC      | YES | YES |
-| PWM      | YES | YES |
-| Bluetooth      | YES | YES |
+| SPI       | YES | YES |
+| I2C       | YES | YES |
+| ADC       | YES | YES |
+| PWM       | YES | YES |
+| USBDevice | YES | YES |
+| Bluetooth | YES | YES |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/stm32f4disco.md
+++ b/content/docs/reference/microcontrollers/stm32f4disco.md
@@ -14,10 +14,11 @@ CS43L22 audio DAC, 2 user buttons, and 4 user LEDs.
 | --------- | ------------- | ----- |
 | GPIO      | YES | YES |
 | UART      | YES | YES |
-| SPI      | YES | YES |
-| I2C      | YES | YES |
-| ADC      | YES | YES |
-| PWM      | YES | Not yet |
+| SPI       | YES | YES |
+| I2C       | YES | YES |
+| ADC       | YES | YES |
+| PWM       | YES | Not yet |
+| USBDevice | YES | Not yet |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/swan.md
+++ b/content/docs/reference/microcontrollers/swan.md
@@ -13,10 +13,11 @@ The Swan has a user button and an LED, LiPo charging and USB.
 | --------- | ------------- | ----- |
 | GPIO      | YES | YES |
 | UART      | YES | YES |
-| SPI      | YES | YES |
-| I2C      | YES | YES |
-| ADC      | YES | Not yet |
-| PWM      | YES | Not yet |
+| SPI       | YES | YES |
+| I2C       | YES | YES |
+| ADC       | YES | Not yet |
+| PWM       | YES | Not yet |
+| USBDevice | YES | Not yet |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/teensy36.md
+++ b/content/docs/reference/microcontrollers/teensy36.md
@@ -11,10 +11,11 @@ The [PJRC Teensy 3.6](https://www.pjrc.com/store/teensy36.html) is a small ARM d
 | --------- | ------------- | ----- |
 | GPIO      | YES | YES |
 | UART      | YES | YES |
-| SPI      | YES | Not yet |
-| I2C      | YES | Not yet |
-| ADC      | YES | Not yet |
-| PWM      | YES | Not yet |
+| SPI       | YES | Not yet |
+| I2C       | YES | Not yet |
+| ADC       | YES | Not yet |
+| PWM       | YES | Not yet |
+| USBDevice | YES | Not yet |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/teensy40.md
+++ b/content/docs/reference/microcontrollers/teensy40.md
@@ -11,10 +11,11 @@ The [PJRC Teensy 4.0](https://www.pjrc.com/store/teensy40.html) is a small ARM d
 | --------- | ------------- | ----- |
 | GPIO      | YES | YES |
 | UART      | YES | YES |
-| SPI      | YES | YES |
-| I2C      | YES | YES |
-| ADC      | YES | YES |
-| PWM      | YES | Not yet |
+| SPI       | YES | YES |
+| I2C       | YES | YES |
+| ADC       | YES | YES |
+| PWM       | YES | Not yet |
+| USBDevice | YES | Not yet |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/thingplus-rp2040.md
+++ b/content/docs/reference/microcontrollers/thingplus-rp2040.md
@@ -15,10 +15,11 @@ Peripherals:
 | --------- | ------------- | ----- |
 | GPIO      | YES | YES |
 | UART      | YES | YES |
-| SPI      | YES | YES |
-| I2C      | YES | YES |
-| ADC      | YES | YES |
-| PWM      | YES | YES |
+| SPI       | YES | YES |
+| I2C       | YES | YES |
+| ADC       | YES | YES |
+| PWM       | YES | YES |
+| USBDevice | YES | YES |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/trinket-m0.md
+++ b/content/docs/reference/microcontrollers/trinket-m0.md
@@ -11,10 +11,11 @@ The [Adafruit Trinket M0](https://www.adafruit.com/product/3500) is a tiny ARM d
 | --------- | ------------- | ----- |
 | GPIO      | YES | YES |
 | UART      | YES | YES |
-| SPI      | YES | YES |
-| I2C      | YES | YES |
-| ADC      | YES | YES |
-| PWM      | YES | YES |
+| SPI       | YES | YES |
+| I2C       | YES | YES |
+| ADC       | YES | YES |
+| PWM       | YES | YES |
+| USBDevice | YES | YES |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/wioterminal.md
+++ b/content/docs/reference/microcontrollers/wioterminal.md
@@ -11,10 +11,11 @@ The [Seeed Wio Terminal](https://www.seeedstudio.com/Wio-Terminal-p-4509.html) i
 | --------- | ------------- | ----- |
 | GPIO      | YES | YES |
 | UART      | YES | YES |
-| SPI      | YES | YES |
-| I2C      | YES | YES |
-| ADC      | YES | YES |
-| PWM      | YES | YES |
+| SPI       | YES | YES |
+| I2C       | YES | YES |
+| ADC       | YES | YES |
+| PWM       | YES | YES |
+| USBDevice | YES | YES |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/x9pro.md
+++ b/content/docs/reference/microcontrollers/x9pro.md
@@ -9,12 +9,13 @@ Info here
 
 | Interface | Hardware Supported | TinyGo Support |
 | --------- | ------------- | ----- |
-| GPIO      | ? | ? |
-| UART      | ? | ? |
-| SPI      | ? | ? |
-| I2C      | ? | ? |
-| ADC      | ? | ? |
-| PWM      | ? | ? |
+| GPIO      | ?   | ?   |
+| UART      | ?   | ?   |
+| SPI       | ?   | ?   |
+| I2C       | ?   | ?   |
+| ADC       | ?   | ?   |
+| PWM       | ?   | ?   |
+| USBDevice | ?   | ?   |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/xiao-ble.md
+++ b/content/docs/reference/microcontrollers/xiao-ble.md
@@ -11,11 +11,12 @@ The [Seeed XIAO BLE](https://www.seeedstudio.com/Seeed-XIAO-BLE-nRF52840-p-5201.
 | --------- | ------------- | ----- |
 | GPIO      | YES | YES |
 | UART      | YES | YES |
-| SPI      | YES | YES |
-| I2C      | YES | YES |
-| ADC      | YES | YES |
-| PWM      | YES | YES |
-| Bluetooth      | YES | YES |
+| SPI       | YES | YES |
+| I2C       | YES | YES |
+| ADC       | YES | YES |
+| PWM       | YES | YES |
+| USBDevice | YES | YES |
+| Bluetooth | YES | YES |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/xiao.md
+++ b/content/docs/reference/microcontrollers/xiao.md
@@ -11,10 +11,11 @@ The [Seeed Seeeduino XIAO](https://www.seeedstudio.com/Seeeduino-XIAO-Arduino-Mi
 | --------- | ------------- | ----- |
 | GPIO      | YES | YES |
 | UART      | YES | YES |
-| SPI      | YES | YES |
-| I2C      | YES | YES |
-| ADC      | YES | YES |
-| PWM      | YES | YES |
+| SPI       | YES | YES |
+| I2C       | YES | YES |
+| ADC       | YES | YES |
+| PWM       | YES | YES |
+| USBDevice | YES | YES |
 
 ## Machine Package Docs
 

--- a/doc-gen/main.go
+++ b/doc-gen/main.go
@@ -330,7 +330,7 @@ func updateBoardDocumentation(path string, pkg *packages.Package, buildTags []st
 				}
 			}
 		}
-		interfacesText += fmt.Sprintf("| %s      | %s | %s |\n", feature, hardwareSupport, softwareSupport)
+		interfacesText += fmt.Sprintf("| %-9s | %-3s | %-3s |\n", feature, hardwareSupport, softwareSupport)
 	}
 
 	// Replace the "Interfaces" section.
@@ -361,6 +361,7 @@ func detectSupportedFeatures(pkg *packages.Package, buildTags []string) map[stri
 		"ADC":       false,
 		"PWM":       false,
 		"Bluetooth": false,
+		"USBDevice": false,
 	}
 
 	pinType := pkg.Types.Scope().Lookup("Pin").Type()
@@ -386,6 +387,9 @@ func detectSupportedFeatures(pkg *packages.Package, buildTags []string) map[stri
 		if tag == "nrf51" || tag == "nrf52" || tag == "nrf52840" || tag == "nrf52833" {
 			features["Bluetooth"] = true
 		}
+	}
+	if pkg.Types.Scope().Lookup("USBDevice") != nil {
+		features["USBDevice"] = true
 	}
 
 	// Detecting PWM support is a bit more tricky.


### PR DESCRIPTION
In TinyGo 0.25, the following microcontrollers support USBDevice.

* atsamd21
* atsamd51
* nrf52840
* rp2040