### PR TITLE
[Game Boy Advance] Add examples section

### DIFF
--- a/content/docs/reference/microcontrollers/gameboy-advance.md
+++ b/content/docs/reference/microcontrollers/gameboy-advance.md
@@ -36,6 +36,11 @@ tinygo build -o main.gba -target gameboy-advance examples/gba-display
 
 You can now use the GBA file with your emulator or flash it onto your physical hardware.
 
+## Examples
+
+* [gba-display](https://github.com/tinygo-org/tinygo/blob/release/src/examples/gba-display/gba-display.go)
+* [Other GBA examples (Buttons, Gopher, Snake...)](https://github.com/tinygo-org/tinygba/tree/main/examples)
+
 ## Flashing
 
 Information needed here...


### PR DESCRIPTION
In the documentation there is a command to build  gba-display app/program for the GBA but what is gba-display? 

It's an example, so the goal is to give the links to gba-display and other examples