### PR TITLE
home: remove link-down

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -14,7 +14,6 @@ title: "TinyGo Home"
 		See the code <i class="fab fa-github ml-2 "></i>
 	</a>
 	<p class="h2 mt-5">Go on embedded systems and WebAssembly</p>
-	{{< blocks/link-down color="info" >}}
 </div>
 {{< /blocks/cover >}}
 


### PR DESCRIPTION
This PR should remove the broken "link-down" on the home page.