### PR TITLE
content/docs: Fix broken links

### DIFF
--- a/content/docs/concepts/low-power.md
+++ b/content/docs/concepts/low-power.md
@@ -38,7 +38,9 @@ Capabilities of different chips:
 
 Especially the distinction between waking up with or without RAM is important, because it greatly affects how you write software.
 
-The common way to wake up from deep sleep is to use [interrupts](compiler-internals/interrupts), such as timer, real-time-clock or an interrupt on a pin change.
+The common way to wake up from deep sleep is to use
+[interrupts]({{<ref "compiler-internals/interrupts">}}), such as timer,
+real-time-clock or an interrupt on a pin change.
 
 ### RP2040
 
@@ -57,7 +59,7 @@ The only thing you may want to tweak is to disable the UART with help of `-seria
 
 ## The Way to Low Power
 
-> Attached [debugger](../guides/debugging) usually blocks the low power state in chip.  
+> Attached [debugger]({{<ref "../guides/debugging">}}) usually blocks the low power state in chip.
 > The best way to measure when using a debugger is to flash the code, do a power cycle, and then measure.
 
 > The changes discussed in this paragraph shall be made in TinyGo and not in your application code.  

--- a/content/docs/guides/tips-n-tricks.md
+++ b/content/docs/guides/tips-n-tricks.md
@@ -66,4 +66,4 @@ buf2 := t.buf[2:6]
 
 For more recipes on how to avoid or minimize allocations while working with slices, please see [additional tricks](https://github.com/golang/go/wiki/SliceTricks#additional-tricks) section of [slice tricks](https://github.com/golang/go/wiki/SliceTricks) page.
 
-Familiarize yourself with [heap allocation concept](../concepts/compiler-internals/heap-allocation.md) and use it to your advantage.
+Familiarize yourself with [heap allocation concept]({{<ref "../concepts/compiler-internals/heap-allocation.md">}}) and use it to your advantage.

--- a/content/docs/reference/microcontrollers/nano-33-ble-sense.md
+++ b/content/docs/reference/microcontrollers/nano-33-ble-sense.md
@@ -5,9 +5,11 @@ weight: 3
 
 The [Arduino Nano 33 BLE Sense](https://store.arduino.cc/arduino-nano-33-ble-sense) is a very small ARM development board based on the Nordic Semiconductor [nrf52840](https://www.nordicsemi.com/eng/Products/nRF52840) processor.
 
-This is the same board as [Arduino Nano 33 BLE](nano-33-ble) but with additional onboard sensors (see below).
+This is the same board as [Arduino Nano 33 BLE]({{<ref "nano-33-ble.md">}}) but
+with additional onboard sensors (see below).
 
-Flash this board exactly the same way as [Arduino Nano 33 BLE](nano-33-ble) (target name is the same too).
+Flash this board exactly the same way as
+[Arduino Nano 33 BLE]({{<ref "nano-33-ble.md">}}) (target name is the same too).
 
 ## Additional onboard sensors
 

--- a/content/docs/reference/microcontrollers/nano-33-ble.md
+++ b/content/docs/reference/microcontrollers/nano-33-ble.md
@@ -5,7 +5,8 @@ weight: 3
 
 The [Arduino Nano33 BLE](https://store.arduino.cc/arduino-nano-33-ble) is a very small ARM development board based on the Nordic Semiconductor [nrf52840](https://www.nordicsemi.com/eng/Products/nRF52840) processor.
 
-There is also the [Arduino Nano33 BLE Sense](nano-33-ble-sense) which is the exact same board but with additional onboard sensors.
+There is also the [Arduino Nano33 BLE Sense]({{<ref "nano-33-ble-sense">}})
+which is the exact same board but with additional onboard sensors.
 
 ## Interfaces
 
@@ -118,7 +119,8 @@ Instructions needed here.
 Nordic Semiconductor's SoftDevice (s140v7) must be flashed first to enable use of [bluetooth](https://github.com/tinygo-org/bluetooth) on this board.
 
 SoftDevice overwrites original bootloader and flashing method described above is not avalable anymore.
-Instead, please use [debug](../../guides/debugging.md) probe and flash your code with `nano-33-ble-s140v7` target.
+Instead, please use [debug]({{<ref "../../guides/debugging.md">}}) probe and
+flash your code with `nano-33-ble-s140v7` target.
 
 ## Notes
 


### PR DESCRIPTION
I wanted to fix one broken link. Then saw a bunch of others, so decided to fix all the ones that I could find.
Verified by running a local `hugo serve` and manually checking that the links are fixed.