### PR TITLE
all: Update docsy 0.6, correct sidebar link

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,6 +1,7 @@
 baseURL = "https://tinygo.org/"
 title = "TinyGo"
-languageCode = "en-us"
+languageCode = "en"
+
 theme = "docsy"
 
 enableGitInfo = true
@@ -22,7 +23,6 @@ anchor = "smart"
 unsafe = true
 
 # Everything below this are Site Params
-
 [params]
 copyright = "The TinyGo Authors"
 
@@ -85,3 +85,8 @@ sidebar_menu_truncate = 1000
 
 [params.mermaid]
 enable = true
+
+[params.path_base_for_github_subdir]
+# change content/<lang>/... to content/...
+from = "content/(.*?)/(.*?)"
+to = "content/$2"


### PR DESCRIPTION
This PR updates the Docsy theme to the latest released version v0.6.0

It also corrects the sidebar links for "edit page" so that they point to the correct location. See https://github.com/google/docsy/issues/1420#issuecomment-1503810483