### PR TITLE
Syntax highlighting on the playground

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -1,1 +1,5 @@
-@import 'td/code-dark'
+@import 'td/code-dark';
+
+code {
+    tab-size: 4;
+}

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -3,3 +3,38 @@
 code {
     tab-size: 4;
 }
+
+.playground-editor {
+    /* make the editor scrollable */
+    overflow: auto;
+}
+.playground-editor:not([style*="height"]) {
+    /* set a default max-height of 20 lines that is resizable (resizing will set
+     * style="height: ..." which invalidates this style) */
+    max-height: calc(20em * var(--bs-body-line-height) + .375rem * 2);
+}
+
+/* Match the appearance of a Bootstrap <textarea>, including the focused state
+ * (for accessibility). */
+.playground-editor {
+    border: solid 1px var(--bs-border-color);
+    border-radius: var(--bs-border-radius);
+    box-shadow: var(--bs-box-shadow-inset);
+    transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+    resize: vertical;
+}
+.playground-editor > .cm-editor {
+    background-color: var(--bs-body-bg);
+    outline: initial;
+    height: 100%;
+}
+.playground-editor .cm-content {
+    padding: .375rem 0; /* match Bootstrap in vertical padding */
+}
+.playground-editor .cm-scroller {
+    line-height: var(--bs-body-line-height); /* match Bootstrap */
+}
+.playground-editor:has( > .cm-focused) {
+    box-shadow: var(--bs-box-shadow-inset), 0 0 0 0.25rem rgba(4, 110, 143, 0.25);
+    border-color: #82b7c7;
+}

--- a/content/_index.md
+++ b/content/_index.md
@@ -31,6 +31,7 @@ Ready to get started? [Click here](getting-started).
 {{% blocks/section color="primary-light" %}}
 <link rel="stylesheet" href="playground/simulator.css">
 <script type="module" src="playground.js"></script>
+<link rel="modulepreload" href="/playground/resources/editor.bundle.min.js"/>
 <div class="col">
 	<div class="container" id="playground">
 		<h1 class="text-center">Try TinyGo</h1>
@@ -47,11 +48,11 @@ Ready to get started? [Click here](getting-started).
 				</div>
 			</div>
 			<div class="col col-auto">
-				<button class="btn btn-secondary playground-btn-flash" disabled>Download binary</button>
-				<a href="/tour/" class="btn btn-link">Tour of TinyGo</a>
+				<button class="btn btn-secondary playground-btn-flash mb-3" disabled>Download binary</button>
+				<a href="/tour/" class="btn btn-link mb-3">Tour of TinyGo</a>
 			</div>
 		</div>
-		<textarea placeholder="Loading..." class="form-control input" rows="20" style="font-family: monospace; tab-size: 4" spellcheck="false"></textarea>
+		<div class="playground-editor mb-3" tabindex="-1"></div>
 		<div class="simulator inline">
 			<div class="schematic-buttons">
 				<button class="schematic-button-pause schematic-button" title="Pause/resume the simulation">

--- a/layouts/tour/baseof.html
+++ b/layouts/tour/baseof.html
@@ -6,6 +6,7 @@
   <head>
     {{ partial "head.html" . }}
     <link rel="stylesheet" href="/playground/simulator.css">
+    <link rel="modulepreload" href="/playground/resources/editor.bundle.min.js"/>
   </head>
   <body class="td-{{ .Kind }}{{ with .Page.Params.body_class }} {{ . }}{{ end }}">
     <header>
@@ -26,7 +27,7 @@
               </div>
               <div class="col-12 col-xl-6">
                 <div class="mb-3">
-                  <textarea placeholder="Loading..." class="form-control input" rows="20" style="font-family: monospace; tab-size: 4" spellcheck="false">{{ block "code" .}}{{ end }}</textarea>
+                  <div class="playground-editor" tabindex="-1"></div>
                 </div>
                 <div class="row justify-content-end">
                   <div class="col col-auto">

--- a/static/playground.js
+++ b/static/playground.js
@@ -1,4 +1,5 @@
 import { Simulator } from './playground/simulator.js';
+import { Editor } from './playground/resources/editor.bundle.min.js';
 
 // Note: to test this locally, run the playground server!
 // Run the following in a terminal:
@@ -13,15 +14,17 @@ addEventListener('DOMContentLoaded', async () => {
 	let playground = document.querySelector('#playground');
 	let exampleSelect = playground.querySelector('.example_select');
 	let root = playground.querySelector('.simulator');
-	let textarea = playground.querySelector('textarea.input');
 	let firmwareButton = playground.querySelector('.playground-btn-flash');
+
+	// Load editor.
+	let editor = new Editor(playground.querySelector('.playground-editor'));
 
 	// Load simulator.
 	let state = structuredClone(examples[exampleSelect.value]);
-	textarea.value = state.code;
+	editor.setText(state.code);
 	let simulator = new Simulator({
 		root: root,
-		input: textarea,
+		editor: editor,
 		firmwareButton: firmwareButton,
 		baseURL: new URL('/playground/', document.baseURI),
 		apiURL: PLAYGROUND_API,
@@ -34,7 +37,7 @@ addEventListener('DOMContentLoaded', async () => {
 	exampleSelect.addEventListener('change', async () => {
 		exampleSelect.disabled = true;
 		state = structuredClone(examples[exampleSelect.value]);
-		textarea.value = state.code;
+		editor.setText(state.code);
 		await simulator.setState(state, state.target);
 		exampleSelect.disabled = false;
 	})

--- a/static/tour.js
+++ b/static/tour.js
@@ -1,4 +1,5 @@
 import { Simulator } from './playground/simulator.js';
+import { Editor } from '/playground/resources/editor.bundle.min.js';
 
 export { setupTour };
 
@@ -76,7 +77,7 @@ async function setupTour(config) {
 	}
 
 	let root = document.querySelector('.simulator');
-	let textarea = document.querySelector('textarea.input');
+	let editor = new Editor(document.querySelector('.playground-editor'));
 	let firmwareButton = document.querySelector('.playground-btn-flash');
 	let resetButton = document.querySelector('.playground-btn-reset');
 
@@ -108,7 +109,7 @@ async function setupTour(config) {
 			boardButton.textContent = boardName;
 			currentBoard = board;
 			state = createState(currentBoard);
-			textarea.value = state.code;
+			editor.setText(state.code);
 			await simulator.setState(state, currentBoard);
 		})
 		boardMenu.appendChild(a);
@@ -116,10 +117,10 @@ async function setupTour(config) {
 
 	// Load simulator.
 	let state = createState(currentBoard);
-	textarea.value = state.code;
+	editor.setText(state.code);
 	let simulator = new Simulator({
 		root: root,
-		input: textarea,
+		editor: editor,
 		features: [],
 		firmwareButton: firmwareButton,
 		baseURL: new URL('/playground/', document.baseURI),
@@ -131,7 +132,7 @@ async function setupTour(config) {
 	resetButton.addEventListener('click', async e => {
 		resetButton.disabled = true;
 		state = createState(currentBoard);
-		textarea.value = state.code;
+		editor.setText(state.code);
 		await simulator.setState(state, currentBoard);
 		resetButton.disabled = false;
 	});


### PR DESCRIPTION
This adds syntax highlighting to the playground on the homepage and in the tour.

I picked highlighting themes that match the code samples on the website as much as possible, although it's not a perfect match. CodeMirror includes a oneDark theme (same as on the website) for dark mode so that's great, but for light mode I actually created a new CodeMirror theme for the tango theme that is used by default by Docsy.

I have tried to keep the appearance and accessibility properties of the textarea the same as much as possible. I think the outcome is pretty neat: it looks just like any other Bootstrap input but with numbered lines and syntax highlighting.

~Eventually I'd like to add a feature to show compiler error messages where they happen. Or at least to highlight the lines with errors. But that's for another time.~ implemented

One major reason for choosing CodeMirror 6 is that it works well on mobile, while most of these web code editors don't.

I've also fixed an issue I introduced in #411: the tab size is now back to 4 spaces instead of 8.