### PR TITLE
Run `make llvm-source` before `make llvm-build`

### DIFF
--- a/content/docs/guides/build.md
+++ b/content/docs/guides/build.md
@@ -108,7 +108,7 @@ choco install --confirm git golang mingw make cmake ninja python
 The following command takes care of downloading and building LLVM. It places the source code in `llvm-project/` and the build output in `llvm-build/`. It only needs to be done once until the next LLVM release (every half year).
 
 ```shell
-make llvm-build
+make llvm-source llvm-build
 ```
 
 #### Building TinyGo


### PR DESCRIPTION
When following steps in the current documentation, the build will fail with:
```
$ make llvm-build
....
CMake Error: The source directory "$DIR/llvm-project/llvm" does not exist.
```

This is because `make llvm-source` must be run first, to download the sources.