### PR TITLE
content: updated switch emulator recommendation since yuzu is no longer

### DIFF
--- a/content/docs/reference/microcontrollers/nintendoswitch.md
+++ b/content/docs/reference/microcontrollers/nintendoswitch.md
@@ -25,7 +25,7 @@ The [Nintendo Switch](https://en.wikipedia.org/wiki/Nintendo_Switch) is a handhe
 
 You will need the `linkle` (https://github.com/MegatonHammer/linkle) program to convert to the NRO format needed by the Switch:
 
-You can use a Nintendo Switch software emulator such as yuzu (https://yuzu-emu.org/) to test your programs.
+You can use a Nintendo Switch software emulator such as [suyu https://suyu.dev/](https://suyu.dev/) to test your programs.
 
 ## Building code
 


### PR DESCRIPTION
Since yuzu has been shutdown: https://www.polygon.com/24090351/nintendo-2-4-million-yuzu-switch-emulator-settlement-lawsuit and a fork is available, I thought an update to the recommended testing tool might be due.