### PR TITLE
Fix light/dark mode syntax highlighting

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -1,0 +1,1 @@
+@import 'td/code-dark'

--- a/config.toml
+++ b/config.toml
@@ -19,6 +19,9 @@ resampleFilter = "CatmullRom"
 quality = 75
 anchor = "smart"
 
+[markup.highlight]
+noClasses = false
+
 [markup.goldmark.renderer]
 unsafe = true
 


### PR DESCRIPTION
See: https://www.docsy.dev/docs/adding-content/lookandfeel/#lightdark-color-themes

Previously the code would effectively be in dark mode, no matter whether the website was light or dark mode. This led to situations like here, which I don't think looks very good:

![Screenshot_20240702_183242](https://github.com/tinygo-org/tinygo-site/assets/729697/45f7cac9-d933-46cd-9114-f02070bd2412)

After this change, the syntax highlighting theme changes with the website theme:

![Screenshot_20240702_183442](https://github.com/tinygo-org/tinygo-site/assets/729697/583ee9d9-2ce8-45c3-8735-877d04852843)
![Screenshot_20240702_183458](https://github.com/tinygo-org/tinygo-site/assets/729697/480e57f3-f767-48f1-9ed4-d25c0c07d40a)
