### PR TITLE
fix: wireless and storage link ref pointing to correct part of documentation in embedded-resources

### DIFF
--- a/content/docs/guides/embedded/resources.md
+++ b/content/docs/guides/embedded/resources.md
@@ -11,9 +11,9 @@ Here are some of the "official" packages and resources in the TinyGo ecosystem t
 
 [I want to use a display connected to my device](#displays)
 
-[I want to make a wireless connection with my device](#sensors)
+[I want to make a wireless connection with my device](#wireless)
 
-[I want to store data on my device](#sensors)
+[I want to store data on my device](#data-storage)
 
 There are also other great resources in the community. You can find some of them in the "Awesome TinyGo" repository:
 


### PR DESCRIPTION
The reference to the wireless and the data storage section was pointing to the sensors sections. I took the liberty to fix it while reading through it.