### PR TITLE
content: correct edit links for site github repo

### DIFF
--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -5,6 +5,12 @@ weight: 20
 menu:
   main:
     weight: 20
+
+cascade:
+  github_repo: https://github.com/tinygo-org/tinygo-site
+  github_subdir: content/docs
+  path_base_for_github_subdir: content/docs
+  github_branch: dev
 ---
 
 The TinyGo documentation is organized into specific sections to help you locate the information that you need.

--- a/content/getting-started/_index.md
+++ b/content/getting-started/_index.md
@@ -6,10 +6,12 @@ weight: 5
 menu:
   main:
     weight: 5
+
+cascade:
+  github_repo: https://github.com/tinygo-org/tinygo-site
+  github_subdir: content/getting-started
+  path_base_for_github_subdir: content/getting-started
+  github_branch: dev
 ---
 
 New to TinyGo? This is the place to get started.
-
-<iframe width="420" height="315"
-src="https://www.youtube.com/embed/Fl5eFIYU1Xg">
-</iframe>

--- a/content/media/_index.md
+++ b/content/media/_index.md
@@ -7,4 +7,10 @@ menu:
     weight: 40
 description: >
   Here are some of the videos, podcasts, and blog posts written about TinyGo.
+
+cascade:
+  github_repo: https://github.com/tinygo-org/tinygo-site
+  github_subdir: content/media
+  path_base_for_github_subdir: content/media
+  github_branch: dev
 ---

--- a/content/tour/_index.md
+++ b/content/tour/_index.md
@@ -1,6 +1,12 @@
 ---
 title: "Tour of TinyGo"
 type: "docs"
+
+cascade:
+  github_repo: https://github.com/tinygo-org/tinygo-site
+  github_subdir: content/tour
+  path_base_for_github_subdir: content/tour
+  github_branch: dev
 ---
 
 Welcome to the tour of TinyGo!


### PR DESCRIPTION
Corrects https://github.com/tinygo-org/tinygo-site/issues/414 by setting the repository links per section. See https://www.docsy.dev/docs/adding-content/repository-links/