### PR TITLE
Fix link to DFU Description.

### DIFF
--- a/content/docs/reference/microcontrollers/feather-stm32f405.md
+++ b/content/docs/reference/microcontrollers/feather-stm32f405.md
@@ -67,7 +67,7 @@ The [Adafruit Feather STM32F405](https://www.adafruit.com/product/4382) is a tin
 
 ## Flashing
 
-Flashing this board using its DFU bootloader can be a bit cumbersome (see Adafruit docs at https://learn.adafruit.com/adafruit-stm32f405-feather-express/dfu-bootloader-details), but it is possible - without requiring an external programmer - by pulling the B0 pin high (you can use the board's 3.3V output pin) at bootup when connected to host PC via USB. This puts the device in bootloader mode.
+Flashing this board using its DFU bootloader can be a bit cumbersome (see Adafruit docs at https://learn.adafruit.com/adafruit-stm32f405-feather-express/dfu-bootloader-details ), but it is possible - without requiring an external programmer - by pulling the B0 pin high (you can use the board's 3.3V output pin) at bootup when connected to host PC via USB. This puts the device in bootloader mode.
 
 Once in bootloader mode, the device can be programmed using the open-source tool `dfu-util`.
 

--- a/content/docs/reference/microcontrollers/feather-stm32f405.md
+++ b/content/docs/reference/microcontrollers/feather-stm32f405.md
@@ -67,7 +67,8 @@ The [Adafruit Feather STM32F405](https://www.adafruit.com/product/4382) is a tin
 
 ## Flashing
 
-Flashing this board using its DFU bootloader can be a bit cumbersome (see Adafruit docs at https://learn.adafruit.com/adafruit-stm32f405-feather-express/dfu-bootloader-details ), but it is possible - without requiring an external programmer - by pulling the B0 pin high (you can use the board's 3.3V output pin) at bootup when connected to host PC via USB. This puts the device in bootloader mode.
+Flashing this board using its DFU bootloader can be a bit cumbersome, but it is possible - without requiring an external programmer - by pulling the B0 pin high (you can use the board's 3.3V output pin) at bootup when connected to host PC via USB. This puts the device in bootloader mode.
+For more information see [Adafruit docs](https://learn.adafruit.com/adafruit-stm32f405-feather-express/dfu-bootloader-details).
 
 Once in bootloader mode, the device can be programmed using the open-source tool `dfu-util`.
 


### PR DESCRIPTION
The trailing ) broke the link, added a space to help markdown a bit.