### PR TITLE
getting-started: remove xtensa-esp32-elf requirement

### DIFF
--- a/content/getting-started/install/macos.md
+++ b/content/getting-started/install/macos.md
@@ -53,12 +53,3 @@ brew tap osx-cross/avr
 brew install avr-gcc
 brew install avrdude
 ```
-
-#### Xtensa ESP32
-
-To compile TinyGo programs for the Xtensa ESP32 based processors from Espressif, you must install some extra tools:
-
-```shell
-brew tap tasanakorn/homebrew-esp32
-brew install xtensa-esp32-elf
-```


### PR DESCRIPTION
These aren't necessary anymore with LLD support for Xtensa.

Should be merged only after https://github.com/tinygo-org/tinygo/pull/3264 is merged.