### PR TITLE
social: add Mastodon links

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -57,10 +57,15 @@ sidebar_menu_truncate = 1000
 [params.links]
 # End user relevant links. These will show up on left side of footer and in the community page if you have one.
 [[params.links.user]]
+	name ="Mastodon"
+	url = "https://mastodon.social/@TinyGo"
+	icon = "fab fa-mastodon"
+		desc = "Follow us on Mastodon to get the latest news!"
+[[params.links.user]]
 	name ="Twitter"
 	url = "https://twitter.com/TinyGolang"
 	icon = "fab fa-twitter"
-        desc = "Follow us on Twitter to get the latest news!"
+		desc = "You can also follow us on Twitter"
 [[params.links.user]]
 	name ="Go Pkg Docs"
 	url = "https://pkg.go.dev/github.com/tinygo-org/tinygo?tab=doc"

--- a/content/_index.md
+++ b/content/_index.md
@@ -21,7 +21,7 @@ title: "TinyGo Home"
 {{% blocks/lead color="secondary" %}}
 TinyGo brings the [Go programming language](https://golang.org) to embedded systems and to the modern web by creating a new compiler based on [LLVM](https://llvm.org/).
 
-You can compile and run TinyGo programs on over 85 different microcontroller boards such as the [BBC micro:bit](https://www.microbit.co.uk/) and the [Arduino Uno](https://store.arduino.cc/usa/arduino-uno-rev3/). [Click here for the complete list](/docs/reference/microcontrollers)
+You can compile and run TinyGo programs on over 94 different microcontroller boards such as the [BBC micro:bit](https://www.microbit.co.uk/) and the [Arduino Uno](https://store.arduino.cc/usa/arduino-uno-rev3/). [Click here for the complete list](/docs/reference/microcontrollers)
 
 TinyGo can also produce [WebAssembly (WASM)](https://webassembly.org/) code which is very compact in size. You can compile programs for web browsers, as well as for server and edge computing environments that support the [WebAssembly System Interface (WASI)](https://github.com/WebAssembly/WASI) family of interfaces.
 
@@ -39,8 +39,8 @@ See the code here
 {{% /blocks/feature %}}
 
 
-{{% blocks/feature icon="fab fa-twitter" title="TinyGo on Twitter" url="https://twitter.com/tinygolang" %}}
-Follow us for news
+{{% blocks/feature icon="fab fa-mastodon" title="TinyGo on Mastodon" url="https://mastodon.social/@TinyGo" %}}
+Join us on Mastodon
 {{% /blocks/feature %}}
 
 {{< /blocks/section >}}


### PR DESCRIPTION
This PR is to add Mastodon links to the TinyGo social links.