### PR TITLE
guides,reference: some explanation about ldflags and build variables

### DIFF
--- a/content/docs/guides/tips-n-tricks.md
+++ b/content/docs/guides/tips-n-tricks.md
@@ -88,9 +88,11 @@ func main() {
 }
 ```
 
-One important thing to note is that you cannot use a default value in your code if you want to be able to set that value using `-ldflags`. This is due to the internals of how the Go SSA works. If you set the varible to a default value, then the value you pass using `ldflags` will be ignored. The value of the `version` variable in this code excerpt would **not** be changed by for this reason:
+One important thing to note is that you cannot use a default value in your code if you want to be able to set that value using `-ldflags`. If you set the variable to a default value, then the value you pass using `ldflags` will be ignored. The value of the `version` variable in this code excerpt would **not** be changed by for this reason:
 
 ```go
 // will not be changed by using ldflags
 var version = "default value"
 ```
+
+Another important thing to note is that the values passed in could end up cached on the machine used to build the binary, for example in `~/.cache/tinygo/thinlto/`. Because this feature is often used to pass in secrets, you will want to clear this cache as needed based on the security needs of your application.

--- a/content/docs/guides/tips-n-tricks.md
+++ b/content/docs/guides/tips-n-tricks.md
@@ -67,3 +67,30 @@ buf2 := t.buf[2:6]
 For more recipes on how to avoid or minimize allocations while working with slices, please see [additional tricks](https://github.com/golang/go/wiki/SliceTricks#additional-tricks) section of [slice tricks](https://github.com/golang/go/wiki/SliceTricks) page.
 
 Familiarize yourself with [heap allocation concept]({{<ref "../concepts/compiler-internals/heap-allocation.md">}}) and use it to your advantage.
+
+## How to set build-time variables
+
+You might have some specific value that you want to set for a variable at build-time. For example, you might want to preset a serial number, or set the WiFi access point SSID that you want your device to connect to, or set the version of the code being built.
+
+This can be done using the `tinygo build` command `-ldflags` flag like this:
+
+`tinygo build -ldflags="-X 'main.version=1.0.0'" -target pyportal .`
+
+In your TinyGo program, the variable of the same package name/variable name will have its value set using the value passed in the `-ldflags` flag. Most commonly this will use the scope of the `main` package.
+
+```go
+package main
+
+var version string
+
+func main() {
+	println("the version is", version)
+}
+```
+
+One important thing to note is that you cannot use a default value in your code if you want to be able to set that value using `-ldflags`. This is due to the internals of how the Go SSA works. If you set the varible to a default value, then the value you pass using `ldflags` will be ignored. The value of the `version` variable in this code excerpt would **not** be changed by for this reason:
+
+```go
+// will not be changed by using ldflags
+var version = "default value"
+```

--- a/content/docs/reference/usage/important-options.md
+++ b/content/docs/reference/usage/important-options.md
@@ -76,3 +76,6 @@ Use the specified scheduler. The default scheduler varies by platform. For examp
   - `scheduler=tasks` The tasks scheduler is a scheduler much like an RTOS available for non-WASM platforms. This is usually the preferred scheduler.
   - `scheduler=asyncify` The asyncify scheduler is a scheduler for WASM based off of [Binaryen's Asyncify Pass](https://github.com/WebAssembly/binaryen/blob/main/src/passes/Asyncify.cpp).
   - `scheduler=none` The none scheduler disables scheduler support, which means that goroutines and channels are not available. It can be used to reduce firmware size and RAM consumption if goroutines and channels are not needed.
+
+- `-ldflags`
+The TinyGo `ldflags` flag has the same behavior as the Go link tool `ldflags` flag. It passes a value along to the TinyGo linker. This is commonly used to set the value for a variable at the time that the program is compiled for example `-ldflags="-X 'package_path.variable_name=new_value'"`


### PR DESCRIPTION
This PR updates the guides and reference sections to add some explanation about the use of the `-ldflags` flag, how to use with build variables.