### PR TITLE
guides/embedded: add resources page

### DIFF
--- a/content/docs/guides/embedded/_index.md
+++ b/content/docs/guides/embedded/_index.md
@@ -1,0 +1,7 @@
+---
+title: "Embedded"
+weight: 2
+description: >
+  TinyGo can compile code that can run on even very small microcontrollers.
+---
+

--- a/content/docs/guides/embedded/resources.md
+++ b/content/docs/guides/embedded/resources.md
@@ -1,0 +1,103 @@
+---
+title: "Resources"
+weight: 4
+description: |
+    Resources for using TinyGo for embedded development
+---
+
+Here are some of the "official" packages and resources in the TinyGo ecosystem that you can use for creating embedded programs.
+
+[I want to use sensors connected to my device](#sensors)
+
+[I want to use a display connected to my device](#displays)
+
+[I want to make a wireless connection with my device](#sensors)
+
+[I want to store data on my device](#sensors)
+
+There are also other great resources in the community. You can find some of them in the "Awesome TinyGo" repository:
+
+https://github.com/tinygo-org/awesome-tinygo
+
+
+## Sensors
+
+Check out the TinyGo Drivers repository for many different kinds of sensors that you can use from your TinyGo programs:
+
+https://github.com/tinygo-org/drivers
+
+
+## Displays
+
+There are a number of displays you can connect via SPI or parallel interfaces and then use from your TinyGo programs.
+
+See the TinyGo Drivers repository for some of the supported display devices:
+
+https://github.com/tinygo-org/drivers
+
+### I want to draw some graphics on my display
+
+Check out the TinyDraw repo:
+
+https://github.com/tinygo-org/tinydraw
+
+### I want to show some text on my display
+
+Take a look at the TinyFont repo:
+
+https://github.com/tinygo-org/tinyfont
+
+### I want to use the display as a terminal interface
+
+See the TinyTerm repo:
+
+https://github.com/tinygo-org/tinyterm
+
+
+## Wireless
+
+### I want to use Bluetooth
+
+Check out the TinyGo Bluetooth repository:
+
+https://github.com/tinygo-org/bluetooth
+
+### I want to use WiFi
+
+Check out the TinyGo Drivers repository for some of the WiFi co-processors that you can use from your TinyGo programs:
+
+https://github.com/tinygo-org/drivers
+
+### I want to use LoRa
+
+Check out the TinyGo Drivers repository for some of the LoRa co-processors that you can use from your TinyGo programs:
+
+https://github.com/tinygo-org/drivers
+
+
+## Data Storage
+
+### I want to store data files on the device
+
+Take a look at the TinyFS repository:
+
+https://github.com/tinygo-org/tinyfs
+
+### I want to use the internal Flash memory on my device
+
+See the TinyGo Drivers repository:
+
+https://github.com/tinygo-org/drivers
+
+### I want to use external Flash memory with my device
+
+See the TinyGo Drivers repository:
+
+https://github.com/tinygo-org/drivers
+
+### I want to use an SD card with my device
+
+See the TinyGo Drivers repository:
+
+https://github.com/tinygo-org/drivers
+


### PR DESCRIPTION
This PR adds a new section for guides/embedded with a new resources page with links to some of the official resources for embedded development.