### PR TITLE
Fix: typo install linux doc arm64

### DIFF
--- a/content/getting-started/install/linux.md
+++ b/content/getting-started/install/linux.md
@@ -37,8 +37,8 @@ sudo dpkg -i tinygo_0.32.0_amd64.deb
 If you are on a Raspberry Pi or other ARM-based Linux computer, you should use this command instead:
 
 ```shell
-wget https://github.com/tinygo-org/tinygo/releases/download/v0.32.0/tinygo_0.32.0_armhf.deb
-sudo dpkg -i tinygo_0.32.0_armhf.deb
+wget https://github.com/tinygo-org/tinygo/releases/download/v0.32.0/tinygo_0.32.0_arm64.deb
+sudo dpkg -i tinygo_0.32.0_arm64.deb
 ```
 
 You will need to ensure that the path to the `tinygo` executable file is in your `PATH` variable.
@@ -57,7 +57,7 @@ tinygo version 0.32.0 linux/amd64 (using go version go1.22 and LLVM version 18.1
 If you are on a 64 bit ARM OS, and running tinygo fails with "no such file or directory", you may need to install the 32 bit C++ runtime library, e.g.:
 
 ```shell
-sudo apt install libstdc++6:armhf
+sudo apt install libstdc++6:arm64
 ```
 
 If you are only interested in compiling TinyGo code for WebAssembly then you are now done with the installation.


### PR DESCRIPTION
I think armhf is arm64.
I changed it to arm64 and confirmed that wget works correctly.

```shell
wget https://github.com/tinygo-org/tinygo/releases/download/v0.32.0/tinygo_0.32.0_armhf.deb                                                                                   
https://github.com/tinygo-org/tinygo/releases/download/v0.32.0/tinygo_0.32.0_armhf.deb                                                                                                                                     
Resolving github.com (github.com)... 20.27.177.113                                                                                                                                                                                                  
Connecting to github.com (github.com)|20.27.177.113|:443... connected.                                                                                                                                                                              
HTTP request sent, awaiting response... 404 Not Found
ERROR 404: Not Found.
```

```shell
wget https://github.com/tinygo-org/tinygo/releases/download/v0.32.0/tinygo_0.32.0_arm64.deb
tinygo_0.32.0_arm64.deb                            100%[================================================================================================================>] 133.66M  10.9MB/s
```