### PR TITLE
playground: style simulator like a Bootstrap card

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -30,6 +30,7 @@ Ready to get started? [Click here](getting-started).
 
 {{% blocks/section color="primary-light" %}}
 <link rel="stylesheet" href="playground/simulator.css">
+<link rel="stylesheet" href="playground/simulator-bootstrap.css">
 <script type="module" src="playground.js"></script>
 <link rel="modulepreload" href="/playground/resources/editor.bundle.min.js"/>
 <div class="col">
@@ -53,7 +54,7 @@ Ready to get started? [Click here](getting-started).
 			</div>
 		</div>
 		<div class="playground-editor mb-3" tabindex="-1"></div>
-		<div class="simulator inline">
+		<div class="simulator">
 			<div class="schematic-buttons">
 				<button class="schematic-button-pause schematic-button" title="Pause/resume the simulation">
 					<!-- only one of these two images is visible at a time -->
@@ -61,29 +62,43 @@ Ready to get started? [Click here](getting-started).
 					<img src="playground/resources/codicon/play.svg" class="button-img-play"/>
 				</button>
 			</div>
-			<svg class="schematic">
+			<svg class="schematic" tabindex="0">
 				<g class="schematic-wrapper" style="transform: translate(50%, 50%)">
 					<g class="schematic-parts"></g>
 					<g class="schematic-wires"></g>
 				</g>
 			</svg>
-			<div class="panels">
-				<div class="tabbar">
-					<span class="tab active panel-tab-terminal"><a>Terminal</a></span>
-					<span class="tab"><a>Properties</a></span>
-					<span class="tab"><a>Add</a></span>
+			<div class="card-header">
+				<ul class="nav nav-tabs card-header-tabs" role="tablist">
+					<li class="nav-item" role="presentation">
+						<button class="nav-link active panel-tab-terminal" id="simulator-tab-terminal" data-bs-toggle="tab" data-bs-target="#simulator-panel-terminal" type="button" role="tab" aria-controls="simulator-panel-terminal" aria-selected="true">Terminal</button>
+					</li>
+					<li class="nav-item" role="presentation">
+						<button class="nav-link" id="simulator-properties-tab" data-bs-toggle="tab" data-bs-target="#simulator-panel-properties" type="button" role="tab" aria-controls="simulator-panel-properties" aria-selected="false">Properties</button>
+					</li>
+					<li class="nav-item" role="presentation">
+						<button class="nav-link" id="simulator-add-tab" data-bs-toggle="tab" data-bs-target="#simulator-panel-add" type="button" role="tab" aria-controls="simulator-panel-add" aria-selected="false">Add</button>
+					</li>
+				</ul>
+			</div>
+			<div class="tab-content">
+				<div class="tab-pane active terminal-box" id="simulator-panel-terminal" role="tabpanel" aria-labelledby="simulator-tab-terminal">
+					<textarea class="terminal" readonly tabindex="0"></textarea>
 				</div>
-				<div class="tabcontent active terminal-box">
-					<textarea class="terminal" readonly></textarea>
+				<div class="tab-pane panel-properties content" id="simulator-panel-properties" role="tabpanel" aria-labelledby="simulator-properties-tab">
+					<div class="content" tabindex="0"></div>
 				</div>
-				<div class="tabcontent panel-properties">
-					<div class="content"></div>
-				</div>
-				<div class="tabcontent panel-add">
-					Loading...
+				<div class="tab-pane" id="simulator-panel-add" role="tabpanel" aria-labelledby="simulator-add-tab" tabindex="0">
+					<div class="panel-add">
+						Loading...
+					</div>
 				</div>
 			</div>
 			<div class="schematic-tooltip"></div>
+			<div class="templates d-none">
+				<button class="panel-add-button btn btn-primary btn-sm">Add</button>
+				<select class="panel-add-select form-select form-select-sm"></select>
+			</div>
 		</div>
 	</div>
 </div>

--- a/layouts/tour/baseof.html
+++ b/layouts/tour/baseof.html
@@ -6,6 +6,7 @@
   <head>
     {{ partial "head.html" . }}
     <link rel="stylesheet" href="/playground/simulator.css">
+    <link rel="stylesheet" href="/playground/simulator-bootstrap.css">
     <link rel="modulepreload" href="/playground/resources/editor.bundle.min.js"/>
   </head>
   <body class="td-{{ .Kind }}{{ with .Page.Params.body_class }} {{ . }}{{ end }}">
@@ -40,7 +41,7 @@
                     <button class="btn btn-secondary mb-3 playground-btn-flash" disabled title="Download firmware image to flash to a board">Flash</button>
                   </div>
                 </div>
-                <div class="simulator">
+                <div class="simulator mb-3">
                   <div class="schematic-buttons">
                     <button class="schematic-button-pause schematic-button" title="Pause/resume the simulation">
                       <!-- only one of these two images is visible at a time -->
@@ -54,23 +55,37 @@
                       <g class="schematic-wires"></g>
                     </g>
                   </svg>
-                  <div class="panels">
-                    <div class="tabbar">
-                      <span class="tab active panel-tab-terminal"><a>Terminal</a></span>
-                      <span class="tab"><a>Properties</a></span>
-                      <span class="tab"><a>Add</a></span>
+                  <div class="card-header">
+                    <ul class="nav nav-tabs card-header-tabs" role="tablist">
+                      <li class="nav-item" role="presentation">
+                        <button class="nav-link active panel-tab-terminal" id="simulator-tab-terminal" data-bs-toggle="tab" data-bs-target="#simulator-panel-terminal" type="button" role="tab" aria-controls="simulator-panel-terminal" aria-selected="true">Terminal</button>
+                      </li>
+                      <li class="nav-item" role="presentation">
+                        <button class="nav-link" id="simulator-properties-tab" data-bs-toggle="tab" data-bs-target="#simulator-panel-properties" type="button" role="tab" aria-controls="simulator-panel-properties" aria-selected="false">Properties</button>
+                      </li>
+                      <li class="nav-item" role="presentation">
+                        <button class="nav-link" id="simulator-add-tab" data-bs-toggle="tab" data-bs-target="#simulator-panel-add" type="button" role="tab" aria-controls="simulator-panel-add" aria-selected="false">Add</button>
+                      </li>
+                    </ul>
+                  </div>
+                  <div class="tab-content">
+                    <div class="tab-pane active terminal-box" id="simulator-panel-terminal" role="tabpanel" aria-labelledby="simulator-tab-terminal">
+                      <textarea class="terminal" readonly tabindex="0"></textarea>
                     </div>
-                    <div class="tabcontent active terminal-box">
-                      <textarea class="terminal" readonly></textarea>
+                    <div class="tab-pane panel-properties content" id="simulator-panel-properties" role="tabpanel" aria-labelledby="simulator-properties-tab">
+                      <div class="content" tabindex="0"></div>
                     </div>
-                    <div class="tabcontent panel-properties">
-                      <div class="content"></div>
-                    </div>
-                    <div class="tabcontent panel-add">
-                      Loading...
+                    <div class="tab-pane" id="simulator-panel-add" role="tabpanel" aria-labelledby="simulator-add-tab" tabindex="0">
+                      <div class="panel-add">
+                        Loading...
+                      </div>
                     </div>
                   </div>
                   <div class="schematic-tooltip"></div>
+                  <div class="templates d-none">
+                    <button class="panel-add-button btn btn-primary btn-sm">Add</button>
+                    <select class="panel-add-select form-select form-select-sm"></select>
+                  </div>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
In my opinion, this looks _much_ better than the previous VSCode-like style.
  * It supports better keyboard navigation of the UI (not complete, but better than it was before).
  * It now supports dark mode (light+dark), instead of staying dark all the time.
  * It integrates with the look&feel of the rest of the website.

This is what it now looks like, which I think is a lot cleaner:

![Screenshot_20240722_192254](https://github.com/user-attachments/assets/01d07c09-34c4-411d-8461-4fd106f7d4b1)
