### PR TITLE
docs(macos): guide to suppress unmount notification

### DIFF
--- a/content/getting-started/install/macos.md
+++ b/content/getting-started/install/macos.md
@@ -44,6 +44,13 @@ If you are only interested in compiling TinyGo code for ARM microcontrollers the
 
 Some boards require a special flashing tool for that particular chip, like `openocd` or `nrfjprog`. See the documentation page for your board as listed [here](../../../docs/reference/microcontrollers/) to see which flashing tool is required for your target board.
 
+The boards with USB Mass Storage Device flashing method, like Raspberry Pi Pico (RP2040), reboot and detach "unsafely" during flashing procedure.  
+This behaviour upsets OS and it shows a modal notification one shall unmount USB drive properly first.  
+To suppress this notification, run the following command and restarting your Mac after that.  
+```
+sudo defaults write /Library/Preferences/SystemConfiguration/com.apple.DiskArbitration.diskarbitrationd.plist DADisableEjectNotification -bool YES && sudo pkill diskarbitrationd
+```
+
 #### AVR (e.g. Arduino Uno)
 
 To flash TinyGo programs for AVR based processors such as the original Arduino Uno you must install `avrdude`:


### PR DESCRIPTION
Solution found here https://www.reddit.com/r/MacOS/comments/vsn32y/how_to_disable_not_ejected_safely_notification_on/

And verified by me personally on my own laptop (macOS Sonoma 14.2)