### PR TITLE
Replace AUR package with Arch community repo package

### DIFF
--- a/content/getting-started/install/linux.md
+++ b/content/getting-started/install/linux.md
@@ -114,7 +114,7 @@ This should allow you to compile and flash TinyGo programs on an Arduino or othe
 
 ### Arch Linux
 
-There is an [AUR package](https://aur.archlinux.org/packages/tinygo-bin/) available for the latest TinyGo release.
+There is an [Arch package](https://archlinux.org/packages/community/x86_64/tinygo/) available for the latest TinyGo release.
 
 If you are only interested in compiling TinyGo code for WebAssembly then you are now done with the installation.
 


### PR DESCRIPTION
Arch has added TinyGo to the community repo. This PR replaces the link to the AUR package with a link to the package in the community repo. This is better for users, as not all users have an AUR helper installed, and some are running Arch-based distros that discourage AUR use.