### PR TITLE
docs/guides: add pages for macOS and Windows

### DIFF
--- a/content/docs/guides/macos.md
+++ b/content/docs/guides/macos.md
@@ -1,0 +1,12 @@
+---
+title: "macOS support"
+weight: 4
+description: |
+  How to use TinyGo to create standard macOS executables.
+---
+
+Using TinyGo you can compile programs for macOS systems.
+
+For cross compiling, you can use `GOOS`. For example, you can cross compile the `examples/serial` example from a Linux host targeting macOS with the following command:
+
+    GOOS=darwin tinygo build -o serial examples/serial

--- a/content/docs/guides/windows.md
+++ b/content/docs/guides/windows.md
@@ -1,0 +1,12 @@
+---
+title: "Windows support"
+weight: 4
+description: |
+  How to use TinyGo to create standard Windows executables.
+---
+
+TinyGo also lets you compile programs for Windows systems.
+
+For cross compiling, you can use `GOOS` and `GOARCH` as usual. For example, you can cross compile the `examples/serial` example from a Linux host targeting Windows with the following command:
+
+    GOOS=windows tinygo build -o serial.exe examples/serial


### PR DESCRIPTION
This PR adds pages for macOS and Windows to the `docs/guides` section.