### PR TITLE
getting-started: remove `avr-gcc` dependency

### DIFF
--- a/content/docs/reference/microcontrollers/arduino-mega1280.md
+++ b/content/docs/reference/microcontrollers/arduino-mega1280.md
@@ -103,14 +103,6 @@ Note: the AVR backend of LLVM is still experimental so you may encounter bugs.
 The Arduino Mega 1280 needs a few extra dependencies to work, for example, if you get an error like this:
 
 ```text
-/usr/lib/gcc/avr/5.4.0/../../../avr/bin/ld: cannot find -lm
-/usr/lib/gcc/avr/5.4.0/../../../avr/bin/ld: cannot find -lc
-collect2: error: ld returned 1 exit status
-```
-
-Or like this:
-
-```text
 /bin/sh: 1: avrdude: not found
 ```
 

--- a/content/docs/reference/microcontrollers/arduino-mega2560.md
+++ b/content/docs/reference/microcontrollers/arduino-mega2560.md
@@ -103,14 +103,6 @@ Note: the AVR backend of LLVM is still experimental so you may encounter bugs.
 The Arduino Mega 2560 needs a few extra dependencies to work, for example, if you get an error like this:
 
 ```text
-/usr/lib/gcc/avr/5.4.0/../../../avr/bin/ld: cannot find -lm
-/usr/lib/gcc/avr/5.4.0/../../../avr/bin/ld: cannot find -lc
-collect2: error: ld returned 1 exit status
-```
-
-Or like this:
-
-```text
 /bin/sh: 1: avrdude: not found
 ```
 

--- a/content/docs/reference/microcontrollers/arduino-nano.md
+++ b/content/docs/reference/microcontrollers/arduino-nano.md
@@ -53,14 +53,6 @@ Note: the AVR backend of LLVM is still experimental so you may encounter bugs.
 The Arduino Nano needs a few extra dependencies to work, for example, if you get an error like this:
 
 ```text
-/usr/lib/gcc/avr/5.4.0/../../../avr/bin/ld: cannot find -lm
-/usr/lib/gcc/avr/5.4.0/../../../avr/bin/ld: cannot find -lc
-collect2: error: ld returned 1 exit status
-```
-
-Or like this:
-
-```text
 /bin/sh: 1: avrdude: not found
 ```
 

--- a/content/docs/reference/microcontrollers/arduino.md
+++ b/content/docs/reference/microcontrollers/arduino.md
@@ -53,14 +53,6 @@ Note: the AVR backend of LLVM is still experimental so you may encounter bugs.
 The Arduino Uno needs a few extra dependencies to work, for example, if you get an error like this:
 
 ```text
-/usr/lib/gcc/avr/5.4.0/../../../avr/bin/ld: cannot find -lm
-/usr/lib/gcc/avr/5.4.0/../../../avr/bin/ld: cannot find -lc
-collect2: error: ld returned 1 exit status
-```
-
-Or like this:
-
-```text
 /bin/sh: 1: avrdude: not found
 ```
 

--- a/content/getting-started/install/linux.md
+++ b/content/getting-started/install/linux.md
@@ -70,15 +70,13 @@ If you are only interested in compiling TinyGo code for ARM microcontrollers the
 
 #### AVR (e.g. Arduino Uno)
 
-To compile and flash TinyGo programs for AVR based processors such as the original Arduino Uno you must install some extra tools:
+To flash TinyGo programs for AVR based processors such as the original Arduino Uno you must install `avrdude`:
 
 ```shell
-sudo apt-get install gcc-avr
-sudo apt-get install avr-libc
 sudo apt-get install avrdude
 ```
 
-This should allow you to compile and flash TinyGo programs on an Arduino or other supported AVR-based board.
+This should allow you to flash TinyGo programs on an Arduino Uno or other supported AVR-based board.
 
 #### You are now done with the TinyGo "Quick Install" for Ubuntu/Debian
 

--- a/content/getting-started/install/macos.md
+++ b/content/getting-started/install/macos.md
@@ -46,10 +46,8 @@ Some boards require a special flashing tool for that particular chip, like `open
 
 #### AVR (e.g. Arduino Uno)
 
-To compile and flash TinyGo programs for AVR based processors such as the original Arduino Uno you must install some extra tools:
+To flash TinyGo programs for AVR based processors such as the original Arduino Uno you must install `avrdude`:
 
 ```shell
-brew tap osx-cross/avr
-brew install avr-gcc
 brew install avrdude
 ```

--- a/content/getting-started/install/windows.md
+++ b/content/getting-started/install/windows.md
@@ -44,17 +44,15 @@ Upgrading to the latest TinyGo version can be done via scoop with:
 
 #### AVR (e.g. Arduino Uno)
 
-If you want to develop code for older Arduino boards such as the Arduino Uno, you can install the dependencies required for AVR development  (`avr-gcc` and `avrdude`) via Scoop:
+If you want to flash programs on older Arduino boards such as the Arduino Uno, you need to install the `avrdude` tool via Scoop:
 
 ```shell
-> scoop install avr-gcc
 > scoop install avrdude
 ```
 
 Upgrading to the latest versions can be as easy as:
 
 ```shell
-> scoop update avr-gcc
 > scoop update avrdude
 ```
 


### PR DESCRIPTION
This dependency is no longer needed to build binaries for AVR. `avrdude` is still needed however.