### PR TITLE
docs(macos): update links according to HCI guidelines for improved readability

### DIFF
--- a/content/getting-started/install/macos.md
+++ b/content/getting-started/install/macos.md
@@ -7,7 +7,7 @@ description: >
   macOS install guide
 ---
 
-This page has information on how to install and use TinyGo on macOS. If you wish to build TinyGo from source, for example if you intend to contribute to the project, please take a look [here](../../../docs/guides/build).
+This page has information on how to install and use TinyGo on macOS. If you wish to build TinyGo from source, for example if you intend to contribute to the project, please take a look at [Guides: Build from source](../../../docs/guides/build).
 
 You must have Go v1.19+ already installed on your machine in order to install TinyGo.
 
@@ -20,17 +20,20 @@ brew install tinygo
 
 ### Alternative installation
 
-Download [this](https://github.com/tinygo-org/tinygo/releases/download/v0.30.0/tinygo0.30.0.darwin-amd64.tar.gz) file. Then, run the following commands:
-
-```shell
-tar xvzf tinygo-0.30.0.darwin-amd64.tar.gz
-export PATH=<extract location>/tinygo/bin:$PATH
-```
+1. Download [tinygo0.30.0.darwin-amd64.tar.gz](https://github.com/tinygo-org/tinygo/releases/download/v0.30.0/tinygo0.30.0.darwin-amd64.tar.gz).
+2. Extract the package and update your PATH:
+   ```shell
+   tar xvf tinygo-0.30.0.darwin-amd64.tar.gz
+   export PATH=<extract location>/tinygo/bin:$PATH
+   ```
 
 You can test that the installation is working properly by running this code which should display the version number:
 
 ```shell
-$ tinygo version
+tinygo version
+```
+
+```text
 tinygo version 0.30.0 darwin/amd64 (using go version go1.21 and LLVM version 16.0.0)
 ```
 
@@ -42,7 +45,9 @@ Otherwise, please continue with the installation of the additional requirements 
 
 If you are only interested in compiling TinyGo code for ARM microcontrollers then you are now done with the installation.
 
-Some boards require a special flashing tool for that particular chip, like `openocd` or `nrfjprog`. See the documentation page for your board as listed [here](../../../docs/reference/microcontrollers/) to see which flashing tool is required for your target board.
+Some boards require a special flashing tool for that particular chip, like `openocd` or `nrfjprog`.
+
+[The Microcontrollers List](../../../docs/reference/microcontrollers/) documents which flashing tool is required for the supported target board.
 
 #### AVR (e.g. Arduino Uno)
 
@@ -58,7 +63,7 @@ You can download the latest builds from the TinyGo `dev` branch where active dev
 
 To obtain the binary, first go to the list of recent actions for the macOS build:
 
-https://github.com/tinygo-org/tinygo/actions/workflows/build-macos.yml?query=branch%3Adev
+<https://github.com/tinygo-org/tinygo/actions/workflows/build-macos.yml?query=branch%3Adev>
 
 Click on the link for the build you want to download. The most recent one is located at the top.
 


### PR DESCRIPTION
## Preview

See the changes in action at:

<https://github.com/coolaj86/tinygo-site/blob/patch-1/content/getting-started/install/macos.md>

## Here, here!

I changed the links by
- making the visual target much larger by making the text of the links more specific and clear
- placing links closer to the beginning or end of the sentence rather than in the middle
- using strict markdown link indicators `<>` 

As general (and highly effective) HCI / Technical Writing / Accessibility guidelines, the words "this", "here", "click", etc should be hunted down and vanquished! (and replaced with action phrases / content descriptions)

## The Colors Duke, The Colors!

I'm a superchromat (i.e. perfect color / hue distinction), on a Macbook (nearly perfect hue/color display), and the difference between the space black text and dark grey blue links is so difficult to distinguish that I couldn't recognize the links as such.

I'd highly recommend changing both the unvisited and visited link colors and adding underlines to at least links in text bodies.