### PR TITLE
guides: add how to build llvm on windows

### DIFF
--- a/content/docs/guides/build.md
+++ b/content/docs/guides/build.md
@@ -128,6 +128,12 @@ The following command takes care of downloading and building LLVM. It places the
 make llvm-source llvm-build
 ```
 
+When building on Windows, add CCACHE=OFF.
+
+```shell
+make llvm-source llvm-build CCACHE=OFF
+```
+
 #### Building TinyGo
 
 Once this is finished, you can build TinyGo against this manually built LLVM:


### PR DESCRIPTION
ccache is installed by choco install mingw.
The addition of CCACHE=OFF is necessary because if ccache is present in windows, it is currently not possible to build.