### PR TITLE
Proposal: add DMA support to SPI

### DIFF
--- a/content/docs/guides/build.md
+++ b/content/docs/guides/build.md
@@ -49,7 +49,7 @@ For **Debian** or **Ubuntu** you can install LLVM by adding a new apt repository
 | Debian | sid    | `unstable`|
 
 ```shell
-echo 'deb http://apt.llvm.org/xxxxx/ llvm-toolchain-xxxxx-15 main' | sudo tee /etc/apt/sources.list.d/llvm.list
+echo 'deb http://apt.llvm.org/xxxxx/ llvm-toolchain-xxxxx-16 main' | sudo tee /etc/apt/sources.list.d/llvm.list
 ```
 
 After adding the apt repository for your distribution you may install the LLVM toolchain packages:
@@ -63,7 +63,7 @@ sudo apt-get install clang-16 llvm-16-dev lld-16 libclang-16-dev
 For **MacOS**, you can install LLVM through [Homebrew](https://formulae.brew.sh/formula/llvm). The Clang/LLVM version from Apple is not supported by TinyGo.
 
 ```shell
-brew install llvm
+brew install llvm@16
 ```
 
 For **Fedora** users you can install LLVM from the repository. Note that the version of LLVM [varies by Fedora version](https://packages.fedoraproject.org/pkgs/llvm/llvm-libs/), for example Fedora 37 has LLVM 15.

--- a/content/docs/guides/build.md
+++ b/content/docs/guides/build.md
@@ -90,7 +90,7 @@ If you are getting a build error like this, LLVM is not installed as expected:
 1 error generated.
 ```
 
-This can often be fixed by specifying the LLVM version as a build tag, for example `-tags=llvm14` if you have LLVM 14 instead of LLVM 16.
+This can often be fixed by specifying the LLVM version as a build tag, for example `-tags=llvm15` if you have LLVM 15 instead of LLVM 16.
 
 Note that you should not use `make` when you want to build using a system-installed LLVM, just use the Go toolchain. `make` is used when you want to use a self-built LLVM, as in the next section.
 

--- a/content/docs/guides/build.md
+++ b/content/docs/guides/build.md
@@ -69,7 +69,7 @@ brew install llvm@16
 For **Fedora** users you can install LLVM from the repository. Note that the version of LLVM [varies by Fedora version](https://packages.fedoraproject.org/pkgs/llvm/llvm-libs/), for example Fedora 37 has LLVM 15.
 
 ```shell
-sudo dnf install llvm-devel lld-libs lld
+sudo dnf install llvm-devel clang-libs lld
 ```
 
 After LLVM has been installed, installing TinyGo should be as easy as running the following command:

--- a/content/docs/reference/machine.md
+++ b/content/docs/reference/machine.md
@@ -366,6 +366,14 @@ CPUReset performs a hard system reset.
 Not all chips support CPUReset.
 
 ```go
+func DeviceID() []byte
+```
+
+DeviceID returns a byte array containing a unique id (aka Serial Number) specific to this chip.  In some architectures (notably RP2040) the device ID is actually the ID of the flash chip.  The device ID can be useful for identifying specific devices within a family.  There is no guarantee the ID is globally unique.  The size of the ID is chip-family specific with 8 bytes (64 bits) and 16 bytes (128 bits) being common.
+
+Not all chips have a hardware ID.
+
+```go
 func GetRNG() uint32
 ```
 

--- a/content/docs/reference/machine.md
+++ b/content/docs/reference/machine.md
@@ -148,6 +148,30 @@ The `Tx` performs the actual SPI transaction, and return an error if there was a
 
 Some chips may also support mismatched lengths of `w` and `r`, in which case they will behave like above for the remaining bytes in the byte slice that's the longest of the two.
 
+```go
+func (spi SPI) IsAsync() bool
+```
+
+Return whether the SPI supports asynchronous operation (usually using [DMA](https://en.wikipedia.org/wiki/Direct_memory_access)). Asynchronous operation may be supported for some or all transfers, for example it may only be supported for send-only transfers.
+
+```go
+func (spi SPI) StartTx(w, r []byte) error
+```
+
+Start a SPI transmission in the background (usually, using DMA). This has the same effect as running `Tx` in a goroutine, but doesn't spawn a new goroutine. The `w` and `r` byte slices must not be used while the transmission is in progress, but must be stored somewhere outside the `StartTx` function to avoid garbage collecting them.
+
+It is allowed to start multiple transactions without waiting for the first to finish. They will have the effect as if `Tx` was called multiple times in sequence. Lots of hardware won't support this however and will simply wait for the first to finish before starting a new transmission.
+
+If `IsAsync` returns false, this is an alias for `Tx`.
+
+```go
+func (spi SPI) Wait() error
+```
+
+Wait until all active transactions (started by `StartTx`) have finished. The buffers provided in `StartTx` will be available after calling `Wait`.
+
+If `IsAsync` returns false, this is a no-op.
+
 
 ## I2C
 


### PR DESCRIPTION
Here is a possible API I've designed to add DMA support in the machine SPI API.

Here is a copy of the API description:

> ```go
> func (spi SPI) IsAsync() bool
> ```
> 
> Return whether the SPI supports asynchronous operation (usually using [DMA](https://en.wikipedia.org/wiki/Direct_memory_access)). Asynchronous operation may be supported for some or all transfers, for example it may only be supported for send-only transfers.
> 
> ```go
> func (spi SPI) StartTx(w, r []byte) error
> ```
> 
> Start a SPI transmission in the background (usually, using DMA). This has the same effect as running `Tx` in a goroutine, but doesn't spawn a new goroutine. The `w` and `r` byte slices must not be used while the transmission is in progress, but must be stored somewhere outside the `StartTx` function to avoid garbage collecting them.
> 
> It is allowed to start multiple transactions without waiting for the first to finish. They will have the effect as if `Tx` was called multiple times in sequence. Lots of hardware won't support this however and will simply wait for the first to finish before starting a new transmission.
> 
> If `IsAsync` returns false, this is an alias for `Tx`.
> 
> ```go
> func (spi SPI) Wait() error
> ```
> 
> Wait until all active transactions (started by `StartTx`) have finished. The buffers provided in `StartTx` will be available after calling `Wait`.
> 
> If `IsAsync` returns false, this is a no-op.

Alternatives I've considered:

  * Making `Tx` yield to the scheduler and relying on goroutines. I tried using this, but found it hard to use correctly - at least when I simply added a `gosched()` call in `Tx`. I struggled to make it actually do things in parallel. Once I switched to an API that exposes asynchronous transfers directly, it worked the first time for me.
  * Letting `StartTx` return a promise/future that can be waited on. I liked the idea, but realized that it would be hard to put in an interface (what's the promise type going to be?). On the other hand, `Wait` is just a simple call that is easy to put in an interface.
  * Not including `IsAsync` but making this purely an implementation detail. Unfortunately, for displays it's important to know whether the transfer can be async: if the SPI peripheral isn't async, it's not worth using two separate buffers (one of which would have been used for DMA).
  * Not allowing multiple buffers in `StartTx`. I don't plan on implementing queuing now, but it seems like a possibly useful feature. Many chips support chained SPI transfers and if the chip doesn't support it, it can be emulated by starting the next transfer from the DMA end interrupt.

I also have a proposal to the Displayer interface coming up which will use this API. Together, they can deliver very fast SPI display updates like in my Simplex noise demo here (where I used DMA to update the display in parallel with calculating the next frame, reducing SPI time from 20ms to almost nothing):
https://twitter.com/aykevl/status/1644411686189776897