### PR TITLE
Update to Docsy 0.7

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -28,7 +28,7 @@ Ready to get started? [Click here](getting-started).
 
 {{% /blocks/lead %}}
 
-{{< blocks/section color="primary-light" >}}
+{{< blocks/section color="primary-light" type="row" >}}
 {{% blocks/feature icon="fa-lightbulb" title="TinyGo Playground" url="https://play.tinygo.org/" %}}
 Try TinyGo online
 {{% /blocks/feature %}}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/tinygo-org/tinygo-site
 go 1.19
 
 require (
-	github.com/google/docsy v0.6.0 // indirect
-	github.com/google/docsy/dependencies v0.6.0 // indirect
+	github.com/google/docsy v0.7.0 // indirect
+	github.com/google/docsy/dependencies v0.7.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,6 @@
-github.com/FortAwesome/Font-Awesome v0.0.0-20220831210243-d3a7818c253f/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
-github.com/google/docsy v0.6.0 h1:43bVF18t2JihAamelQjjGzx1vO2ljCilVrBgetCA8oI=
-github.com/google/docsy v0.6.0/go.mod h1:VKKLqD8PQ7AglJc98yBorATfW7GrNVsn0kGXVYF6G+M=
-github.com/google/docsy/dependencies v0.6.0 h1:BFXDCINbp8ZuUGl/mrHjMfhCg+b1YX+hVLAA5fGW7Pc=
-github.com/google/docsy/dependencies v0.6.0/go.mod h1:EDGc2znMbGUw0RW5kWwy2oGgLt0iVXBmoq4UOqstuNE=
-github.com/twbs/bootstrap v4.6.2+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=
+github.com/FortAwesome/Font-Awesome v0.0.0-20230327165841-0698449d50f2/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
+github.com/google/docsy v0.7.0 h1:JaeZ0/KufX/BJ3SyATb/fmZa1DFI7o5d9KU+i6+lLJY=
+github.com/google/docsy v0.7.0/go.mod h1:5WhIFchr5BfH6agjcInhpLRz7U7map0bcmKSpcrg6BE=
+github.com/google/docsy/dependencies v0.7.0 h1:/xUlWCZOSMDubHfrhIz1YtaRn2Oc/swfJ7OUfglXE8U=
+github.com/google/docsy/dependencies v0.7.0/go.mod h1:gihhs5gmgeO+wuoay4FwOzob+jYJVyQbNaQOh788lD4=
+github.com/twbs/bootstrap v5.2.3+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=


### PR DESCRIPTION
Most notably, this is an update to Bootstrap 5.2. It only needed a single line change to fix the layout.

It would make it slightly easier to add a TinyGo Playground on the homepage (just like on https://go.dev/) because then I don't have to juggle with Bootstrap versions.

I tried updating to Docsy 0.8, but the search function breaks with that change and I'm not sure how to fix it. So I decided to just bump the version to 0.7.