### PR TITLE
docs/guides: some improvements to the webassembly section

### DIFF
--- a/content/docs/guides/webassembly/_index.md
+++ b/content/docs/guides/webassembly/_index.md
@@ -1,0 +1,7 @@
+---
+title: "WebAssembly"
+weight: 2
+description: >
+  TinyGo is very useful for compiling programs both for use in browsers (WASM) as well as for use on servers and other edge devices (WASI).
+---
+

--- a/content/docs/guides/webassembly/wasi.md
+++ b/content/docs/guides/webassembly/wasi.md
@@ -1,0 +1,31 @@
+---
+title: "Using WASI"
+weight: 3
+description: |
+  How to use TinyGo with the WebAssembly System Interface (WASI).
+---
+
+TinyGo is very useful for compiling programs for use on servers and other edge devices (WASI).
+
+TinyGo programs can run in Fastly Compute@Edge (https://developer.fastly.com/learning/compute/go/), Fermyon Spin (https://developer.fermyon.com/spin/go-components), wazero (https://wazero.io/languages/tinygo/) and many other WebAssembly runtimes.
+
+Here is a small TinyGo program for use within a WASI host application:
+
+```go
+package main
+
+//go:wasm-module yourmodulename
+//export add
+func add(x, y uint32) uint32 {
+	return x + y
+}
+
+// main is required for the `wasi` target, even if it isn't used.
+func main() {}
+```
+
+To compile the above TinyGo program for use on any WASI runtime:
+
+```shell
+tinygo build -o main.wasm -target=wasi main.go
+```

--- a/content/docs/guides/webassembly/wasm.md
+++ b/content/docs/guides/webassembly/wasm.md
@@ -1,5 +1,5 @@
 ---
-title: "Using WebAssembly"
+title: "Using WASM"
 weight: 3
 description: |
   How to call WebAssembly from JavaScript in a browser.


### PR DESCRIPTION
This PR makes some improvements to the docs/guides/webassembly section, by adding a new page for WASI information, and moving both pages into a single `webassembly` subsection.