### PR TITLE
Integrated playground at tinygo.org/play

### DIFF
--- a/config/development/server.toml
+++ b/config/development/server.toml
@@ -1,0 +1,6 @@
+# Internal redirect for playground share URLs.
+[[redirects]]
+  force = false
+  from = "/play/s/*"
+  to = "/play/"
+  status = 200

--- a/content/_index.md
+++ b/content/_index.md
@@ -54,61 +54,7 @@ Ready to get started? [Click here](getting-started).
 			</div>
 		</div>
 		<div class="playground-editor mb-3" tabindex="-1"></div>
-		<div class="simulator">
-			<div class="schematic-buttons">
-				<button class="schematic-button-pause schematic-button" title="Pause/resume the simulation">
-					<!-- only one of these two images is visible at a time -->
-					<img src="playground/resources/codicon/debug-pause.svg" class="button-img-pause"/>
-					<img src="playground/resources/codicon/play.svg" class="button-img-play"/>
-				</button>
-			</div>
-			<svg class="schematic" tabindex="0">
-				<g class="schematic-wrapper" style="transform: translate(50%, 50%)">
-					<g class="schematic-parts"></g>
-					<g class="schematic-wires"></g>
-				</g>
-			</svg>
-			<div class="card-header">
-				<ul class="nav nav-tabs card-header-tabs" role="tablist">
-					<li class="nav-item" role="presentation">
-						<button class="nav-link active panel-tab-terminal" id="simulator-tab-terminal" data-bs-toggle="tab" data-bs-target="#simulator-panel-terminal" type="button" role="tab" aria-controls="simulator-panel-terminal" aria-selected="true">Terminal</button>
-					</li>
-					<li class="nav-item" role="presentation">
-						<button class="nav-link" id="simulator-properties-tab" data-bs-toggle="tab" data-bs-target="#simulator-panel-properties" type="button" role="tab" aria-controls="simulator-panel-properties" aria-selected="false">Properties</button>
-					</li>
-					<li class="nav-item" role="presentation">
-						<button class="nav-link" id="simulator-power-tab" data-bs-toggle="tab" data-bs-target="#simulator-panel-power" type="button" role="tab" aria-controls="simulator-panel-power" aria-selected="false">Power</button>
-					</li>
-					<li class="nav-item" role="presentation">
-						<button class="nav-link" id="simulator-add-tab" data-bs-toggle="tab" data-bs-target="#simulator-panel-add" type="button" role="tab" aria-controls="simulator-panel-add" aria-selected="false">Add</button>
-					</li>
-				</ul>
-			</div>
-			<div class="tab-content">
-				<div class="tab-pane active terminal-box" id="simulator-panel-terminal" role="tabpanel" aria-labelledby="simulator-tab-terminal">
-					<div class="terminal" tabindex="0"></div>
-				</div>
-				<div class="tab-pane panel-properties content" id="simulator-panel-properties" role="tabpanel" aria-labelledby="simulator-properties-tab">
-					<div class="content" tabindex="0"></div>
-				</div>
-				<div class="tab-pane panel-power content" id="simulator-panel-power" role="tabpanel" aria-labelledby="simulator-power-tab">
-					<div class="content" tabindex="0">
-						<div class="power-table">Loading...</div>
-						<p class="mb-0 mt-3"><strong>Note:</strong> these numbers are estimates, based on datasheets and measurements. They don't include everything and may be wrong.</p>
-					</div>
-				</div>
-				<div class="tab-pane" id="simulator-panel-add" role="tabpanel" aria-labelledby="simulator-add-tab" tabindex="0">
-					<div class="panel-add">
-						Loading...
-					</div>
-				</div>
-			</div>
-			<div class="schematic-tooltip"></div>
-			<div class="templates d-none">
-				<button class="panel-add-button btn btn-primary btn-sm">Add</button>
-				<select class="panel-add-select form-select form-select-sm"></select>
-			</div>
-		</div>
+		<div class="simulator">{{< readfile "/simulator/simulator.md" >}}</div>
 	</div>
 </div>
 {{% /blocks/section %}}

--- a/content/_index.md
+++ b/content/_index.md
@@ -31,7 +31,7 @@ Ready to get started? [Click here](getting-started).
 {{% blocks/section color="primary-light" %}}
 <link rel="stylesheet" href="playground/simulator.css">
 <link rel="stylesheet" href="playground/simulator-bootstrap.css">
-<script type="module" src="playground.js"></script>
+<script type="module" src="playground-home.js"></script>
 <link rel="modulepreload" href="/playground/resources/editor.bundle.min.js"/>
 <div class="col">
 	<div class="container" id="playground">

--- a/content/_index.md
+++ b/content/_index.md
@@ -60,7 +60,7 @@ Ready to get started? [Click here](getting-started).
 {{% /blocks/section %}}
 
 {{< blocks/section color="primary" type="row" >}}
-{{% blocks/feature icon="fa-lightbulb" title="TinyGo Playground" url="https://play.tinygo.org/" %}}
+{{% blocks/feature icon="fa-lightbulb" title="TinyGo Playground" url="/play/" %}}
 Try TinyGo online
 {{% /blocks/feature %}}
 

--- a/content/play/_index.md
+++ b/content/play/_index.md
@@ -1,0 +1,156 @@
+---
+title: Playground
+description: "TinyGo playground. Run Go code directly in the browser and simulate some popular development boards."
+---
+
+<link rel="stylesheet" href="/playground/simulator.css">
+<link rel="stylesheet" href="/playground/simulator-bootstrap.css">
+<script type="module" src="/playground-play.js"></script>
+<style>
+#playground {
+	margin-top: 1.5rem;
+	margin-bottom: 0.75rem;
+	display: flex;
+	flex-direction: column;
+}
+#playground-header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	flex-wrap: wrap;
+}
+#target .project-name .buttons {
+	margin-left: 16px;
+}
+.playground-editor {
+	min-height: 60vh;
+	flex: 1 0 0;
+	resize: none;
+}
+.playground-editor:not([style*="height"]) {
+	max-height: initial;
+}
+.playground-editor .cm-scroller {
+	flex: 1 0 0;
+}
+#middle {
+	display: flex;
+	flex-grow: 1;
+	flex-direction: column;
+	gap: 0.75rem;
+}
+#output {
+	flex: 1 0 0;
+}
+@media (min-width: 768px) {
+	#playground {
+		margin-top: 5rem;
+		/* 100% - header - padding bottom */
+		height: calc(100vh - 5rem - 0.75rem);
+	}
+	#middle {
+		flex-direction: row;
+	}
+	.playground-editor {
+		min-height: initial;
+	}
+}
+</style>
+<div id="playground">
+	<div id="playground-header">
+		<h2>Playground</h2>
+		<div>
+			<div id="target" class="btn-group mb-2">
+				<button type="button" class="btn btn-primary dropdown-toggle" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+				Console (TinyGo)
+				</button>
+				<div class="dropdown-menu">
+					<a class="dropdown-item active" href>Console (TinyGo)</a>
+					<span id="target-loading" class="dropdown-item disabled">Loading...</span>
+				</div>
+			</div>
+			<button type="button" id="btn-flash" class="btn btn-secondary mb-2" disabled>Flash</button>
+			<button type="button" id="btn-share" class="btn btn-secondary mb-2">Share</button>
+			<button type="button" id="btn-about" class="btn btn-secondary mb-2" data-bs-toggle="modal" data-bs-target="#aboutModal">About</button>
+			<a href="/tour/" class="btn btn-secondary mb-2">Tour</a>
+		</div>
+	</div>
+	<div id="middle">
+		<div class="playground-editor" tabindex="-1"></div>
+		<div id="output" class="simulator inline">{{< readfile "/simulator/simulator.md" >}}</div>
+	</div>
+	<div class="modal fade" id="aboutModal" tabindex="-1" aria-labelledby="aboutModalTitle" aria-hidden="true">
+		<div class="modal-dialog">
+			<div class="modal-content">
+				<div class="modal-header">
+					<h1 class="modal-title fs-5" id="exampleModalLabel">About TinyGo Playground</h1>
+					<button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+				</div>
+				<div class="modal-body">
+					<p>
+						The TinyGo Playground is a service provided by the TinyGo project
+						to compile and run small code samples directly in the browser. It
+						has been heavily inspired by the <a
+						href="https://play.golang.org/">Go Playground</a> but differs in
+						some significant ways:
+					</p>
+					<ul>
+						<li>
+							We use the <a href="https://github.com/tinygo-org/tinygo">TinyGo compiler</a> in addition to the main Go compiler.
+						</li>
+						<li>
+							Instead of running code on the server, code is compiled to <a
+							href="https://webassembly.org/">WebAssembly</a> and runs
+							directly in the browser.
+						</li>
+						<li>
+							It can simulate a few popular boards directly in the browser.
+							However, please note that this is a simulation which can differ
+							in behavior from how the program will run on an actual device.
+						</li>
+						<li>
+							Boards that support drag-and-drop programming can be flashed
+							directly using the Flash button.
+						</li>
+					</ul>
+					<p>
+						Like the Go Playground, it's possible to share code
+						snippets. These code snippets are stored on Google's
+						servers in the US and can be viewed by some TinyGo
+						members. While we'll try to make sure the shared data
+						can only be accessed by those who have the URL, we
+						cannot guarantee security. If you accidentally shared
+						something that should not be shared (for example, a
+						password or personally identifying information), you can
+						contact us at
+						<a href="mailto:privacy@tinygo.org">privacy@tinygo.org</a>
+						with the URL so we can remove it.
+					</p>
+					<p>
+						Source code of the playground: <a
+						href="https://github.com/tinygo-org/playground">github.com/tinygo-org/playground</a>.
+					</p>
+				</div>
+				<div class="modal-footer">
+					<button type="button" class="btn btn-primary" data-bs-dismiss="modal">Close</button>
+				</div>
+			</div>
+		</div>
+	</div>
+	<div class="modal modal-lg fade" id="shareModal" tabindex="-1" aria-labelledby="shareModalLabel" aria-hidden="true">
+		<div class="modal-dialog">
+			<div class="modal-content">
+				<div class="modal-header">
+					<h1 class="modal-title fs-5" id="shareModalLabel">Share</h1>
+					<button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+				</div>
+				<div class="modal-body">
+					<div class="input-group">
+						<input type="text" class="form-control user-select-all" placeholder="Loading..." readonly/>
+						<button class="btn btn-outline-secondary copy-to-clipboard" type="button" data-bs-toggle="tooltip" data-bs-title="Copy to clipboard" data-bs-placement="bottom" disabled><span class="fa fa-clipboard"></span></button>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>

--- a/content/simulator/simulator.md
+++ b/content/simulator/simulator.md
@@ -1,0 +1,53 @@
+<div class="schematic-buttons">
+	<button class="schematic-button-pause schematic-button" title="Pause/resume the simulation">
+		<!-- only one of these two images is visible at a time -->
+		<img src="/playground/resources/codicon/debug-pause.svg" class="button-img-pause"/>
+		<img src="/playground/resources/codicon/play.svg" class="button-img-play"/>
+	</button>
+</div>
+<svg class="schematic" tabindex="0">
+	<g class="schematic-wrapper" style="transform: translate(50%, 50%)">
+		<g class="schematic-parts"></g>
+		<g class="schematic-wires"></g>
+	</g>
+</svg>
+<div class="card-header">
+	<ul class="nav nav-tabs card-header-tabs" role="tablist">
+		<li class="nav-item" role="presentation">
+			<button class="nav-link active panel-tab-terminal" id="simulator-tab-terminal" data-bs-toggle="tab" data-bs-target="#simulator-panel-terminal" type="button" role="tab" aria-controls="simulator-panel-terminal" aria-selected="true">Terminal</button>
+		</li>
+		<li class="nav-item" role="presentation">
+			<button class="nav-link" id="simulator-properties-tab" data-bs-toggle="tab" data-bs-target="#simulator-panel-properties" type="button" role="tab" aria-controls="simulator-panel-properties" aria-selected="false">Properties</button>
+		</li>
+		<li class="nav-item" role="presentation">
+			<button class="nav-link" id="simulator-power-tab" data-bs-toggle="tab" data-bs-target="#simulator-panel-power" type="button" role="tab" aria-controls="simulator-panel-power" aria-selected="false">Power</button>
+		</li>
+		<li class="nav-item" role="presentation">
+			<button class="nav-link" id="simulator-add-tab" data-bs-toggle="tab" data-bs-target="#simulator-panel-add" type="button" role="tab" aria-controls="simulator-panel-add" aria-selected="false">Add</button>
+		</li>
+	</ul>
+</div>
+<div class="tab-content">
+	<div class="tab-pane active terminal-box" id="simulator-panel-terminal" role="tabpanel" aria-labelledby="simulator-tab-terminal">
+		<div class="terminal" tabindex="0"></div>
+	</div>
+	<div class="tab-pane panel-properties content" id="simulator-panel-properties" role="tabpanel" aria-labelledby="simulator-properties-tab">
+		<div class="content" tabindex="0"></div>
+	</div>
+	<div class="tab-pane panel-power content" id="simulator-panel-power" role="tabpanel" aria-labelledby="simulator-power-tab">
+		<div class="content" tabindex="0">
+			<div class="power-table">Loading...</div>
+			<p class="mb-0 mt-3"><strong>Note:</strong> these numbers are estimates, based on datasheets and measurements. They don't include everything and may be wrong.</p>
+		</div>
+	</div>
+	<div class="tab-pane" id="simulator-panel-add" role="tabpanel" aria-labelledby="simulator-add-tab" tabindex="0">
+		<div class="panel-add">
+			Loading...
+		</div>
+	</div>
+</div>
+<div class="schematic-tooltip"></div>
+<div class="templates d-none">
+	<button class="panel-add-button btn btn-primary btn-sm">Add</button>
+	<select class="panel-add-select form-select form-select-sm"></select>
+</div>

--- a/layouts/tour/baseof.html
+++ b/layouts/tour/baseof.html
@@ -42,59 +42,7 @@
                   </div>
                 </div>
                 <div class="simulator mb-3">
-                  <div class="schematic-buttons">
-                    <button class="schematic-button-pause schematic-button" title="Pause/resume the simulation">
-                      <!-- only one of these two images is visible at a time -->
-                      <img src="/playground/resources/codicon/debug-pause.svg" class="button-img-pause"/>
-                      <img src="/playground/resources/codicon/play.svg" class="button-img-play"/>
-                    </button>
-                  </div>
-                  <svg class="schematic" tabindex="0">
-                    <g class="schematic-wrapper" style="transform: translate(50%, 50%)">
-                      <g class="schematic-parts"></g>
-                      <g class="schematic-wires"></g>
-                    </g>
-                  </svg>
-                  <div class="card-header">
-                    <ul class="nav nav-tabs card-header-tabs" role="tablist">
-                      <li class="nav-item" role="presentation">
-                        <button class="nav-link active panel-tab-terminal" id="simulator-tab-terminal" data-bs-toggle="tab" data-bs-target="#simulator-panel-terminal" type="button" role="tab" aria-controls="simulator-panel-terminal" aria-selected="true">Terminal</button>
-                      </li>
-                      <li class="nav-item" role="presentation">
-                        <button class="nav-link" id="simulator-properties-tab" data-bs-toggle="tab" data-bs-target="#simulator-panel-properties" type="button" role="tab" aria-controls="simulator-panel-properties" aria-selected="false">Properties</button>
-                      </li>
-                      <li class="nav-item" role="presentation">
-                        <button class="nav-link" id="simulator-power-tab" data-bs-toggle="tab" data-bs-target="#simulator-panel-power" type="button" role="tab" aria-controls="simulator-panel-power" aria-selected="false">Power</button>
-                      </li>
-                      <li class="nav-item" role="presentation">
-                        <button class="nav-link" id="simulator-add-tab" data-bs-toggle="tab" data-bs-target="#simulator-panel-add" type="button" role="tab" aria-controls="simulator-panel-add" aria-selected="false">Add</button>
-                      </li>
-                    </ul>
-                  </div>
-                  <div class="tab-content">
-                    <div class="tab-pane active terminal-box" id="simulator-panel-terminal" role="tabpanel" aria-labelledby="simulator-tab-terminal">
-                      <div class="terminal" tabindex="0"></div>
-                    </div>
-                    <div class="tab-pane panel-properties content" id="simulator-panel-properties" role="tabpanel" aria-labelledby="simulator-properties-tab">
-                      <div class="content" tabindex="0"></div>
-                    </div>
-                    <div class="tab-pane panel-power content" id="simulator-panel-power" role="tabpanel" aria-labelledby="simulator-power-tab">
-                      <div class="content" tabindex="0">
-                        <div class="power-table">Loading...</div>
-                        <p class="mb-0 mt-3"><strong>Note:</strong> these numbers are estimates, based on datasheets and measurements. They don't include everything and may be wrong.</p>
-                      </div>
-                    </div>
-                    <div class="tab-pane" id="simulator-panel-add" role="tabpanel" aria-labelledby="simulator-add-tab" tabindex="0">
-                      <div class="panel-add">
-                        Loading...
-                      </div>
-                    </div>
-                  </div>
-                  <div class="schematic-tooltip"></div>
-                  <div class="templates d-none">
-                    <button class="panel-add-button btn btn-primary btn-sm">Add</button>
-                    <select class="panel-add-select form-select form-select-sm"></select>
-                  </div>
+                  {{ readFile "/simulator/simulator.md" | safeHTML }}
                 </div>
               </div>
             </div>

--- a/netlify.toml
+++ b/netlify.toml
@@ -21,6 +21,13 @@
     Cross-Origin-Opener-Policy = "same-origin"
     Cross-Origin-Embedder-Policy = "require-corp"
 
+# Internal redirect for playground share URLs.
+[[redirects]]
+  force = false
+  from = "/play/s/*"
+  to = "/play/"
+  status = 200
+
 [[redirects]]
   from = "/bluetooth"
   to = "https://github.com/tinygo-org/bluetooth#go-bluetooth"

--- a/static/playground-home.js
+++ b/static/playground-home.js
@@ -1,6 +1,8 @@
 import { Simulator } from './playground/simulator.js';
 import { Editor } from './playground/resources/editor.bundle.min.js';
 
+// This file is for the playground on the home page.
+
 // Note: to test this locally, run the playground server!
 // Run the following in a terminal:
 //

--- a/static/playground-play.js
+++ b/static/playground-play.js
@@ -1,0 +1,221 @@
+import { Simulator } from './playground/simulator.js';
+import { Editor } from './playground/resources/editor.bundle.min.js';
+import { boards } from './playground/boards.js';
+
+// This file is for the playground at the /play URL.
+
+const PLAYGROUND_API = location.hostname == 'localhost' ? 'http://localhost:8080/api' : 'https://playground-bttoqog3vq-uc.a.run.app/api';
+
+const defaultBoardName = 'console';
+
+let simulator = null;
+let editor = null;
+
+// Regexp for a URL like /s/abcdef
+let shareURLRegexp = RegExp('/s/([a-zA-Z0-9]*)$');
+
+// updateBoards updates the dropdown menu. This must be done on load or after
+// selecting a different board.
+function updateBoards(state) {
+  // Try to figure out the board name based on the saved state.
+  let activeName = '';
+  if (state) {
+    let matches = RegExp('parts/([a-z0-9-]+).json$').exec(state.parts.main.location);
+    if (matches) {
+      activeName = matches[1];
+      if (activeName === 'console' && state.compiler === 'go') {
+        activeName = 'console-go';
+      }
+    }
+    let button = document.querySelector('#target > button');
+    if (activeName in boards) {
+      button.textContent = boards[activeName].humanName;
+    } else {
+      // For some reason we couldn't find the board (should only happen with a
+      // malformed editor state).
+      button.textContent = '...';
+    }
+  }
+
+  // Replace the dropdown with a new dropdown.
+  let dropdown = document.querySelector('#target > .dropdown-menu');
+  dropdown.innerHTML = '';
+  for (let name in boards) {
+    let item = document.createElement('a');
+    item.textContent = boards[name].humanName;
+    item.classList.add('dropdown-item');
+    if (name === activeName) {
+      item.classList.add('active');
+    }
+    item.setAttribute('href', '');
+    item.dataset.name = name;
+    dropdown.appendChild(item);
+    item.addEventListener('click', (e) => {
+      e.preventDefault();
+      clearShareURL();
+      setBoard(item.dataset.name);
+    });
+  }
+}
+
+// setBoard reloads the editor and simulator to use the given board.
+async function setBoard(name) {
+  // Create a new clean state object for this board.
+  let board = boards[name];
+  let state = {
+    code: board.code,
+    compiler: board.compiler,
+    parts: {
+      main: {
+        location: board.location,
+        x: 0,
+        y: 0,
+      },
+    },
+    wires: [],
+  };
+
+  // Update the editor/simulator.
+  await setState(state);
+
+  // Load the same board after a reload.
+  localStorage.tinygo_playground_boardName = name;
+  delete localStorage.tinygo_playground_state;
+}
+
+// Reset the editor and simulator to use the given state.
+async function setState(state) {
+  updateBoards(state);
+  editor.setText(state.code);
+
+  // Change to the new project state.
+  await simulator.setState(state);
+}
+
+// Load the editor state on page load.
+async function loadSavedState() {
+  // Check whether this is a share URL, and if so load the editor state from the
+  // API.
+  let matches = shareURLRegexp.exec(document.location.pathname);
+  if (matches) {
+    let id = matches[1];
+    let response = await fetch(`${PLAYGROUND_API}/share?id=${id}`);
+    if (response.status != 200) {
+      // Can't load the shared code.
+      // Users can still select a different sample from the dropdown. This is
+      // not very obvious, so might need a more explicit message.
+      simulator.terminal.appendError(`failed to fetch shared code: ${response.status} ${response.statusText}`);
+      return;
+    }
+    let state = await response.json();
+    setState(state.data);
+    return;
+  }
+
+  // Check whether the editor saved a previous state.
+  if (localStorage.tinygo_playground_state) {
+    setState(JSON.parse(localStorage.tinygo_playground_state));
+    return;
+  }
+
+  // Load the default board.
+  let board = localStorage.tinygo_playground_boardName;
+  if (!(board in boards)) {
+    board = defaultBoardName;
+  }
+  setBoard(board);
+}
+
+// Remove the /s/foobar suffix of the URL, and replace it with a bare /play/ URL
+// instead.
+function clearShareURL() {
+  let parts = shareURLRegexp.exec(document.location.pathname);
+  if (parts) {
+    let pathname = document.location.pathname;
+    pathname = pathname.substring(0, pathname.length-parts[0].length+1);
+    history.replaceState({}, '', pathname);
+  }
+}
+
+function setupShareButton() {
+  let modalElement = document.querySelector('#shareModal');
+  let input = modalElement.querySelector('input');
+  let button = modalElement.querySelector('button.copy-to-clipboard');
+
+  let copiedTooltip = new bootstrap.Tooltip(input, {
+    title: 'Copied to clipboard!',
+    trigger: 'manual',
+    placement: 'bottom',
+  });
+
+  let buttonTooltip = bootstrap.Tooltip.getOrCreateInstance(button);
+
+  document.querySelector('#btn-share').addEventListener('click', async e => {
+    e.preventDefault();
+
+    // Share modal with 'loading...' input.
+    input.value = '';
+    button.disabled = true;
+    let modal = new bootstrap.Modal(modalElement, {});
+    modal.show();
+
+    // Save the current code snippet.
+    let id = await simulator.share();
+
+    // Update the modal and URL.
+    let url;
+    if (shareURLRegexp.test(document.location.pathname)) {
+      url = new URL(id, document.location.href);
+    } else {
+      url = new URL('s/' + id, document.location.href);
+    }
+    history.replaceState({}, '', url);
+    input.value = url;
+    button.disabled = false;
+  });
+
+  button.addEventListener('click', e => {
+    e.preventDefault();
+    navigator.clipboard.writeText(input.value);
+    input.focus();
+
+    // Hide the 'Copy to clipboard' tooltip on the button.
+    buttonTooltip.hide();
+
+    // Show a new tooltip on the input element.
+    copiedTooltip.show();
+    setTimeout(() => {
+      copiedTooltip.hide();
+    }, 1500);
+  });
+
+  input.addEventListener('focus', e => {
+    input.select();
+  })
+}
+
+// Initialize the playground.
+document.addEventListener('DOMContentLoaded', async function(e) {
+  editor = new Editor(document.querySelector('.playground-editor'));
+
+  simulator = new Simulator({
+    root: document.querySelector('#output'),
+    editor: editor,
+    firmwareButton: document.querySelector('#btn-flash'),
+    baseURL: new URL('/playground/', document.baseURI),
+    apiURL: PLAYGROUND_API,
+    saveState: () => {
+      // Strip /s/* URL suffix.
+      clearShareURL();
+      localStorage.tinygo_playground_state = JSON.stringify(simulator.schematic.state);
+    },
+  });
+
+  setupShareButton();
+
+  // Update the drop down list of boards.
+  updateBoards();
+
+  // Now see which editor state we should load (depending on various things).
+  loadSavedState();
+})


### PR DESCRIPTION
Instead of having a separate https://play.tinygo.org, use https://tinygo.org/play that actually integrates into the Docsy theme.

Once this is in, I'd like to make play.tinygo.org just a redirect to tinygo.org/play so that I can modify the default UI.