### PR TITLE
Fix wasm docs for tinygo 0.26.0

### DIFF
--- a/content/docs/guides/webassembly.md
+++ b/content/docs/guides/webassembly.md
@@ -16,8 +16,10 @@ func main() {
 }
 
 // This function is imported from JavaScript, as it doesn't define a body.
-// You should define a function named 'main.add' in the WebAssembly 'env'
+// You should define a function named 'add' in the WebAssembly 'env'
 // module from JavaScript.
+//
+//export add
 func add(x, y int) int
 
 // This function is exported to JavaScript, so can be called using
@@ -34,7 +36,7 @@ Related JavaScript would look something like this:
 // Providing the environment object, used in WebAssembly.instantiateStreaming.
 // This part goes after "const go = new Go();" declaration.
 go.importObject.env = {
-    'main.add': function(x, y) {
+    'add': function(x, y) {
         return x + y
     }
     // ... other functions


### PR DESCRIPTION
As of 0.26.0 the go `//export` directive is required for
functions defined in JS (see [PR 3133](https://github.com/tinygo-org/tinygo/pull/3133)), otherwise we get 
a `tinygo:wasm-ld: error` of `undefined symbol`. 

Along with this change the `main.` package prefix is no longer required on the
JS side when declaring the `go.importObject.env` object.

Thanks to @camh- for working this out first!

Issue: https://github.com/tinygo-org/tinygo/issues/3283