### PR TITLE
microcontrollers: change to documentation with usbcdc assumption

### DIFF
--- a/content/docs/reference/microcontrollers/feather-rp2040.md
+++ b/content/docs/reference/microcontrollers/feather-rp2040.md
@@ -55,8 +55,6 @@ The Feather RP2040 comes with the [UF2 bootloader](https://github.com/Microsoft/
 
 ### CLI Flashing
 
-- Plug your Feather RP2040 into your computer's USB port while holding down the RESET button on the board.
-- One plugged in, release the RESET button.
 - Flash your TinyGo program to the board using this command:
 
     ```shell
@@ -71,4 +69,4 @@ Any troubleshooting tips go here.
 
 ## Notes
 
-You cannot yet use the USB port to the Feather RP2040 as a serial port. Instead `UART0` refers to the TX/RX pins on the board itself.
+You can use the USB port to the Feather RP2040 as a serial port.

--- a/content/docs/reference/microcontrollers/nano-rp2040.md
+++ b/content/docs/reference/microcontrollers/nano-rp2040.md
@@ -67,8 +67,6 @@ The Nano RP2040 comes with the [UF2 bootloader](https://github.com/Microsoft/uf2
 
 ### CLI Flashing
 
-- Plug your Nano RP2040 into your computer's USB port while shorting the pins REC and GND with a jumper wire.
-- Once plugged in, remove the jumper pin.
 - Flash your TinyGo program to the board using this command:
 
     ```shell
@@ -83,4 +81,4 @@ Any troubleshooting tips go here.
 
 ## Notes
 
-You cannot yet use the USB port to the Nano RP2040 as a serial port. Instead `UART0` refers to the TX/RX pins on the board itself.
+You can use the USB port to the Nano RP2040 as a serial port.

--- a/content/docs/reference/microcontrollers/pico.md
+++ b/content/docs/reference/microcontrollers/pico.md
@@ -62,8 +62,6 @@ The Pico comes with the [UF2 bootloader](https://github.com/Microsoft/uf2) alrea
 
 ### CLI Flashing
 
-- Plug your Pico into your computer's USB port while holding down the RESET button on the board.
-- One plugged in, release the RESET button.
 - Flash your TinyGo program to the board using this command:
 
     ```shell
@@ -78,6 +76,6 @@ Any troubleshooting tips go here.
 
 ## Notes
 
-You cannot yet use the USB port to the Pico as a serial port. Instead `UART0` refers to the TX/RX pins on the board itself.
+You can use the USB port to the Pico as a serial port.
 
 You can refer to [getting started with Raspberry Pi Pico](https://datasheets.raspberrypi.org/pico/getting-started-with-pico.pdf) documentation on how to connect two Picos together (see Appendix A: Using Picoprobe) to debug and convert `UART0` output on target pico to USB output on picoprobe. You will need the [Picoprobe UF2](https://www.raspberrypi.org/documentation/rp2040/getting-started/#board-specifications), available on the Pico's website under "About" tab.

--- a/content/docs/reference/microcontrollers/thingplus-rp2040.md
+++ b/content/docs/reference/microcontrollers/thingplus-rp2040.md
@@ -65,8 +65,6 @@ The Sparkfun Thing Plus RP2040 comes with the [UF2 bootloader](https://github.co
 
 ### CLI Flashing
 
-- Plug your Thing Plus RP2040 into your computer's USB port while pressing the BOOT button
-- Release BOOT Button
 - Flash your TinyGo program to the board using this command:
 
     ```shell
@@ -81,6 +79,6 @@ Any troubleshooting tips go here.
 
 ## Notes
 
-You cannot yet use the USB port to the Thing Plus RP2040 as a serial port. Instead `UART0` refers to the TX/RX pins on the board itself.
+You can use the USB port to the Thing Plus RP2040 as a serial port.
 
 The Neopixel LED and the SD Card are supported by [tinygo drivers](https://github.com/tinygo-org/drivers)


### PR DESCRIPTION
Now it is no longer necessary to press BOOTSEL.
Also, the default machine.Serial is now USBCDC.