### PR TITLE
Update to Docsy v0.10.0

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -50,10 +50,10 @@ breadcrumb_disable = false
 sidebar_search_disable = true
 #  Set to false if you don't want to display a logo (/assets/icons/logo.svg) in the top nav bar
 navbar_logo = true
-# Set to true to disable the About link in the site footer
-footer_about_disable = false
 # Set the maximum number of menus to be displayed in the sidebar
 sidebar_menu_truncate = 1000
+# Show a menu to the left of the search menu to toggle light/dark mode (or set it to auto).
+showLightDarkModeMenu = true
 
 [params.links]
 # End user relevant links. These will show up on left side of footer and in the community page if you have one.

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/tinygo-org/tinygo-site
 go 1.19
 
 require (
-	github.com/google/docsy v0.7.0 // indirect
+	github.com/google/docsy v0.10.0 // indirect
 	github.com/google/docsy/dependencies v0.7.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 github.com/FortAwesome/Font-Awesome v0.0.0-20230327165841-0698449d50f2/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
-github.com/google/docsy v0.7.0 h1:JaeZ0/KufX/BJ3SyATb/fmZa1DFI7o5d9KU+i6+lLJY=
-github.com/google/docsy v0.7.0/go.mod h1:5WhIFchr5BfH6agjcInhpLRz7U7map0bcmKSpcrg6BE=
+github.com/FortAwesome/Font-Awesome v0.0.0-20240402185447-c0f460dca7f7/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
+github.com/google/docsy v0.10.0 h1:6tMDacPwAyRWNCfvsn/9qGOZDQ8b0aRzjRZvnZPY5dg=
+github.com/google/docsy v0.10.0/go.mod h1:c0nIAqmRTOuJ01F85U/wJPQtc3Zj9N58Kea9bOT2AJc=
 github.com/google/docsy/dependencies v0.7.0 h1:/xUlWCZOSMDubHfrhIz1YtaRn2Oc/swfJ7OUfglXE8U=
 github.com/google/docsy/dependencies v0.7.0/go.mod h1:gihhs5gmgeO+wuoay4FwOzob+jYJVyQbNaQOh788lD4=
 github.com/twbs/bootstrap v5.2.3+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=
+github.com/twbs/bootstrap v5.3.3+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=

--- a/netlify.toml
+++ b/netlify.toml
@@ -6,7 +6,8 @@
 
 # "production" environment specific build settings
 [build.environment]
-  HUGO_VERSION = "0.111.3"
+  HUGO_VERSION = "0.125.4"
+  GO_VERSION = "1.22.x" # any reasonably recent version
 
 # "production" environment specific build settings
 [context.release.environment]


### PR DESCRIPTION
This adds support for light/dark mode, which I've waited for for a while. (I wish we could just make it automatic without menu entry, but this is already better than nothing).

There are a few small visual changes, which I think are generally an improvement:

  - Buttons are more square.
  - Links now have underscores, for accessibility reasons.
  - The ellipsis after "Read more..." on the home page is gone.
  - The copyright in the footer has changed slightly.

I did a quick browse through the website and couldn't find any breaking changes.