### PR TITLE
Update to Docsy v0.9.1

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -50,8 +50,6 @@ breadcrumb_disable = false
 sidebar_search_disable = true
 #  Set to false if you don't want to display a logo (/assets/icons/logo.svg) in the top nav bar
 navbar_logo = true
-# Set to true to disable the About link in the site footer
-footer_about_disable = false
 # Set the maximum number of menus to be displayed in the sidebar
 sidebar_menu_truncate = 1000
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/tinygo-org/tinygo-site
 go 1.19
 
 require (
-	github.com/google/docsy v0.7.0 // indirect
+	github.com/google/docsy v0.9.1 // indirect
 	github.com/google/docsy/dependencies v0.7.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,6 @@
-github.com/FortAwesome/Font-Awesome v0.0.0-20230327165841-0698449d50f2/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
-github.com/google/docsy v0.7.0 h1:JaeZ0/KufX/BJ3SyATb/fmZa1DFI7o5d9KU+i6+lLJY=
-github.com/google/docsy v0.7.0/go.mod h1:5WhIFchr5BfH6agjcInhpLRz7U7map0bcmKSpcrg6BE=
+github.com/FortAwesome/Font-Awesome v0.0.0-20240108205627-a1232e345536/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
+github.com/google/docsy v0.9.1 h1:+jqges1YCd+yHeuZ1BUvD8V8mEGVtPxULg5j/vaJ984=
+github.com/google/docsy v0.9.1/go.mod h1:saOqKEUOn07Bc0orM/JdIF3VkOanHta9LU5Y53bwN2U=
 github.com/google/docsy/dependencies v0.7.0 h1:/xUlWCZOSMDubHfrhIz1YtaRn2Oc/swfJ7OUfglXE8U=
 github.com/google/docsy/dependencies v0.7.0/go.mod h1:gihhs5gmgeO+wuoay4FwOzob+jYJVyQbNaQOh788lD4=
 github.com/twbs/bootstrap v5.2.3+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=


### PR DESCRIPTION
I'm doing this to stay up to date, and because I'm looking forward to dark mode support in Docsy v0.10 (which according to https://github.com/google/docsy/issues/331 seems to be almost finished).

There are a few small visual changes, which I think are generally an improvement:

  - Buttons are more square.
  - Links now have underscores, for accessibility reasons.
  - The ellipsis after "Read more..." on the home page is gone.

I did a quick browse through the website and couldn't find any breaking changes.

Note that not all hugo versions seem to work. My Fedora-shipped version v0.111.3 resulted in errors, and the latest version also results in errors for me. However v0.122.0 works for me.