### PR TITLE
microcontrollers: remove esp32 toolchain installation instructions

### DIFF
--- a/content/docs/reference/microcontrollers/esp32-coreboard-v2.md
+++ b/content/docs/reference/microcontrollers/esp32-coreboard-v2.md
@@ -64,11 +64,7 @@ The esp32-coreboard-v2 is a development board based on the [Espressif ESP32](htt
 
 ### CLI Flashing on Linux
 
-You need to install the Espressif toolchain for Linux to use TinyGo with the ESP32: 
-
-https://docs.espressif.com/projects/esp-idf/en/release-v3.0/get-started/linux-setup.html#standard-setup-of-toolchain-for-linux
-
-In addition, you must install the `esptool` flashing tool:
+You need to install the `esptool` flashing tool:
 
 https://github.com/espressif/esptool#easy-installation
 
@@ -85,11 +81,7 @@ Now you should be able to flash your board as follows:
 
 ### CLI Flashing on macOS
 
-You need to install the Espressif toolchain for macOS to use TinyGo with the ESP32: 
-
-https://docs.espressif.com/projects/esp-idf/en/release-v3.0/get-started/macos-setup.html
-
-In addition, you must install the `esptool` flashing tool:
+You need to install the `esptool` flashing tool:
 
 https://github.com/espressif/esptool#easy-installation
 
@@ -106,11 +98,7 @@ Now you should be able to flash your board as follows:
 
 ### CLI Flashing on Windows
 
-You need to install the Espressif toolchain for Windows to use TinyGo with the ESP32: 
-
-https://docs.espressif.com/projects/esp-idf/en/release-v3.0/get-started/windows-setup.html
-
-In addition, you must install the `esptool` flashing tool:
+You need to install the `esptool` flashing tool:
 
 https://github.com/espressif/esptool#easy-installation
 

--- a/content/docs/reference/microcontrollers/esp32-mini32.md
+++ b/content/docs/reference/microcontrollers/esp32-mini32.md
@@ -64,11 +64,7 @@ The mini32 is a small development board based on the popular [Espressif ESP32](h
 
 ### CLI Flashing on Linux
 
-You need to install the Espressif toolchain for Linux to use TinyGo with the ESP32: 
-
-https://docs.espressif.com/projects/esp-idf/en/release-v3.0/get-started/linux-setup.html#standard-setup-of-toolchain-for-linux
-
-In addition, you must install the `esptool` flashing tool:
+You need to install the `esptool` flashing tool:
 
 https://github.com/espressif/esptool#easy-installation
 
@@ -85,11 +81,7 @@ Now you should be able to flash your board as follows:
 
 ### CLI Flashing on macOS
 
-You need to install the Espressif toolchain for macOS to use TinyGo with the ESP32: 
-
-https://docs.espressif.com/projects/esp-idf/en/release-v3.0/get-started/macos-setup.html
-
-In addition, you must install the `esptool` flashing tool:
+You need to install the `esptool` flashing tool:
 
 https://github.com/espressif/esptool#easy-installation
 
@@ -106,11 +98,7 @@ Now you should be able to flash your board as follows:
 
 ### CLI Flashing on Windows
 
-You need to install the Espressif toolchain for Windows to use TinyGo with the ESP32: 
-
-https://docs.espressif.com/projects/esp-idf/en/release-v3.0/get-started/windows-setup.html
-
-In addition, you must install the `esptool` flashing tool:
+You need to install the `esptool` flashing tool:
 
 https://github.com/espressif/esptool#easy-installation
 

--- a/content/docs/reference/microcontrollers/m5stack-core2.md
+++ b/content/docs/reference/microcontrollers/m5stack-core2.md
@@ -103,11 +103,7 @@ The [m5stack-core2](https://shop.m5stack.com/products/m5stack-core2-esp32-iot-de
 
 ### CLI Flashing on Linux
 
-You need to install the Espressif toolchain for Linux to use TinyGo with the ESP32: 
-
-https://docs.espressif.com/projects/esp-idf/en/release-v3.0/get-started/linux-setup.html#standard-setup-of-toolchain-for-linux
-
-In addition, you must install the `esptool` flashing tool:
+You need to install the `esptool` flashing tool:
 
 https://github.com/espressif/esptool#easy-installation
 
@@ -124,11 +120,7 @@ Now you should be able to flash your board as follows:
 
 ### CLI Flashing on macOS
 
-You need to install the Espressif toolchain for macOS to use TinyGo with the ESP32: 
-
-https://docs.espressif.com/projects/esp-idf/en/release-v3.0/get-started/macos-setup.html
-
-In addition, you must install the `esptool` flashing tool:
+You need to install the `esptool` flashing tool:
 
 https://github.com/espressif/esptool#easy-installation
 
@@ -145,11 +137,7 @@ Now you should be able to flash your board as follows:
 
 ### CLI Flashing on Windows
 
-You need to install the Espressif toolchain for Windows to use TinyGo with the ESP32: 
-
-https://docs.espressif.com/projects/esp-idf/en/release-v3.0/get-started/windows-setup.html
-
-In addition, you must install the `esptool` flashing tool:
+You need to install the `esptool` flashing tool:
 
 https://github.com/espressif/esptool#easy-installation
 

--- a/content/docs/reference/microcontrollers/m5stack.md
+++ b/content/docs/reference/microcontrollers/m5stack.md
@@ -66,11 +66,7 @@ The [m5stack](https://docs.m5stack.com/en/core/basic) is a development board bas
 
 ### CLI Flashing on Linux
 
-You need to install the Espressif toolchain for Linux to use TinyGo with the ESP32: 
-
-https://docs.espressif.com/projects/esp-idf/en/release-v3.0/get-started/linux-setup.html#standard-setup-of-toolchain-for-linux
-
-In addition, you must install the `esptool` flashing tool:
+You need to install the `esptool` flashing tool:
 
 https://github.com/espressif/esptool#easy-installation
 
@@ -87,11 +83,7 @@ Now you should be able to flash your board as follows:
 
 ### CLI Flashing on macOS
 
-You need to install the Espressif toolchain for macOS to use TinyGo with the ESP32: 
-
-https://docs.espressif.com/projects/esp-idf/en/release-v3.0/get-started/macos-setup.html
-
-In addition, you must install the `esptool` flashing tool:
+You need to install the `esptool` flashing tool:
 
 https://github.com/espressif/esptool#easy-installation
 
@@ -108,11 +100,7 @@ Now you should be able to flash your board as follows:
 
 ### CLI Flashing on Windows
 
-You need to install the Espressif toolchain for Windows to use TinyGo with the ESP32: 
-
-https://docs.espressif.com/projects/esp-idf/en/release-v3.0/get-started/windows-setup.html
-
-In addition, you must install the `esptool` flashing tool:
+You need to install the `esptool` flashing tool:
 
 https://github.com/espressif/esptool#easy-installation
 


### PR DESCRIPTION
These are not necessary anymore.