### PR TITLE
fix(wasi): MD formatting for Links

### DIFF
--- a/content/docs/guides/webassembly/wasi.md
+++ b/content/docs/guides/webassembly/wasi.md
@@ -7,7 +7,7 @@ description: |
 
 TinyGo is very useful for compiling programs for use on servers and other edge devices (WASI).
 
-TinyGo programs can run in Fastly Compute@Edge (https://developer.fastly.com/learning/compute/go/), Fermyon Spin (https://developer.fermyon.com/spin/go-components), wazero (https://wazero.io/languages/tinygo/) and many other WebAssembly runtimes.
+TinyGo programs can run in [Fastly Compute@Edge](https://developer.fastly.com/learning/compute/go/), [Fermyon Spin](https://developer.fermyon.com/spin/go-components), [wazero](https://wazero.io/languages/tinygo/) and many other WebAssembly runtimes.
 
 Here is a small TinyGo program for use within a WASI host application:
 


### PR DESCRIPTION
Use Markdown Syntax for Links in the WASI doc.