### PR TITLE
Fixes to LLVM related installation

### DIFF
--- a/content/docs/guides/build.md
+++ b/content/docs/guides/build.md
@@ -49,7 +49,7 @@ For **Debian** or **Ubuntu** you can install LLVM by adding a new apt repository
 | Debian | sid    | `unstable`|
 
 ```shell
-echo 'deb http://apt.llvm.org/xxxxx/ llvm-toolchain-xxxxx-15 main' | sudo tee /etc/apt/sources.list.d/llvm.list
+echo 'deb http://apt.llvm.org/xxxxx/ llvm-toolchain-xxxxx-16 main' | sudo tee /etc/apt/sources.list.d/llvm.list
 ```
 
 After adding the apt repository for your distribution you may install the LLVM toolchain packages:
@@ -63,7 +63,7 @@ sudo apt-get install clang-16 llvm-16-dev lld-16 libclang-16-dev
 For **MacOS**, you can install LLVM through [Homebrew](https://formulae.brew.sh/formula/llvm). The Clang/LLVM version from Apple is not supported by TinyGo.
 
 ```shell
-brew install llvm
+brew install llvm@16
 ```
 
 For **Fedora** users you can install LLVM from the repository. Note that the version of LLVM [varies by Fedora version](https://packages.fedoraproject.org/pkgs/llvm/llvm-libs/), for example Fedora 37 has LLVM 15.

--- a/content/docs/guides/build.md
+++ b/content/docs/guides/build.md
@@ -90,7 +90,7 @@ If you are getting a build error like this, LLVM is not installed as expected:
 1 error generated.
 ```
 
-This can often be fixed by specifying the LLVM version as a build tag, for example `-tags=llvm14` if you have LLVM 14 instead of LLVM 16.
+This can often be fixed by specifying the LLVM version as a build tag, for example `-tags=llvm15` if you have LLVM 15 instead of LLVM 16.
 
 Note that you should not use `make` when you want to build using a system-installed LLVM, just use the Go toolchain. `make` is used when you want to use a self-built LLVM, as in the next section.
 

--- a/content/docs/guides/build.md
+++ b/content/docs/guides/build.md
@@ -69,7 +69,7 @@ brew install llvm@16
 For **Fedora** users you can install LLVM from the repository. Note that the version of LLVM [varies by Fedora version](https://packages.fedoraproject.org/pkgs/llvm/llvm-libs/), for example Fedora 37 has LLVM 15.
 
 ```shell
-sudo dnf install llvm-devel lld-libs lld
+sudo dnf install llvm-devel clang-libs lld
 ```
 
 After LLVM has been installed, installing TinyGo should be as easy as running the following command:


### PR DESCRIPTION
* Use newer LLVM versions
* Use `brew install llvm@16` instead of `brew install llvm` to avoid confusion with newer LLVM version (like now, with LLVM 17).
* Fix Fedora install command (@QuLogic: FYI)