### PR TITLE
Solving typo in build.md

### DIFF
--- a/content/docs/guides/build.md
+++ b/content/docs/guides/build.md
@@ -49,7 +49,7 @@ For **Debian** or **Ubuntu** you can install LLVM by adding a new apt repository
 | Debian | sid    | `unstable`|
 
 ```shell
-echo 'deb http://apt.llvm.org/xxxxx/ llvm-toolchain-xxxxx-15 main' | sudo tee /etc/apt/sources.list.d/llvm.list
+echo 'deb http://apt.llvm.org/xxxxx/ llvm-toolchain-xxxxx-16 main' | sudo tee /etc/apt/sources.list.d/llvm.list
 ```
 
 After adding the apt repository for your distribution you may install the LLVM toolchain packages:


### PR DESCRIPTION
The version for llvm apt repository did not correspond the llvm version one would  install in the subsequent command. 

```
sudo apt-get install clang-16 llvm-16-dev lld-16 libclang-16-dev
```

I was having issues following the guide. After this change I'm able to install `clang-16`