### PR TITLE
Add a playground view on the homepage

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "static/playground"]
+	path = static/playground
+	url = https://github.com/tinygo-org/playground.git

--- a/config.toml
+++ b/config.toml
@@ -91,3 +91,12 @@ enable = true
 # change content/<lang>/... to content/...
 from = "content/(.*?)/(.*?)"
 to = "content/$2"
+
+# Add some extra headers to the development server.
+# This is only relevant with `hugo serve`.
+[server]
+[[server.headers]]
+    for = '/**'
+    [server.headers.values]
+      Cross-Origin-Opener-Policy = "same-origin"
+      Cross-Origin-Embedder-Policy = "require-corp"

--- a/content/_index.md
+++ b/content/_index.md
@@ -28,7 +28,66 @@ Ready to get started? [Click here](getting-started).
 
 {{% /blocks/lead %}}
 
-{{< blocks/section color="primary-light" type="row" >}}
+{{% blocks/section color="primary-light" %}}
+<link rel="stylesheet" href="playground/simulator.css">
+<script type="module" src="playground.js"></script>
+<div class="col">
+	<div class="container" id="playground">
+		<h1 class="text-center">Try TinyGo</h1>
+		<div class="row px-0">
+			<div class="col col-auto">
+				<div class="input-group mb-3">
+					<span class="input-group-text">Example</span>
+					<select class="form-select example_select" disabled>
+						<option value="hello">Hello world</option>
+						<option value="arduino" selected>Blinking LED (Arduino Uno)</option>
+						<option value="circuitplay_express">RGB LEDs (Adafruit Circuit Playground Express)</option>
+						<option value="gopher_badge">Display (Gopher Badge)</option>
+					</select>
+				</div>
+			</div>
+			<div class="col col-auto">
+				<button class="btn btn-secondary playground-btn-flash" disabled>Download binary</button>
+			</div>
+		</div>
+		<textarea placeholder="Loading..." class="form-control input" rows="20" style="font-family: monospace; tab-size: 4" spellcheck="false"></textarea>
+		<div class="simulator inline">
+			<div class="schematic-buttons">
+				<button class="schematic-button-pause schematic-button" title="Pause/resume the simulation">
+					<!-- only one of these two images is visible at a time -->
+					<img src="playground/resources/codicon/debug-pause.svg" class="button-img-pause"/>
+					<img src="playground/resources/codicon/play.svg" class="button-img-play"/>
+				</button>
+			</div>
+			<svg class="schematic">
+				<g class="schematic-wrapper" style="transform: translate(50%, 50%)">
+					<g class="schematic-parts"></g>
+					<g class="schematic-wires"></g>
+				</g>
+			</svg>
+			<div class="panels">
+				<div class="tabbar">
+					<span class="tab active panel-tab-terminal"><a>Terminal</a></span>
+					<span class="tab"><a>Properties</a></span>
+					<span class="tab"><a>Add</a></span>
+				</div>
+				<div class="tabcontent active terminal-box">
+					<textarea class="terminal" readonly></textarea>
+				</div>
+				<div class="tabcontent panel-properties">
+					<div class="content"></div>
+				</div>
+				<div class="tabcontent panel-add">
+					Loading...
+				</div>
+			</div>
+			<div class="schematic-tooltip"></div>
+		</div>
+	</div>
+</div>
+{{% /blocks/section %}}
+
+{{< blocks/section color="primary" type="row" >}}
 {{% blocks/feature icon="fa-lightbulb" title="TinyGo Playground" url="https://play.tinygo.org/" %}}
 Try TinyGo online
 {{% /blocks/feature %}}

--- a/netlify.toml
+++ b/netlify.toml
@@ -12,6 +12,13 @@
 [context.release.environment]
   HUGO_ENV = "production"
 
+# Required for the playground (it needs SharedArrayBuffer).
+[[headers]]
+  for = "/*"
+  [headers.values]
+    Cross-Origin-Opener-Policy = "same-origin"
+    Cross-Origin-Embedder-Policy = "require-corp"
+
 [[redirects]]
   from = "/bluetooth"
   to = "https://github.com/tinygo-org/bluetooth#go-bluetooth"

--- a/static/playground.js
+++ b/static/playground.js
@@ -1,0 +1,214 @@
+import { Simulator } from './playground/simulator.js';
+
+// Note: to test this locally, run the playground server!
+// Run the following in a terminal:
+//
+//    cd static/playground
+//    go run .
+//
+const PLAYGROUND_API = location.hostname == 'localhost' ? 'http://localhost:8080/api' : 'https://playground-bttoqog3vq-uc.a.run.app/api';
+
+// Initialize the playground embedded in the homepage.
+addEventListener('DOMContentLoaded', async () => {
+	let playground = document.querySelector('#playground');
+	let exampleSelect = playground.querySelector('.example_select');
+	let root = playground.querySelector('.simulator');
+	let textarea = playground.querySelector('textarea.input');
+	let firmwareButton = playground.querySelector('.playground-btn-flash');
+
+	// Load simulator.
+	let state = structuredClone(examples[exampleSelect.value]);
+	textarea.value = state.code;
+	let simulator = new Simulator({
+		root: root,
+		input: textarea,
+		firmwareButton: firmwareButton,
+		baseURL: new URL('/playground/', document.baseURI),
+		apiURL: PLAYGROUND_API,
+	});
+	await simulator.setState(state, state.target);
+
+	// Respond to changes in the example select box.
+	exampleSelect.disabled = false;
+	exampleSelect.addEventListener('change', async () => {
+		exampleSelect.disabled = true;
+		state = structuredClone(examples[exampleSelect.value]);
+		textarea.value = state.code;
+		await simulator.setState(state, state.target);
+		exampleSelect.disabled = false;
+	})
+});
+
+
+const exampleHello = `// You can edit this code!
+package main
+
+func main() {
+	println("hello world!")
+}`;
+
+const exampleBlink = `// You can edit this code!
+package main
+
+import (
+	"machine"
+	"time"
+)
+
+func main() {
+	led := machine.LED
+	led.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	for {
+		led.High()
+		time.Sleep(time.Second/2)
+
+		led.Low()
+		time.Sleep(time.Second/2)
+	}
+}`;
+
+const exampleST7789 = `package main
+
+import (
+	"machine"
+	"image/color"
+	"tinygo.org/x/drivers/st7789"
+)
+
+func main() {
+	// configure the display
+	machine.SPI0.Configure(machine.SPIConfig{
+		Frequency: 62_500_000, // 62.5MHz
+		Mode:      3,
+		SCK:       machine.SPI0_SCK_PIN,
+		SDI:       machine.SPI0_SDI_PIN,
+		SDO:       machine.SPI0_SDO_PIN,
+	})
+	display := st7789.New(machine.SPI0,
+		machine.TFT_RST,       // reset
+		machine.TFT_WRX,       // data/command
+		machine.TFT_CS,        // chip select
+		machine.TFT_BACKLIGHT) // backlight
+	display.Configure(st7789.Config{
+		Rotation: st7789.ROTATION_270,
+		Height:   320,
+	})
+
+	width, height := display.Size()
+
+	white := color.RGBA{255, 255, 255, 255}
+	red := color.RGBA{255, 0, 0, 255}
+	blue := color.RGBA{0, 0, 255, 255}
+	green := color.RGBA{0, 255, 0, 255}
+	black := color.RGBA{0, 0, 0, 255}
+
+	display.FillRectangle(0, 0, width/2, height/2, white)
+	display.FillRectangle(width/2, 0, width/2, height/2, red)
+	display.FillRectangle(0, height/2, width/2, height/2, green)
+	display.FillRectangle(width/2, height/2, width/2, height/2, blue)
+	display.FillRectangle(width/4, height/4, width/2, height/2, black)
+}`;
+
+const exampleLEDs = `package main
+
+import (
+	"image/color"
+	"machine"
+	"time"
+
+	"tinygo.org/x/drivers/ws2812"
+)
+
+func main() {
+	// Set up the ring of RGB LEDs.
+	pin := machine.WS2812
+	pin.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	ws := ws2812.New(pin)
+	leds := make([]color.RGBA, 10)
+
+	for cycle := uint8(0); ; cycle++ {
+		// Calculate a new color for each LED.
+		for i := range leds {
+			leds[i] = colorWheel(cycle*2 + uint8(i*8))
+		}
+
+		// Write colors to the LED ring.
+		ws.WriteColors(leds)
+
+		// Wait a bit each loop (running at around 30fps).
+		time.Sleep(time.Second / 30)
+	}
+}
+
+// Pick a color from the color wheel (red, then, green, then blue, and back to
+// red).
+func colorWheel(index uint8) color.RGBA {
+	index = 255-index
+	if index < 85 {
+		return color.RGBA{R: 255 - index*3, B: index * 3}
+	} else if index < 170 {
+		return color.RGBA{G: (index - 85) * 3, B: 255 - (index-85)*3}
+	} else {
+		return color.RGBA{R: (index - 170) * 3, G: 255 - (index-170)*3}
+	}
+}`;
+
+var examples = {
+	// Simple "hello world" example.
+	hello: {
+		target: 'console',
+		code: exampleHello,
+		parts: {
+			main: {
+				location: 'parts/console.json',
+				x: 0,
+				y: 0,
+			}
+		},
+		wires: [],
+	},
+
+	// Simple "blinky light" example.
+	// The Arduino Uno, despite its limitations, is very well known and many
+	// people have one. So it seems like a good testcase.
+	arduino: {
+		target: 'arduino',
+		code: exampleBlink,
+		parts: {
+			main: {
+				location: 'parts/arduino.json',
+				x: 0,
+				y: 0,
+			}
+		},
+		wires: [],
+	},
+
+	// Commonly used board, and a nice demo with LEDs.
+	circuitplay_express: {
+		target: 'circuitplay_express',
+		code: exampleLEDs,
+		parts: {
+			main: {
+				location: 'parts/circuitplay-express.json',
+				x: 0,
+				y: 0,
+			},
+		},
+		wires: [],
+	},
+
+	// Our own Gopher Badge, which importantly has a display!
+	gopher_badge: {
+		target: 'gopher_badge',
+		code: exampleST7789,
+		parts: {
+			main: {
+				location: 'parts/gopher-badge.json',
+				x: 0,
+				y: 0,
+			},
+		},
+		wires: [],
+	},
+};


### PR DESCRIPTION
This is the result of what I described previously on Mastodon: https://hachyderm.io/@ayke/112157503770449896

![Screenshot_20240325_182034](https://github.com/tinygo-org/tinygo-site/assets/729697/b8865b50-23a7-4072-94a1-5141f858db56)

Eventually I'd like to add the Gopher Badge as well so we can have an appropriate simulator, but I think the Arduino Uno and the BBC micro:bit are already nice to showcase in this way.

This will very likely put more strain on the Google Cloud Run app that compiles the source code. I'll have to monitor it to see whether it causes any issues.