### PR TITLE
theme: switch to use Docsy as module

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "themes/docsy"]
-	path = themes/docsy
-	url = https://github.com/google/docsy.git

--- a/config.toml
+++ b/config.toml
@@ -2,7 +2,7 @@ baseURL = "https://tinygo.org/"
 title = "TinyGo"
 languageCode = "en"
 
-theme = "docsy"
+theme = ["github.com/google/docsy", "github.com/google/docsy/dependencies"]
 
 enableGitInfo = true
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/tinygo-org/tinygo-site
+
+go 1.19
+
+require (
+	github.com/google/docsy v0.6.0 // indirect
+	github.com/google/docsy/dependencies v0.6.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,6 @@
+github.com/FortAwesome/Font-Awesome v0.0.0-20220831210243-d3a7818c253f/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
+github.com/google/docsy v0.6.0 h1:43bVF18t2JihAamelQjjGzx1vO2ljCilVrBgetCA8oI=
+github.com/google/docsy v0.6.0/go.mod h1:VKKLqD8PQ7AglJc98yBorATfW7GrNVsn0kGXVYF6G+M=
+github.com/google/docsy/dependencies v0.6.0 h1:BFXDCINbp8ZuUGl/mrHjMfhCg+b1YX+hVLAA5fGW7Pc=
+github.com/google/docsy/dependencies v0.6.0/go.mod h1:EDGc2znMbGUw0RW5kWwy2oGgLt0iVXBmoq4UOqstuNE=
+github.com/twbs/bootstrap v4.6.2+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,11 +2,11 @@
 
 # Default build settings
 [build]
-  command = "cd themes/docsy && git submodule update -f --init && cd ../.. && hugo"
+  command = "hugo"
 
 # "production" environment specific build settings
 [build.environment]
-  HUGO_VERSION = "0.82.0"
+  HUGO_VERSION = "0.111.3"
 
 # "production" environment specific build settings
 [context.release.environment]


### PR DESCRIPTION
This PR switches to use Docsy as a module, since the original use of the theme as a git submodule is now giving trouble with building the needed SCSS/JS dependencies.