### PR TITLE
site: update references to TinyGo 0.25.0 to 0.26.0

### DIFF
--- a/content/docs/guides/build.md
+++ b/content/docs/guides/build.md
@@ -146,7 +146,7 @@ This results in a `tinygo` binary in the `build` directory:
 
 ```shell
 $ ./build/tinygo version
-tinygo version 0.25.0 linux/amd64 (using go version go1.18.1 and LLVM version 14.0.0)
+tinygo version 0.26.0 linux/amd64 (using go version go1.19.1 and LLVM version 14.0.0)
 ```
 
 You have successfully built TinyGo from source. Congratulations!

--- a/content/docs/guides/webassembly.md
+++ b/content/docs/guides/webassembly.md
@@ -60,13 +60,13 @@ Note the `--no-debug` flag, which reduces the size of the final binary by removi
 debug symbols from the output. Also note that you must change the path to your Wasm file from `/go/src/github.com/myuser/myrepo/wasm-main.go` to whatever the actual path to your file is:
 
 ```
-docker run -v $GOPATH:/go -e "GOPATH=/go" tinygo/tinygo:0.25.0 tinygo build -o /go/src/github.com/myuser/myrepo/wasm.wasm -target wasm --no-debug /go/src/github.com/myuser/myrepo/wasm-main.go
+docker run -v $GOPATH:/go -e "GOPATH=/go" tinygo/tinygo:0.26.0 tinygo build -o /go/src/github.com/myuser/myrepo/wasm.wasm -target wasm --no-debug /go/src/github.com/myuser/myrepo/wasm-main.go
 ```
 
 Make sure you copy `wasm_exec.js` to your runtime environment:
 
 ```
-docker run -v $GOPATH:/go -e "GOPATH=/go" tinygo/tinygo:0.25.0 /bin/bash -c "cp /usr/local/tinygo/targets/wasm_exec.js /go/src/github.com/myuser/myrepo/
+docker run -v $GOPATH:/go -e "GOPATH=/go" tinygo/tinygo:0.26.0 /bin/bash -c "cp /usr/local/tinygo/targets/wasm_exec.js /go/src/github.com/myuser/myrepo/
 ```
 
 More complete examples are provided in the [wasm examples](https://github.com/tinygo-org/tinygo/tree/release/src/examples/wasm).

--- a/content/getting-started/install/linux.md
+++ b/content/getting-started/install/linux.md
@@ -28,15 +28,15 @@ You must have Go already installed on your machine in order to install TinyGo. W
 If you are using Ubuntu or another Debian based Linux on an Intel processor, download the DEB file from Github and install it using the following commands:
 
 ```shell
-wget https://github.com/tinygo-org/tinygo/releases/download/v0.25.0/tinygo_0.25.0_amd64.deb
-sudo dpkg -i tinygo_0.25.0_amd64.deb
+wget https://github.com/tinygo-org/tinygo/releases/download/v0.26.0/tinygo_0.26.0_amd64.deb
+sudo dpkg -i tinygo_0.26.0_amd64.deb
 ```
 
 If you are on a Raspberry Pi or other ARM-based Linux computer, you should use this command instead:
 
 ```shell
-wget https://github.com/tinygo-org/tinygo/releases/download/v0.25.0/tinygo_0.25.0_armhf.deb
-sudo dpkg -i tinygo_0.25.0_armhf.deb
+wget https://github.com/tinygo-org/tinygo/releases/download/v0.26.0/tinygo_0.26.0_armhf.deb
+sudo dpkg -i tinygo_0.26.0_armhf.deb
 ```
 
 You will need to ensure that the path to the `tinygo` executable file is in your `PATH` variable.
@@ -49,7 +49,7 @@ You can test that the installation is working properly by running this code whic
 
 ```shell
 $ tinygo version
-tinygo version 0.25.0 linux/amd64 (using go version go1.18.1 and LLVM version 14.0.0)
+tinygo version 0.26.0 linux/amd64 (using go version go1.19.1 and LLVM version 14.0.0)
 ```
 
 If you are on a 64 bit ARM OS, and running tinygo fails with "no such file or directory", you may need to install the 32 bit C++ runtime library, e.g.:

--- a/content/getting-started/install/macos.md
+++ b/content/getting-started/install/macos.md
@@ -20,10 +20,10 @@ brew install tinygo
 
 ### Alternative installation
 
-Download [this](https://github.com/tinygo-org/tinygo/releases/download/v0.25.0/tinygo0.25.0.darwin-amd64.tar.gz) file. Then, run the following commands:
+Download [this](https://github.com/tinygo-org/tinygo/releases/download/v0.26.0/tinygo0.26.0.darwin-amd64.tar.gz) file. Then, run the following commands:
 
 ```shell
-tar xvzf tinygo-0.25.0.darwin-amd64.tar.gz
+tar xvzf tinygo-0.26.0.darwin-amd64.tar.gz
 export PATH=<extract location>/tinygo/bin:$PATH
 ```
 
@@ -31,7 +31,7 @@ You can test that the installation is working properly by running this code whic
 
 ```shell
 $ tinygo version
-tinygo version 0.25.0 darwin/amd64 (using go version go1.18.1 and LLVM version 14.0.0)
+tinygo version 0.26.0 darwin/amd64 (using go version go1.19.1 and LLVM version 14.0.0)
 ```
 
 If you are only interested in compiling TinyGo code for WebAssembly then you are done with the installation.

--- a/content/getting-started/install/using-docker.md
+++ b/content/getting-started/install/using-docker.md
@@ -9,7 +9,7 @@ You can use our Docker image to be able to run the TinyGo compiler on your compu
 
 ## Installing
 
-    docker pull tinygo/tinygo:0.25.0
+    docker pull tinygo/tinygo:0.26.0
 
 ## Using
 
@@ -18,24 +18,24 @@ For your own code, you will probably want to use absolute paths.
 
 A docker container exists for easy access to the TinyGo CLI. For example, to compile `wasm.wasm` for the WebAssembly export example:
 
-    docker run --rm -v $(pwd):/src tinygo/tinygo:0.25.0 tinygo build -o wasm.wasm -target=wasm examples/wasm/export
+    docker run --rm -v $(pwd):/src tinygo/tinygo:0.26.0 tinygo build -o wasm.wasm -target=wasm examples/wasm/export
 
 See the [WebAssembly page](../../../docs/guides/webassembly) for more information on executing the compiled
 WebAssembly.
 
 To compile `blinky1.hex` targeting an ARM microcontroller, such as the PCA10040:
 
-    docker run --rm -v $(pwd):/src tinygo/tinygo:0.25.0 tinygo build -o /src/blinky1.hex -size=short -target=pca10040 examples/blinky1
+    docker run --rm -v $(pwd):/src tinygo/tinygo:0.26.0 tinygo build -o /src/blinky1.hex -size=short -target=pca10040 examples/blinky1
 
 To compile `blinky1.hex` targeting an AVR microcontroller such as the Arduino:
 
-    docker run --rm -v $(pwd):/src tinygo/tinygo:0.25.0 tinygo build -o /src/blinky1.hex -size=short -target=arduino examples/blinky1
+    docker run --rm -v $(pwd):/src tinygo/tinygo:0.26.0 tinygo build -o /src/blinky1.hex -size=short -target=arduino examples/blinky1
 
 For projects that have remote dependencies outside of the standard library and
 go code within your own project, you will need to map your entire `$GOPATH`
 into the docker image for those dependencies to be found:
 
-    docker run -v $GOPATH:/go -e "GOPATH=/go" tinygo/tinygo:0.25.0 tinygo build -o /go/src/github.com/myuser/myrepo/wasm.wasm -target wasm --no-debug /go/src/github.com/myuser/myrepo/wasm-main.go
+    docker run -v $GOPATH:/go -e "GOPATH=/go" tinygo/tinygo:0.26.0 tinygo build -o /go/src/github.com/myuser/myrepo/wasm.wasm -target wasm --no-debug /go/src/github.com/myuser/myrepo/wasm-main.go
 
 **note: At this time, tinygo does not resolve dependencies from the /vendor/ folder within your project.**
 

--- a/content/getting-started/install/windows.md
+++ b/content/getting-started/install/windows.md
@@ -33,7 +33,7 @@ You can test that the installation was successful by running the `version` comma
 
 ```shell
 > tinygo version
-tinygo version 0.25.0 windows/amd64 (using go version go1.18.1 and LLVM version 14.0.0)
+tinygo version 0.26.0 windows/amd64 (using go version go1.19.1 and LLVM version 14.0.0)
 ```
 
 Upgrading to the latest TinyGo version can be done via scoop with:
@@ -67,7 +67,7 @@ Upgrading to the latest versions can be as easy as:
 
     - Choose the download link for Microsoft Windows, Windows 7 or later, Intel 64-bit processor.
 
-- Download the TinyGo binary for Windows file from https://github.com/tinygo-org/tinygo/releases/download/v0.25.0/tinygo0.25.0.windows-amd64.zip
+- Download the TinyGo binary for Windows file from https://github.com/tinygo-org/tinygo/releases/download/v0.26.0/tinygo0.26.0.windows-amd64.zip
 
 - Decompress the file like this:
 
@@ -87,7 +87,7 @@ Upgrading to the latest versions can be as easy as:
 
     ```
     > tinygo version
-    tinygo version 0.25.0 windows/amd64 (using go version go1.18.1 and LLVM version 14.0.0)
+    tinygo version 0.26.0 windows/amd64 (using go version go1.19.1 and LLVM version 14.0.0)
     ```
 
 ### Flashing boards


### PR DESCRIPTION
This PR updates site references from TinyGo 0.25.0 to 0.26.0