### PR TITLE
content: update lang-support info for TinyGo 0.33 with Go 1.23

### DIFF
--- a/content/docs/reference/lang-support/stdlib.md
+++ b/content/docs/reference/lang-support/stdlib.md
@@ -11,10 +11,11 @@ Test results are for linux/amd64.
 
 Package | Importable | Passes tests
 --- | --- | --- |
-archive/tar |  [<span style="color: red">✗</span> no](#archivetar)  |  <span style="color: gray">✗</span> no  | 
+archive/tar |  <span style="color: green">✔</span> yes  |  [<span style="color: red">✗</span> no](#archivetar)  | 
 archive/zip |  <span style="color: green">✔</span> yes  |  <span style="color: green">✔</span> yes  | 
 bufio |  <span style="color: green">✔</span> yes  |  [<span style="color: red">✗</span> no](#bufio)  | 
-bytes |  <span style="color: green">✔</span> yes  |  <span style="color: green">✔</span> yes  | 
+bytes |  <span style="color: green">✔</span> yes  |  [<span style="color: red">✗</span> no](#bytes)  | 
+cmp |  <span style="color: green">✔</span> yes  |  <span style="color: green">✔</span> yes  | 
 compress/bzip2 |  <span style="color: green">✔</span> yes  |  <span style="color: green">✔</span> yes  | 
 compress/flate |  <span style="color: green">✔</span> yes  |  <span style="color: green">✔</span> yes  | 
 compress/gzip |  <span style="color: green">✔</span> yes  |  [<span style="color: red">✗</span> no](#compressgzip)  | 
@@ -23,16 +24,16 @@ compress/zlib |  <span style="color: green">✔</span> yes  |  <span style="colo
 container/heap |  <span style="color: green">✔</span> yes  |  <span style="color: green">✔</span> yes  | 
 container/list |  <span style="color: green">✔</span> yes  |  <span style="color: green">✔</span> yes  | 
 container/ring |  <span style="color: green">✔</span> yes  |  <span style="color: green">✔</span> yes  | 
-context |  <span style="color: green">✔</span> yes  |  [<span style="color: red">✗</span> no](#context)  | 
+context |  <span style="color: green">✔</span> yes  |  <span style="color: green">✔</span> yes  | 
 crypto |  <span style="color: green">✔</span> yes  |  [<span style="color: red">✗</span> no](#crypto)  | 
-crypto/aes |  <span style="color: green">✔</span> yes  |  [<span style="color: red">✗</span> no](#cryptoaes)  | 
+crypto/aes |  <span style="color: green">✔</span> yes  |  <span style="color: green">✔</span> yes  | 
 crypto/cipher |  <span style="color: green">✔</span> yes  |  [<span style="color: red">✗</span> no](#cryptocipher)  | 
 crypto/des |  <span style="color: green">✔</span> yes  |  <span style="color: green">✔</span> yes  | 
 crypto/dsa |  <span style="color: green">✔</span> yes  |  <span style="color: green">✔</span> yes  | 
 crypto/ecdh |  <span style="color: green">✔</span> yes  |  [<span style="color: red">✗</span> no](#cryptoecdh)  | 
-crypto/ecdsa |  <span style="color: green">✔</span> yes  |  [<span style="color: red">✗</span> no](#cryptoecdsa)  | 
-crypto/ed25519 |  [<span style="color: red">✗</span> no](#cryptoed25519)  |  <span style="color: gray">✗</span> no  | 
-crypto/elliptic |  <span style="color: green">✔</span> yes  |  [<span style="color: red">✗</span> no](#cryptoelliptic)  | 
+crypto/ecdsa |  <span style="color: green">✔</span> yes  |  <span style="color: green">✔</span> yes  | 
+crypto/ed25519 |  <span style="color: green">✔</span> yes  |  [<span style="color: red">✗</span> no](#cryptoed25519)  | 
+crypto/elliptic |  <span style="color: green">✔</span> yes  |  <span style="color: green">✔</span> yes  | 
 crypto/hmac |  <span style="color: green">✔</span> yes  |  <span style="color: green">✔</span> yes  | 
 crypto/md5 |  <span style="color: green">✔</span> yes  |  <span style="color: green">✔</span> yes  | 
 crypto/rand |  <span style="color: green">✔</span> yes  |  <span style="color: green">✔</span> yes  | 
@@ -42,8 +43,8 @@ crypto/sha1 |  <span style="color: green">✔</span> yes  |  <span style="color:
 crypto/sha256 |  <span style="color: green">✔</span> yes  |  <span style="color: green">✔</span> yes  | 
 crypto/sha512 |  <span style="color: green">✔</span> yes  |  <span style="color: green">✔</span> yes  | 
 crypto/subtle |  <span style="color: green">✔</span> yes  |  [<span style="color: red">✗</span> no](#cryptosubtle)  | 
-crypto/tls |  [<span style="color: red">✗</span> no](#cryptotls)  |  <span style="color: gray">✗</span> no  | 
-crypto/x509 |  [<span style="color: red">✗</span> no](#cryptox509)  |  <span style="color: gray">✗</span> no  | 
+crypto/tls |  <span style="color: green">✔</span> yes  |  <span style="color: green">✔</span> yes  | 
+crypto/x509 |  <span style="color: green">✔</span> yes  |  [<span style="color: red">✗</span> no](#cryptox509)  | 
 crypto/x509/pkix |  <span style="color: green">✔</span> yes  |  <span style="color: green">✔</span> yes  | 
 database/sql |  <span style="color: green">✔</span> yes  |  [<span style="color: red">✗</span> no](#databasesql)  | 
 database/sql/driver |  <span style="color: green">✔</span> yes  |  <span style="color: green">✔</span> yes  | 
@@ -54,7 +55,7 @@ debug/gosym |  <span style="color: green">✔</span> yes  |  [<span style="color
 debug/macho |  <span style="color: green">✔</span> yes  |  <span style="color: green">✔</span> yes  | 
 debug/pe |  <span style="color: green">✔</span> yes  |  [<span style="color: red">✗</span> no](#debugpe)  | 
 debug/plan9obj |  <span style="color: green">✔</span> yes  |  <span style="color: green">✔</span> yes  | 
-embed |  <span style="color: green">✔</span> yes  |  [<span style="color: red">✗</span> no](#embed)  | 
+embed |  <span style="color: green">✔</span> yes  |  <span style="color: green">✔</span> yes  | 
 encoding |  <span style="color: green">✔</span> yes  |  <span style="color: green">✔</span> yes  | 
 encoding/ascii85 |  <span style="color: green">✔</span> yes  |  <span style="color: green">✔</span> yes  | 
 encoding/asn1 |  <span style="color: green">✔</span> yes  |  <span style="color: green">✔</span> yes  | 
@@ -78,12 +79,13 @@ go/constant |  <span style="color: green">✔</span> yes  |  [<span style="color
 go/doc |  <span style="color: green">✔</span> yes  |  [<span style="color: red">✗</span> no](#godoc)  | 
 go/doc/comment |  <span style="color: green">✔</span> yes  |  [<span style="color: red">✗</span> no](#godoccomment)  | 
 go/format |  <span style="color: green">✔</span> yes  |  <span style="color: green">✔</span> yes  | 
-go/importer |  [<span style="color: red">✗</span> no](#goimporter)  |  <span style="color: gray">✗</span> no  | 
+go/importer |  <span style="color: green">✔</span> yes  |  [<span style="color: red">✗</span> no](#goimporter)  | 
 go/parser |  <span style="color: green">✔</span> yes  |  [<span style="color: red">✗</span> no](#goparser)  | 
 go/printer |  <span style="color: green">✔</span> yes  |  <span style="color: green">✔</span> yes  | 
 go/scanner |  <span style="color: green">✔</span> yes  |  <span style="color: green">✔</span> yes  | 
 go/token |  <span style="color: green">✔</span> yes  |  [<span style="color: red">✗</span> no](#gotoken)  | 
 go/types |  <span style="color: green">✔</span> yes  |  [<span style="color: red">✗</span> no](#gotypes)  | 
+go/version |  <span style="color: green">✔</span> yes  |  <span style="color: green">✔</span> yes  | 
 hash |  <span style="color: green">✔</span> yes  |  <span style="color: green">✔</span> yes  | 
 hash/adler32 |  <span style="color: green">✔</span> yes  |  <span style="color: green">✔</span> yes  | 
 hash/crc32 |  <span style="color: green">✔</span> yes  |  [<span style="color: red">✗</span> no](#hashcrc32)  | 
@@ -101,16 +103,20 @@ image/jpeg |  <span style="color: green">✔</span> yes  |  [<span style="color:
 image/png |  <span style="color: green">✔</span> yes  |  [<span style="color: red">✗</span> no](#imagepng)  | 
 index/suffixarray |  <span style="color: green">✔</span> yes  |  <span style="color: green">✔</span> yes  | 
 io |  <span style="color: green">✔</span> yes  |  [<span style="color: red">✗</span> no](#io)  | 
-io/fs |  <span style="color: green">✔</span> yes  |  <span style="color: green">✔</span> yes  | 
+io/fs |  <span style="color: green">✔</span> yes  |  [<span style="color: red">✗</span> no](#iofs)  | 
 io/ioutil |  <span style="color: green">✔</span> yes  |  <span style="color: green">✔</span> yes  | 
+iter |  <span style="color: green">✔</span> yes  |  [<span style="color: red">✗</span> no](#iter)  | 
 log |  <span style="color: green">✔</span> yes  |  [<span style="color: red">✗</span> no](#log)  | 
+log/slog |  <span style="color: green">✔</span> yes  |  [<span style="color: red">✗</span> no](#logslog)  | 
 log/syslog |  <span style="color: green">✔</span> yes  |  [<span style="color: red">✗</span> no](#logsyslog)  | 
+maps |  <span style="color: green">✔</span> yes  |  [<span style="color: red">✗</span> no](#maps)  | 
 math |  <span style="color: green">✔</span> yes  |  <span style="color: green">✔</span> yes  | 
 math/big |  <span style="color: green">✔</span> yes  |  [<span style="color: red">✗</span> no](#mathbig)  | 
 math/bits |  <span style="color: green">✔</span> yes  |  [<span style="color: red">✗</span> no](#mathbits)  | 
 math/cmplx |  <span style="color: green">✔</span> yes  |  <span style="color: green">✔</span> yes  | 
 math/rand |  <span style="color: green">✔</span> yes  |  [<span style="color: red">✗</span> no](#mathrand)  | 
-mime |  <span style="color: green">✔</span> yes  |  [<span style="color: red">✗</span> no](#mime)  | 
+math/rand/v2 |  <span style="color: green">✔</span> yes  |  [<span style="color: red">✗</span> no](#mathrandv2)  | 
+mime |  <span style="color: green">✔</span> yes  |  <span style="color: green">✔</span> yes  | 
 mime/multipart |  <span style="color: green">✔</span> yes  |  <span style="color: green">✔</span> yes  | 
 mime/quotedprintable |  <span style="color: green">✔</span> yes  |  <span style="color: green">✔</span> yes  | 
 net |  <span style="color: green">✔</span> yes  |  <span style="color: green">✔</span> yes  | 
@@ -132,23 +138,26 @@ net/url |  <span style="color: green">✔</span> yes  |  [<span style="color: re
 os |  <span style="color: green">✔</span> yes  |  <span style="color: green">✔</span> yes  | 
 os/exec |  <span style="color: green">✔</span> yes  |  [<span style="color: red">✗</span> no](#osexec)  | 
 os/signal |  <span style="color: green">✔</span> yes  |  [<span style="color: red">✗</span> no](#ossignal)  | 
-os/user |  [<span style="color: red">✗</span> no](#osuser)  |  <span style="color: gray">✗</span> no  | 
+os/user |  <span style="color: green">✔</span> yes  |  <span style="color: green">✔</span> yes  | 
 path |  <span style="color: green">✔</span> yes  |  <span style="color: green">✔</span> yes  | 
 path/filepath |  <span style="color: green">✔</span> yes  |  [<span style="color: red">✗</span> no](#pathfilepath)  | 
 plugin |  [<span style="color: red">✗</span> no](#plugin)  |  <span style="color: gray">✗</span> no  | 
 reflect |  <span style="color: green">✔</span> yes  |  <span style="color: green">✔</span> yes  | 
 regexp |  <span style="color: green">✔</span> yes  |  [<span style="color: red">✗</span> no](#regexp)  | 
 regexp/syntax |  <span style="color: green">✔</span> yes  |  <span style="color: green">✔</span> yes  | 
+slices |  <span style="color: green">✔</span> yes  |  [<span style="color: red">✗</span> no](#slices)  | 
 sort |  <span style="color: green">✔</span> yes  |  [<span style="color: red">✗</span> no](#sort)  | 
 strconv |  <span style="color: green">✔</span> yes  |  <span style="color: green">✔</span> yes  | 
 strings |  <span style="color: green">✔</span> yes  |  [<span style="color: red">✗</span> no](#strings)  | 
+structs |  <span style="color: green">✔</span> yes  |  <span style="color: green">✔</span> yes  | 
 sync |  <span style="color: green">✔</span> yes  |  <span style="color: green">✔</span> yes  | 
 sync/atomic |  <span style="color: green">✔</span> yes  |  [<span style="color: red">✗</span> no](#syncatomic)  | 
 syscall |  <span style="color: green">✔</span> yes  |  [<span style="color: red">✗</span> no](#syscall)  | 
 testing |  <span style="color: green">✔</span> yes  |  <span style="color: green">✔</span> yes  | 
-testing/fstest |  <span style="color: green">✔</span> yes  |  <span style="color: green">✔</span> yes  | 
+testing/fstest |  <span style="color: green">✔</span> yes  |  [<span style="color: red">✗</span> no](#testingfstest)  | 
 testing/iotest |  <span style="color: green">✔</span> yes  |  <span style="color: green">✔</span> yes  | 
 testing/quick |  <span style="color: green">✔</span> yes  |  [<span style="color: red">✗</span> no](#testingquick)  | 
+testing/slogtest |  <span style="color: green">✔</span> yes  |  [<span style="color: red">✗</span> no](#testingslogtest)  | 
 text/scanner |  <span style="color: green">✔</span> yes  |  <span style="color: green">✔</span> yes  | 
 text/tabwriter |  <span style="color: green">✔</span> yes  |  <span style="color: green">✔</span> yes  | 
 text/template |  <span style="color: green">✔</span> yes  |  [<span style="color: red">✗</span> no](#texttemplate)  | 
@@ -158,6 +167,7 @@ time/tzdata |  [<span style="color: red">✗</span> no](#timetzdata)  |  <span s
 unicode |  <span style="color: green">✔</span> yes  |  <span style="color: green">✔</span> yes  | 
 unicode/utf16 |  <span style="color: green">✔</span> yes  |  <span style="color: green">✔</span> yes  | 
 unicode/utf8 |  <span style="color: green">✔</span> yes  |  <span style="color: green">✔</span> yes  | 
+unique |  <span style="color: green">✔</span> yes  |  <span style="color: green">✔</span> yes  | 
 unsafe |  <span style="color: green">✔</span> yes  |  <span style="color: green">✔</span> yes  | 
 
 
@@ -165,9 +175,14 @@ unsafe |  <span style="color: green">✔</span> yes  |  <span style="color: gree
 ## archive/tar
 
 
-This package cannot be imported because the following dependencies cannot be compiled:
 
-  * [os/user](#osuser)
+The compiler gave the following error when running the tests for this package:
+
+
+    [tinygo: panic at <Go interface method>]
+    panic: runtime error at 0x000000000026eae5: nil pointer dereference
+    FAIL	archive/tar	0.269s
+
 
 
 
@@ -185,7 +200,23 @@ The compiler gave the following error when running the tests for this package:
     --- FAIL: TestReadStringAllocs (0.00s)
         Unexpected number of allocations, got 0.000000, want 1
     FAIL
-    FAIL	bufio	0.833s
+    FAIL	bufio	0.130s
+
+
+
+
+
+
+## bytes
+
+
+
+The compiler gave the following error when running the tests for this package:
+
+
+    [tinygo: panic at /home/ron/Development/tinygo/tinygo-122/src/internal/bytealg/bytealg.go:304:13]
+    panic: runtime error at 0x000000000022d209: out of memory
+    FAIL	bytes	5.732s
 
 
 
@@ -205,22 +236,8 @@ The compiler gave the following error when running the tests for this package:
 The compiler gave the following error when running the tests for this package:
 
 
-    ld.lld: error: undefined symbol: vendor/golang.org/x/sys/cpu.cpuid
-    >>> referenced by main
-    >>>               /home/ayke/.cache/tinygo/thinlto/llvmcache-DC599358A5C8BD4AABB7CE20F999F63B34961798:(runtime.initAll)
-    >>> referenced by main
-    >>>               /home/ayke/.cache/tinygo/thinlto/llvmcache-DC599358A5C8BD4AABB7CE20F999F63B34961798:(runtime.initAll)
-    >>> referenced by main
-    >>>               /home/ayke/.cache/tinygo/thinlto/llvmcache-DC599358A5C8BD4AABB7CE20F999F63B34961798:(runtime.initAll)
-    >>> referenced 1 more times
-    
-    ld.lld: error: undefined symbol: vendor/golang.org/x/sys/cpu.xgetbv
-    >>> referenced by main
-    >>>               /home/ayke/.cache/tinygo/thinlto/llvmcache-DC599358A5C8BD4AABB7CE20F999F63B34961798:(runtime.initAll)
-    
-    ld.lld: error: undefined symbol: crypto/subtle.xorBytes
-    >>> referenced by xor.go:22 (/usr/local/go1.20/src/crypto/subtle/xor.go:22)
-    [...more lines following...]
+    FAIL		0.000s
+    /home/ron/.gvm/gos/go1.23/src/compress/gzip/example_test.go:14:2: package net/http/httptest is not in std (/home/ron/.cache/tinygo/goroot-8dfa52493353b482ef2f92e428ccd70087bafb9ea49be4487874c40c866336de/src/net/http/httptest)
 
 
 
@@ -233,33 +250,6 @@ The compiler gave the following error when running the tests for this package:
 
 
 
-
-
-
-
-## context
-
-
-
-The compiler gave the following error when running the tests for this package:
-
-
-    FAIL	context	0.000s
-    # context_test
-    /usr/local/go1.20/src/context/x_test.go:12:74: cannot use t (variable of type *testing.T) as context.testingT value in argument to XTestBackground: *testing.T does not implement context.testingT (missing method Deadline)
-    /usr/local/go1.20/src/context/x_test.go:13:68: cannot use t (variable of type *testing.T) as context.testingT value in argument to XTestTODO: *testing.T does not implement context.testingT (missing method Deadline)
-    /usr/local/go1.20/src/context/x_test.go:14:74: cannot use t (variable of type *testing.T) as context.testingT value in argument to XTestWithCancel: *testing.T does not implement context.testingT (missing method Deadline)
-    /usr/local/go1.20/src/context/x_test.go:15:83: cannot use t (variable of type *testing.T) as context.testingT value in argument to XTestParentFinishesChild: *testing.T does not implement context.testingT (missing method Deadline)
-    /usr/local/go1.20/src/context/x_test.go:16:82: cannot use t (variable of type *testing.T) as context.testingT value in argument to XTestChildFinishesFirst: *testing.T does not implement context.testingT (missing method Deadline)
-    /usr/local/go1.20/src/context/x_test.go:17:72: cannot use t (variable of type *testing.T) as context.testingT value in argument to XTestDeadline: *testing.T does not implement context.testingT (missing method Deadline)
-    /usr/local/go1.20/src/context/x_test.go:18:71: cannot use t (variable of type *testing.T) as context.testingT value in argument to XTestTimeout: *testing.T does not implement context.testingT (missing method Deadline)
-    /usr/local/go1.20/src/context/x_test.go:19:79: cannot use t (variable of type *testing.T) as context.testingT value in argument to XTestCanceledTimeout: *testing.T does not implement context.testingT (missing method Deadline)
-    /usr/local/go1.20/src/context/x_test.go:20:70: cannot use t (variable of type *testing.T) as context.testingT value in argument to XTestValues: *testing.T does not implement context.testingT (missing method Deadline)
-    /usr/local/go1.20/src/context/x_test.go:21:70: cannot use t (variable of type *testing.T) as context.testingT value in argument to XTestAllocs: *testing.T does not implement context.testingT (missing method Deadline)
-    /usr/local/go1.20/src/context/x_test.go:22:83: cannot use t (variable of type *testing.T) as context.testingT value in argument to XTestSimultaneousCancels: *testing.T does not implement context.testingT (missing method Deadline)
-    /usr/local/go1.20/src/context/x_test.go:23:82: cannot use t (variable of type *testing.T) as context.testingT value in argument to XTestInterlockedCancels: *testing.T does not implement context.testingT (missing method Deadline)
-    /usr/local/go1.20/src/context/x_test.go:24:76: cannot use t (variable of type *testing.T) as context.testingT value in argument to XTestLayersCancel: *testing.T does not implement context.testingT (missing method Deadline)
-    [...more lines following...]
 
 
 
@@ -273,37 +263,10 @@ The compiler gave the following error when running the tests for this package:
 The compiler gave the following error when running the tests for this package:
 
 
-    ld.lld: error: undefined symbol: crypto/subtle.xorBytes
-    >>> referenced by xor.go:22 (/usr/local/go1.20/src/crypto/subtle/xor.go:22)
-    >>>               /home/ayke/.cache/tinygo/thinlto/llvmcache-2488623C069C9DC12EF6E37F26080642CE5B006E:(crypto/subtle.XORBytes)
-    
-    ld.lld: error: undefined symbol: crypto/aes.encryptBlockAsm
-    >>> referenced by cipher_asm.go:81 (/usr/local/go1.20/src/crypto/aes/cipher_asm.go:81)
-    >>>               /home/ayke/.cache/tinygo/thinlto/llvmcache-2488623C069C9DC12EF6E37F26080642CE5B006E:((*crypto/aes.aesCipherAsm).Encrypt)
-    FAIL	crypto	0.000s
-    error: failed to link /tmp/tinygo1116462727/main: exit status 1
+    panic: runtime error at 0x000000000028df55: index out of range
+    FAIL	crypto	0.004s
 
 
-
-
-
-
-## crypto/aes
-
-
-
-The compiler gave the following error when running the tests for this package:
-
-
-    ld.lld: error: undefined symbol: crypto/aes.decryptBlockAsm
-    >>> referenced by cipher_asm.go:95 (/usr/local/go1.20/src/crypto/aes/cipher_asm.go:95)
-    >>>               /home/ayke/.cache/tinygo/thinlto/llvmcache-2D00ED78EE01FF7528848C59DF182739099E48B0:((*crypto/aes.aesCipherAsm).Decrypt)
-    
-    ld.lld: error: undefined symbol: crypto/aes.encryptBlockAsm
-    >>> referenced by cipher_asm.go:81 (/usr/local/go1.20/src/crypto/aes/cipher_asm.go:81)
-    >>>               /home/ayke/.cache/tinygo/thinlto/llvmcache-2D00ED78EE01FF7528848C59DF182739099E48B0:((*crypto/aes.aesCipherAsm).Encrypt)
-    FAIL	crypto/aes	0.000s
-    error: failed to link /tmp/tinygo3158500475/main: exit status 1
 
 
 
@@ -317,22 +280,11 @@ The compiler gave the following error when running the tests for this package:
 The compiler gave the following error when running the tests for this package:
 
 
-    ld.lld: error: undefined symbol: crypto/subtle.xorBytes
-    >>> referenced by xor.go:22 (/usr/local/go1.20/src/crypto/subtle/xor.go:22)
-    >>>               /home/ayke/.cache/tinygo/thinlto/llvmcache-85892024269DA2D4324A4B2FCF26D2931ACFD6C2:(crypto/subtle.XORBytes)
-    >>> referenced by xor.go:22 (/usr/local/go1.20/src/crypto/subtle/xor.go:22)
-    >>>               /home/ayke/.cache/tinygo/thinlto/llvmcache-85892024269DA2D4324A4B2FCF26D2931ACFD6C2:((*crypto/cipher.gcm).auth)
-    
-    ld.lld: error: undefined symbol: crypto/aes.gcmAesInit
-    >>> referenced by aes_gcm.go:49 (/usr/local/go1.20/src/crypto/aes/aes_gcm.go:49)
-    >>>               /home/ayke/.cache/tinygo/thinlto/llvmcache-85892024269DA2D4324A4B2FCF26D2931ACFD6C2:(crypto/cipher.newGCMWithNonceAndTagSize)
-    
-    ld.lld: error: undefined symbol: crypto/aes.decryptBlockAsm
-    >>> referenced by cipher_asm.go:95 (/usr/local/go1.20/src/crypto/aes/cipher_asm.go:95)
-    >>>               /home/ayke/.cache/tinygo/thinlto/llvmcache-85892024269DA2D4324A4B2FCF26D2931ACFD6C2:((*crypto/aes.aesCipherAsm).Decrypt)
-    
-    ld.lld: error: undefined symbol: crypto/aes.encryptBlockAsm
-    [...more lines following...]
+    --- FAIL: TestGCMAsm (0.31s)
+        no assembly implementation of GCM
+        SkipNow is incomplete, requires runtime.Goexit()
+    FAIL
+    FAIL	crypto/cipher	0.311s
 
 
 
@@ -350,51 +302,24 @@ The compiler gave the following error when running the tests for this package:
 The compiler gave the following error when running the tests for this package:
 
 
-    ld.lld: error: undefined symbol: crypto/internal/edwards25519/field.feSquare
-    >>> referenced by fe.go:309 (/usr/local/go1.20/src/crypto/internal/edwards25519/field/fe.go:309)
-    >>>               /home/ayke/.cache/tinygo/thinlto/llvmcache-8B5337492012101A96AFD7F823C76B7EE0629FAF:((*crypto/internal/edwards25519/field.Element).Square)
-    
-    ld.lld: error: undefined symbol: crypto/internal/edwards25519/field.feMul
-    >>> referenced by fe.go:303 (/usr/local/go1.20/src/crypto/internal/edwards25519/field/fe.go:303)
-    >>>               /home/ayke/.cache/tinygo/thinlto/llvmcache-8B5337492012101A96AFD7F823C76B7EE0629FAF:((*crypto/internal/edwards25519/field.Element).Multiply)
-    
-    ld.lld: error: undefined symbol: crypto/internal/nistec.p256Sqr
-    >>> referenced by p256_asm.go:563 (/usr/local/go1.20/src/crypto/internal/nistec/p256_asm.go:563)
-    >>>               /home/ayke/.cache/tinygo/thinlto/llvmcache-8B5337492012101A96AFD7F823C76B7EE0629FAF:(crypto/internal/nistec.p256Inverse)
-    >>> referenced by p256_asm.go:565 (/usr/local/go1.20/src/crypto/internal/nistec/p256_asm.go:565)
-    >>>               /home/ayke/.cache/tinygo/thinlto/llvmcache-8B5337492012101A96AFD7F823C76B7EE0629FAF:(crypto/internal/nistec.p256Inverse)
-    >>> referenced by p256_asm.go:567 (/usr/local/go1.20/src/crypto/internal/nistec/p256_asm.go:567)
-    >>>               /home/ayke/.cache/tinygo/thinlto/llvmcache-8B5337492012101A96AFD7F823C76B7EE0629FAF:(crypto/internal/nistec.p256Inverse)
+    --- FAIL: TestLinker (0.00s)
+        skipping test: 'go build' unavailable: /home/ron/.gvm/gos/go1.23/bin/go tool -n compile: fork/exec /home/ron/.gvm/gos/go1.23/bin/go: operation not implemented
+        SkipNow is incomplete, requires runtime.Goexit()
+        skipping test: 'go build' unavailable: /home/ron/.gvm/gos/go1.23/bin/go tool -n compile: fork/exec /home/ron/.gvm/gos/go1.23/bin/go: operation not implemented
+        SkipNow is incomplete, requires runtime.Goexit()
+        platform cannot run go tool
+        FailNow is incomplete, requires runtime.Goexit()
+        [ build -o hello.exe hello.go]: exec: no command
+        FailNow is incomplete, requires runtime.Goexit()
+        [./hello.exe]: fork/exec ./hello.exe: operation not implemented
+        FailNow is incomplete, requires runtime.Goexit()
+        unexpected output: 
+        [ tool nm hello.exe]: exec: no command
+        FailNow is incomplete, requires runtime.Goexit()
+        no P384 symbols found in program using ecdh.P384, test is broken
     [...more lines following...]
 
 
-
-
-
-
-## crypto/ecdsa
-
-
-
-The compiler gave the following error when running the tests for this package:
-
-
-    ld.lld: error: undefined symbol: crypto/subtle.xorBytes
-    >>> referenced by xor.go:22 (/usr/local/go1.20/src/crypto/subtle/xor.go:22)
-    >>>               /home/ayke/.cache/tinygo/thinlto/llvmcache-D2CF4BBB69E0C8F4FB42E53CB99819414C667E08:((crypto/cipher.StreamReader).Read)
-    
-    ld.lld: error: undefined symbol: crypto/aes.encryptBlockAsm
-    >>> referenced by cipher_asm.go:81 (/usr/local/go1.20/src/crypto/aes/cipher_asm.go:81)
-    >>>               /home/ayke/.cache/tinygo/thinlto/llvmcache-D2CF4BBB69E0C8F4FB42E53CB99819414C667E08:((*crypto/aes.aesCipherAsm).Encrypt)
-    
-    ld.lld: error: undefined symbol: crypto/internal/edwards25519/field.feSquare
-    >>> referenced by fe.go:309 (/usr/local/go1.20/src/crypto/internal/edwards25519/field/fe.go:309)
-    >>>               /home/ayke/.cache/tinygo/thinlto/llvmcache-D2CF4BBB69E0C8F4FB42E53CB99819414C667E08:((*crypto/internal/edwards25519/field.Element).Square)
-    
-    ld.lld: error: undefined symbol: crypto/internal/edwards25519/field.feMul
-    >>> referenced by fe.go:303 (/usr/local/go1.20/src/crypto/internal/edwards25519/field/fe.go:303)
-    >>>               /home/ayke/.cache/tinygo/thinlto/llvmcache-D2CF4BBB69E0C8F4FB42E53CB99819414C667E08:((*crypto/internal/edwards25519/field.Element).Multiply)
-    [...more lines following...]
 
 
 
@@ -405,46 +330,27 @@ The compiler gave the following error when running the tests for this package:
 
 
 
-The compiler gave the following error when this package was imported:
-
-
-    ld.lld: error: undefined symbol: crypto/internal/edwards25519/field.feSquare
-    >>> referenced by fe.go:309 (/usr/local/go1.20/src/crypto/internal/edwards25519/field/fe.go:309)
-    >>>               /home/ayke/.cache/tinygo/thinlto/llvmcache-0789AEB7EFB32DDEE9CB09DBEDFBFD637F9C1A48:((*crypto/internal/edwards25519/field.Element).Square)
-    
-    ld.lld: error: undefined symbol: crypto/internal/edwards25519/field.feMul
-    >>> referenced by fe.go:303 (/usr/local/go1.20/src/crypto/internal/edwards25519/field/fe.go:303)
-    >>>               /home/ayke/.cache/tinygo/thinlto/llvmcache-0789AEB7EFB32DDEE9CB09DBEDFBFD637F9C1A48:((*crypto/internal/edwards25519/field.Element).Multiply)
-    error: failed to link /tmp/tinygo3040995961/main: exit status 1
-
-
-
-
-
-
-## crypto/elliptic
-
-
-
 The compiler gave the following error when running the tests for this package:
 
 
-    ld.lld: error: undefined symbol: crypto/internal/nistec.p256PointAddAsm
-    >>> referenced by p256_asm.go:372 (/usr/local/go1.20/src/crypto/internal/nistec/p256_asm.go:372)
-    >>>               /home/ayke/.cache/tinygo/thinlto/llvmcache-21418DD625739E361D10381CEF2116024FD473AA:((*crypto/internal/nistec.P256Point).Add)
-    >>> referenced by p256_asm.go:652 (/usr/local/go1.20/src/crypto/internal/nistec/p256_asm.go:652)
-    >>>               /home/ayke/.cache/tinygo/thinlto/llvmcache-21418DD625739E361D10381CEF2116024FD473AA:((*crypto/internal/nistec.P256Point).ScalarMult)
-    >>> referenced by p256_asm.go:653 (/usr/local/go1.20/src/crypto/internal/nistec/p256_asm.go:653)
-    >>>               /home/ayke/.cache/tinygo/thinlto/llvmcache-21418DD625739E361D10381CEF2116024FD473AA:((*crypto/internal/nistec.P256Point).ScalarMult)
-    >>> referenced 7 more times
-    
-    ld.lld: error: undefined symbol: crypto/internal/nistec.p256PointDoubleAsm
-    >>> referenced by p256_asm.go:373 (/usr/local/go1.20/src/crypto/internal/nistec/p256_asm.go:373)
-    >>>               /home/ayke/.cache/tinygo/thinlto/llvmcache-21418DD625739E361D10381CEF2116024FD473AA:((*crypto/internal/nistec.P256Point).Add)
-    >>> referenced by p256_asm.go:643 (/usr/local/go1.20/src/crypto/internal/nistec/p256_asm.go:643)
-    >>>               /home/ayke/.cache/tinygo/thinlto/llvmcache-21418DD625739E361D10381CEF2116024FD473AA:((*crypto/internal/nistec.P256Point).ScalarMult)
-    >>> referenced by p256_asm.go:644 (/usr/local/go1.20/src/crypto/internal/nistec/p256_asm.go:644)
+    --- FAIL: TestEd25519Vectors (0.00s)
+        skipping test: 'go build' unavailable: /home/ron/.gvm/gos/go1.23/bin/go tool -n compile: fork/exec /home/ron/.gvm/gos/go1.23/bin/go: operation not implemented
+        SkipNow is incomplete, requires runtime.Goexit()
+        platform cannot run go tool
+        FailNow is incomplete, requires runtime.Goexit()
+        failed to run `go mod download -json filippo.io/mostly-harmless/ed25519vectors@v0.0.0-20210322192420-30a2d7243a94`, output: 
+        FailNow is incomplete, requires runtime.Goexit()
+        unexpected end of JSON input
+        FailNow is incomplete, requires runtime.Goexit()
+        failed to read ed25519vectors.json: open ed25519vectors.json: file does not exist
+        FailNow is incomplete, requires runtime.Goexit()
+        unexpected end of JSON input
+        FailNow is incomplete, requires runtime.Goexit()
+    FAIL
+    FAIL	crypto/ed25519	0.208s
     [...more lines following...]
+
+
 
 
 
@@ -466,22 +372,8 @@ The compiler gave the following error when running the tests for this package:
 The compiler gave the following error when running the tests for this package:
 
 
-    ld.lld: error: undefined symbol: crypto/internal/bigmod.montgomeryLoop
-    >>> referenced by nat.go:599 (/usr/local/go1.20/src/crypto/internal/bigmod/nat.go:599)
-    >>>               /home/ayke/.cache/tinygo/thinlto/llvmcache-3EBC3D31FF2668FC7A7C761DEF96D971602D6951:((*crypto/internal/bigmod.Nat).montgomeryMul)
-    
-    ld.lld: error: undefined symbol: crypto/subtle.xorBytes
-    >>> referenced by xor.go:22 (/usr/local/go1.20/src/crypto/subtle/xor.go:22)
-    >>>               /home/ayke/.cache/tinygo/thinlto/llvmcache-3EBC3D31FF2668FC7A7C761DEF96D971602D6951:((crypto/cipher.StreamReader).Read)
-    
-    ld.lld: error: undefined symbol: crypto/aes.encryptBlockAsm
-    >>> referenced by cipher_asm.go:81 (/usr/local/go1.20/src/crypto/aes/cipher_asm.go:81)
-    >>>               /home/ayke/.cache/tinygo/thinlto/llvmcache-3EBC3D31FF2668FC7A7C761DEF96D971602D6951:((*crypto/aes.aesCipherAsm).Encrypt)
-    
-    ld.lld: error: undefined symbol: crypto/internal/edwards25519/field.feSquare
-    >>> referenced by fe.go:309 (/usr/local/go1.20/src/crypto/internal/edwards25519/field/fe.go:309)
-    >>>               /home/ayke/.cache/tinygo/thinlto/llvmcache-3EBC3D31FF2668FC7A7C761DEF96D971602D6951:((*crypto/internal/edwards25519/field.Element).Square)
-    [...more lines following...]
+    panic: unimplemented: (reflect.Type).NumOut()
+    FAIL	crypto/rsa	0.034s
 
 
 
@@ -501,24 +393,11 @@ The compiler gave the following error when running the tests for this package:
 The compiler gave the following error when running the tests for this package:
 
 
-    ld.lld: error: undefined symbol: crypto/subtle.xorBytes
-    >>> referenced by xor.go:22 (/usr/local/go1.20/src/crypto/subtle/xor.go:22)
-    >>>               /home/ayke/.cache/tinygo/thinlto/llvmcache-414ED2EC413D93DD8C112FA3A0B6257CABEB7F13:(crypto/subtle.XORBytes)
-    FAIL	crypto/subtle	0.000s
-    error: failed to link /tmp/tinygo3362733111/main: exit status 1
+    panic: unimplemented: (reflect.Type).NumIn()
+    FAIL	crypto/subtle	0.001s
 
 
 
-
-
-
-## crypto/tls
-
-
-This package cannot be imported because the following dependencies cannot be compiled:
-
-  * [crypto/ed25519](#cryptoed25519)
-  * [crypto/x509](#cryptox509)
 
 
 
@@ -527,9 +406,14 @@ This package cannot be imported because the following dependencies cannot be com
 ## crypto/x509
 
 
-This package cannot be imported because the following dependencies cannot be compiled:
 
-  * [crypto/ed25519](#cryptoed25519)
+The compiler gave the following error when running the tests for this package:
+
+
+    FAIL	crypto/x509	0.000s
+    # crypto/x509_test
+    /home/ron/.gvm/gos/go1.23/src/crypto/x509/hybrid_pool_test.go:63:17: c.ConnectionState undefined (type *net.TLSConn has no field or method ConnectionState)
+
 
 
 
@@ -546,7 +430,7 @@ The compiler gave the following error when running the tests for this package:
 
     FAIL	database/sql	0.000s
     # database/sql
-    /usr/local/go1.20/src/database/sql/sql_test.go:4574:4: b.SetParallelism undefined (type *testing.B has no field or method SetParallelism)
+    /home/ron/.gvm/gos/go1.23/src/database/sql/sql_test.go:4804:4: b.SetParallelism undefined (type *testing.B has no field or method SetParallelism)
 
 
 
@@ -563,7 +447,7 @@ The compiler gave the following error when this package was imported:
 
 
     # debug/buildinfo
-    /usr/local/go1.20/src/debug/buildinfo/buildinfo.go:79:19: undefined: debug.ParseBuildInfo
+    /home/ron/.gvm/gos/go1.23/src/debug/buildinfo/buildinfo.go:89:19: undefined: debug.ParseBuildInfo
 
 
 
@@ -581,7 +465,7 @@ The compiler gave the following error when running the tests for this package:
 
     FAIL	debug/elf	0.000s
     # debug/elf
-    /usr/local/go1.20/src/debug/elf/file_test.go:906:10: undefined: net.ResolveIPAddr
+    /home/ron/.gvm/gos/go1.23/src/debug/elf/file_test.go:1159:10: undefined: net.ResolveIPAddr
 
 
 
@@ -595,8 +479,9 @@ The compiler gave the following error when running the tests for this package:
 The compiler gave the following error when running the tests for this package:
 
 
-    panic: runtime error at 0x00000000002549ab: nil pointer dereference
-    FAIL	debug/gosym	1.671s
+    [tinygo: panic at /home/ron/.gvm/gos/go1.23/src/debug/elf/file.go]
+    panic: runtime error at 0x000000000025bf84: nil pointer dereference
+    FAIL	debug/gosym	0.003s
 
 
 
@@ -612,39 +497,13 @@ The compiler gave the following error when running the tests for this package:
 The compiler gave the following error when running the tests for this package:
 
 
-    panic: runtime error at 0x00000000002737d1: index out of range
-    FAIL	debug/pe	1.148s
+    [tinygo: panic at /home/ron/.gvm/gos/go1.23/src/debug/pe/file_test.go]
+    panic: runtime error at 0x0000000000275b0d: index out of range
+    FAIL	debug/pe	0.004s
 
 
 
 
-
-
-
-
-## embed
-
-
-
-The compiler gave the following error when running the tests for this package:
-
-
-    ld.lld: error: undefined symbol: vendor/golang.org/x/sys/cpu.cpuid
-    >>> referenced by main
-    >>>               /home/ayke/.cache/tinygo/thinlto/llvmcache-3B6D6B682F19B044232E3E4C73B8A78F898E93C6:(runtime.initAll)
-    >>> referenced by main
-    >>>               /home/ayke/.cache/tinygo/thinlto/llvmcache-3B6D6B682F19B044232E3E4C73B8A78F898E93C6:(runtime.initAll)
-    >>> referenced by main
-    >>>               /home/ayke/.cache/tinygo/thinlto/llvmcache-3B6D6B682F19B044232E3E4C73B8A78F898E93C6:(runtime.initAll)
-    >>> referenced 1 more times
-    
-    ld.lld: error: undefined symbol: vendor/golang.org/x/sys/cpu.xgetbv
-    >>> referenced by main
-    >>>               /home/ayke/.cache/tinygo/thinlto/llvmcache-3B6D6B682F19B044232E3E4C73B8A78F898E93C6:(runtime.initAll)
-    
-    ld.lld: error: undefined symbol: crypto/internal/edwards25519/field.feSquare
-    >>> referenced by fe.go:309 (/usr/local/go1.20/src/crypto/internal/edwards25519/field/fe.go:309)
-    [...more lines following...]
 
 
 
@@ -668,7 +527,9 @@ The compiler gave the following error when running the tests for this package:
 The compiler gave the following error when running the tests for this package:
 
 
-    FAIL	encoding/binary	1.025s
+    [tinygo: panic at /home/ron/.gvm/gos/go1.23/src/encoding/binary/binary.go:109:7]
+    panic: runtime error at 0x000000000024bf78: index out of range
+    FAIL	encoding/binary	0.005s
 
 
 
@@ -685,7 +546,7 @@ The compiler gave the following error when running the tests for this package:
 
 
     panic: reflect: unimplemented: AssignableTo with interface
-    FAIL	encoding/gob	1.418s
+    FAIL	encoding/gob	0.000s
 
 
 
@@ -701,22 +562,8 @@ The compiler gave the following error when running the tests for this package:
 The compiler gave the following error when running the tests for this package:
 
 
-    ld.lld: error: undefined symbol: vendor/golang.org/x/sys/cpu.cpuid
-    >>> referenced by main
-    >>>               /home/ayke/.cache/tinygo/thinlto/llvmcache-B546F5E015501B15C784EB346D71B542493E6867:(runtime.initAll)
-    >>> referenced by main
-    >>>               /home/ayke/.cache/tinygo/thinlto/llvmcache-B546F5E015501B15C784EB346D71B542493E6867:(runtime.initAll)
-    >>> referenced by main
-    >>>               /home/ayke/.cache/tinygo/thinlto/llvmcache-B546F5E015501B15C784EB346D71B542493E6867:(runtime.initAll)
-    >>> referenced 1 more times
-    
-    ld.lld: error: undefined symbol: vendor/golang.org/x/sys/cpu.xgetbv
-    >>> referenced by main
-    >>>               /home/ayke/.cache/tinygo/thinlto/llvmcache-B546F5E015501B15C784EB346D71B542493E6867:(runtime.initAll)
-    
-    ld.lld: error: undefined symbol: crypto/subtle.xorBytes
-    >>> referenced by xor.go:22 (/usr/local/go1.20/src/crypto/subtle/xor.go:22)
-    [...more lines following...]
+    FAIL		0.000s
+    /home/ron/.gvm/gos/go1.23/src/encoding/json/stream_test.go:14:2: package net/http/httptest is not in std (/home/ron/.cache/tinygo/goroot-8dfa52493353b482ef2f92e428ccd70087bafb9ea49be4487874c40c866336de/src/net/http/httptest)
 
 
 
@@ -730,15 +577,8 @@ The compiler gave the following error when running the tests for this package:
 The compiler gave the following error when running the tests for this package:
 
 
-    ld.lld: error: undefined symbol: crypto/internal/edwards25519/field.feSquare
-    >>> referenced by fe.go:309 (/usr/local/go1.20/src/crypto/internal/edwards25519/field/fe.go:309)
-    >>>               /home/ayke/.cache/tinygo/thinlto/llvmcache-FD0540891799D0F9AF48E24892644EB0DE3691B1:((*crypto/internal/edwards25519/field.Element).Square)
-    
-    ld.lld: error: undefined symbol: crypto/internal/edwards25519/field.feMul
-    >>> referenced by fe.go:303 (/usr/local/go1.20/src/crypto/internal/edwards25519/field/fe.go:303)
-    >>>               /home/ayke/.cache/tinygo/thinlto/llvmcache-FD0540891799D0F9AF48E24892644EB0DE3691B1:((*crypto/internal/edwards25519/field.Element).Multiply)
-    FAIL	encoding/pem	0.000s
-    error: failed to link /tmp/tinygo1826234130/main: exit status 1
+    panic: unimplemented: (reflect.Type).NumOut()
+    FAIL	encoding/pem	1.549s
 
 
 
@@ -752,7 +592,7 @@ The compiler gave the following error when running the tests for this package:
 The compiler gave the following error when running the tests for this package:
 
 
-    FAIL	encoding/xml	1.169s
+    FAIL	encoding/xml	0.022s
 
 
 
@@ -766,20 +606,20 @@ The compiler gave the following error when running the tests for this package:
 The compiler gave the following error when running the tests for this package:
 
 
-    --- FAIL: TestAs (0.01s)
-        --- FAIL: TestAs/8:As(Errorf(...,_err),_0x400081ee90) (0.00s)
+    --- FAIL: TestAs (0.00s)
+        --- FAIL: TestAs/8:As(Errorf(...,_err),_0x78b942e17bd0) (0.00s)
             match: got true; want false
             FailNow is incomplete, requires runtime.Goexit()
             got &errors.errorString{s:"err"}, want <nil>
             FailNow is incomplete, requires runtime.Goexit()
-        --- FAIL: TestAs/10:As(Errorf(...,_path_error),_0x400081ee90) (0.00s)
-            got errors_test.wrapped{msg:"path error", err:(*fs.PathError)(0x400081eef0)}, want &fs.PathError{Op:"open", Path:"non-existing", Err:(*errors.errorString)(0x2520d8)}
+        --- FAIL: TestAs/10:As(Errorf(...,_path_error),_0x78b942e17bd0) (0.00s)
+            got errors_test.wrapped{msg:"path error", err:(*fs.PathError)(0x78b942e17c30)}, want &fs.PathError{Op:"open", Path:"non-existing", Err:(*errors.errorString)(0x253968)}
             FailNow is incomplete, requires runtime.Goexit()
-        --- FAIL: TestAs/16:As(Errorf(...,_multiError),_0x400081ee90) (0.00s)
-            got errors_test.multiErr{errors_test.wrapped{msg:"path error", err:(*fs.PathError)(0x400081eef0)}}, want &fs.PathError{Op:"open", Path:"non-existing", Err:(*errors.errorString)(0x2520d8)}
+        --- FAIL: TestAs/16:As(Errorf(...,_multiError),_0x78b942e17bd0) (0.00s)
+            got errors_test.multiErr{errors_test.wrapped{msg:"path error", err:(*fs.PathError)(0x78b942e17c30)}}, want &fs.PathError{Op:"open", Path:"non-existing", Err:(*errors.errorString)(0x253968)}
             FailNow is incomplete, requires runtime.Goexit()
     FAIL
-    FAIL	errors	0.038s
+    FAIL	errors	0.001s
 
 
 
@@ -804,7 +644,7 @@ This package cannot be imported because the following dependencies cannot be com
 The compiler gave the following error when running the tests for this package:
 
 
-    --- FAIL: TestExitCode (0.01s)
+    --- FAIL: TestExitCode (0.00s)
         unexpected exit code for test case {flag:-h flagHandle: expectExit:0} 
             : got -1, expect 0
         unexpected exit code for test case {flag:-help flagHandle: expectExit:0} 
@@ -815,8 +655,11 @@ The compiler gave the following error when running the tests for this package:
             : got -1, expect 123
         unexpected exit code for test case {flag:-help flagHandle:help expectExit:123} 
             : got -1, expect 123
+    --- FAIL: TestDefineAfterSet (0.00s)
+        DefineAfterSet
+            : expected panic("flag myFlag set at .*/flag_test.go:.* before being defined"), but got panic("flag myFlag set at ?:0 before being defined")
     FAIL
-    FAIL	flag	0.047s
+    [...more lines following...]
 
 
 
@@ -830,8 +673,9 @@ The compiler gave the following error when running the tests for this package:
 The compiler gave the following error when running the tests for this package:
 
 
-    panic: reflect: call of Slice on array Value
-    FAIL	fmt	1.154s
+    [tinygo: panic at /home/ron/Development/tinygo/tinygo-122/src/reflect/type.go:507:11]
+    panic: runtime error at 0x0000000000228ecc: nil pointer dereference
+    FAIL	fmt	0.003s
 
 
 
@@ -852,16 +696,16 @@ The compiler gave the following error when running the tests for this package:
         FailNow is incomplete, requires runtime.Goexit()
         import "./file": unknown compiler "tinygo"
         FailNow is incomplete, requires runtime.Goexit()
-    --- FAIL: TestLocalDirectory (0.01s)
+    --- FAIL: TestLocalDirectory (0.00s)
         import ".": unknown compiler "tinygo"
         FailNow is incomplete, requires runtime.Goexit()
-    --- FAIL: TestImportCmd (0.00s)
-        import "cmd/internal/objfile": unknown compiler "tinygo"
+        ImportPath=".", want "go/build"
         FailNow is incomplete, requires runtime.Goexit()
-    --- FAIL: TestImportDirNotExist (0.01s)
-        --- FAIL: TestImportDirNotExist/GO111MODULE=on (0.00s)
-            Import(full, 0) got error: "go/build: go list go/build/doesnotexist: fork/exec /usr/local/go/bin/go: operation not implemented\n\n", want "cannot find package" or "is not in GOROOT" error
-            Import(full, FindOnly) got error: "go/build: go list go/build/doesnotexist: fork/exec /usr/local/go/bin/go: operation not implemented\n\n", want "cannot find package" or "is not in GOROOT" error
+    --- FAIL: TestImportCmd (0.00s)
+        go/build: go list cmd/internal/objfile: fork/exec /usr/local/go/bin/go: operation not implemented
+            
+            
+        FailNow is incomplete, requires runtime.Goexit()
     [...more lines following...]
 
 
@@ -878,8 +722,9 @@ The compiler gave the following error when running the tests for this package:
 The compiler gave the following error when running the tests for this package:
 
 
-    panic: runtime error at 0x00000000002549ec: divide by zero
-    FAIL	go/constant	1.037s
+    [tinygo: panic at /home/ron/.gvm/gos/go1.23/src/go/constant/value.go]
+    panic: runtime error at 0x00000000002549e8: divide by zero
+    FAIL	go/constant	0.004s
 
 
 
@@ -894,7 +739,7 @@ The compiler gave the following error when running the tests for this package:
 
 
     panic: unimplemented: (reflect.Type).NumOut()
-    FAIL	go/doc	1.349s
+    FAIL	go/doc	0.000s
 
 
 
@@ -908,21 +753,21 @@ The compiler gave the following error when running the tests for this package:
 The compiler gave the following error when running the tests for this package:
 
 
-    --- FAIL: TestStd (0.01s)
-        fork/exec /usr/local/go/bin/go: operation not implemented
+    --- FAIL: TestStd (0.00s)
+        skipping test: 'go build' unavailable: /home/ron/.gvm/gos/go1.23/bin/go tool -n compile: fork/exec /home/ron/.gvm/gos/go1.23/bin/go: operation not implemented
+        SkipNow is incomplete, requires runtime.Goexit()
+        platform cannot run go tool
+        FailNow is incomplete, requires runtime.Goexit()
+        exec: no command
         FailNow is incomplete, requires runtime.Goexit()
         stdPkgs is out of date: regenerate with 'go generate'
             diff stdPkgs want
             --- stdPkgs
             +++ want
-            @@ -1,33 +1,1 @@
+            @@ -1,39 +1,1 @@
             -bufio
             -bytes
-            -context
-            -crypto
-            -embed
-            -encoding
-            -errors
+            -cmp
     [...more lines following...]
 
 
@@ -936,11 +781,12 @@ The compiler gave the following error when running the tests for this package:
 
 
 
-The compiler gave the following error when this package was imported:
+The compiler gave the following error when running the tests for this package:
 
 
-    # internal/pkgbits
-    /usr/local/go1.20/src/internal/pkgbits/sync.go:38:64: frame.Entry undefined (type runtime.Frame has no field or method Entry)
+    [tinygo: panic at <Go interface method>]
+    panic: runtime error at 0x0000000000320e41: nil pointer dereference
+    FAIL	go/importer	0.006s
 
 
 
@@ -954,7 +800,7 @@ The compiler gave the following error when this package was imported:
 The compiler gave the following error when running the tests for this package:
 
 
-    FAIL	go/parser	1.963s
+    FAIL	go/parser	0.092s
 
 
 
@@ -973,7 +819,7 @@ The compiler gave the following error when running the tests for this package:
 
 
     panic: reflect: unimplemented: AssignableTo with interface
-    FAIL	go/token	1.369s
+    FAIL	go/token	0.001s
 
 
 
@@ -988,8 +834,10 @@ The compiler gave the following error when running the tests for this package:
 
 
     FAIL	go/types	0.000s
-    # internal/pkgbits
-    /usr/local/go1.20/src/internal/pkgbits/sync.go:38:64: frame.Entry undefined (type runtime.Frame has no field or method Entry)
+    # go/types_test
+    /home/ron/.gvm/gos/go1.23/src/go/types/self_test.go:103:4: b.ReportMetric undefined (type *testing.B has no field or method ReportMetric)
+
+
 
 
 
@@ -1008,7 +856,7 @@ The compiler gave the following error when running the tests for this package:
 
 
     panic: not available
-    FAIL	hash/crc32	1.532s
+    FAIL	hash/crc32	0.012s
 
 
 
@@ -1026,8 +874,9 @@ The compiler gave the following error when running the tests for this package:
 The compiler gave the following error when running the tests for this package:
 
 
-    panic: runtime error at 0x0000000000223ba1: out of memory
-    FAIL	hash/maphash	144.258s
+    [tinygo: panic at /home/ron/Development/tinygo/tinygo-122/src/runtime/slice.go:50:14]
+    panic: runtime error at 0x0000000000224be8: out of memory
+    FAIL	hash/maphash	30.162s
 
 
 
@@ -1044,7 +893,7 @@ The compiler gave the following error when running the tests for this package:
 
 
     panic: unimplemented: (reflect.Type).NumOut()
-    FAIL	html/template	1.105s
+    FAIL	html/template	0.002s
 
 
 
@@ -1061,7 +910,7 @@ The compiler gave the following error when running the tests for this package:
 
 
     panic: unimplemented: (reflect.Type).NumIn()
-    FAIL	image/color	1.340s
+    FAIL	image/color	0.000s
 
 
 
@@ -1078,7 +927,7 @@ The compiler gave the following error when running the tests for this package:
 
 
     panic: unimplemented: (reflect.Type).NumIn()
-    FAIL	image/draw	1.669s
+    FAIL	image/draw	0.033s
 
 
 
@@ -1094,8 +943,8 @@ The compiler gave the following error when running the tests for this package:
 
     FAIL	image/gif	0.000s
     # image/gif
-    /usr/local/go1.20/src/image/gif/reader_test.go:421:26: s1.HeapAlloc undefined (type *runtime.MemStats has no field or method HeapAlloc)
-    /usr/local/go1.20/src/image/gif/reader_test.go:421:41: s0.HeapAlloc undefined (type *runtime.MemStats has no field or method HeapAlloc)
+    /home/ron/.gvm/gos/go1.23/src/image/gif/reader_test.go:422:26: s1.HeapAlloc undefined (type *runtime.MemStats has no field or method HeapAlloc)
+    /home/ron/.gvm/gos/go1.23/src/image/gif/reader_test.go:422:41: s0.HeapAlloc undefined (type *runtime.MemStats has no field or method HeapAlloc)
 
 
 
@@ -1111,7 +960,7 @@ The compiler gave the following error when running the tests for this package:
 
     FAIL	image/jpeg	0.000s
     # image/jpeg
-    /usr/local/go1.20/src/image/jpeg/reader_test.go:253:9: undefined: debug.SetTraceback
+    /home/ron/.gvm/gos/go1.23/src/image/jpeg/reader_test.go:253:9: undefined: debug.SetTraceback
 
 
 
@@ -1125,8 +974,9 @@ The compiler gave the following error when running the tests for this package:
 The compiler gave the following error when running the tests for this package:
 
 
-    panic: runtime error at 0x00000000002593d3: out of memory
-    FAIL	image/png	3.639s
+    [tinygo: panic at /home/ron/.gvm/gos/go1.23/src/image/png/reader.go:506:12]
+    panic: runtime error at 0x0000000000259314: out of memory
+    FAIL	image/png	0.880s
 
 
 
@@ -1152,11 +1002,43 @@ The compiler gave the following error when running the tests for this package:
         timeout waiting for collection of buf1
         FailNow is incomplete, requires runtime.Goexit()
     FAIL
-    FAIL	io	5.193s
+    FAIL	io	5.053s
 
 
 
 
+
+
+## io/fs
+
+
+
+The compiler gave the following error when running the tests for this package:
+
+
+    FAIL	io/fs	0.003s
+
+
+
+
+
+
+
+
+## iter
+
+
+
+The compiler gave the following error when running the tests for this package:
+
+
+    FAIL	iter	0.000s
+    /home/ron/.gvm/gos/go1.23/src/iter/iter.go:251: linker could not find symbol runtime.newcoro
+    /home/ron/.gvm/gos/go1.23/src/iter/iter.go:267: linker could not find symbol runtime.coroswitch
+    /home/ron/.gvm/gos/go1.23/src/iter/iter.go:297: linker could not find symbol runtime.coroswitch
+    /home/ron/.gvm/gos/go1.23/src/iter/iter.go:317: linker could not find symbol runtime.coroswitch
+    /home/ron/.gvm/gos/go1.23/src/iter/iter.go:367: linker could not find symbol runtime.newcoro
+    /home/ron/.gvm/gos/go1.23/src/iter/iter.go:367: linker could not find symbol runtime.newcoro
 
 
 
@@ -1170,22 +1052,37 @@ The compiler gave the following error when running the tests for this package:
 The compiler gave the following error when running the tests for this package:
 
 
-    --- FAIL: TestAll (0.02s)
-        log output should match "^.*/[A-Za-z0-9_\\-]+\\.go:(61|63): hello 23 world$" is "???:0: hello 23 world"
-        log output should match "^.*/[A-Za-z0-9_\\-]+\\.go:(61|63): hello 23 world$" is "???:0: hello 23 world"
-        log output should match "^[A-Za-z0-9_\\-]+\\.go:(61|63): hello 23 world$" is "???:0: hello 23 world"
-        log output should match "^[A-Za-z0-9_\\-]+\\.go:(61|63): hello 23 world$" is "???:0: hello 23 world"
-        log output should match "^[A-Za-z0-9_\\-]+\\.go:(61|63): hello 23 world$" is "???:0: hello 23 world"
-        log output should match "^[A-Za-z0-9_\\-]+\\.go:(61|63): hello 23 world$" is "???:0: hello 23 world"
-        log output should match "^XXX[0-9][0-9][0-9][0-9]/[0-9][0-9]/[0-9][0-9] [0-9][0-9]:[0-9][0-9]:[0-9][0-9]\\.[0-9][0-9][0-9][0-9][0-9][0-9] .*/[A-Za-z0-9_\\-]+\\.go:(61|63): hello 23 world$" is "XXX2023/06/11 18:35:24.852021 ???:0: hello 23 world"
-        log output should match "^XXX[0-9][0-9][0-9][0-9]/[0-9][0-9]/[0-9][0-9] [0-9][0-9]:[0-9][0-9]:[0-9][0-9]\\.[0-9][0-9][0-9][0-9][0-9][0-9] .*/[A-Za-z0-9_\\-]+\\.go:(61|63): hello 23 world$" is "XXX2023/06/11 18:35:24.852221 ???:0: hello 23 world"
-        log output should match "^XXX[0-9][0-9][0-9][0-9]/[0-9][0-9]/[0-9][0-9] [0-9][0-9]:[0-9][0-9]:[0-9][0-9]\\.[0-9][0-9][0-9][0-9][0-9][0-9] [A-Za-z0-9_\\-]+\\.go:(61|63): hello 23 world$" is "XXX2023/06/11 18:35:24.853505 ???:0: hello 23 world"
-        log output should match "^XXX[0-9][0-9][0-9][0-9]/[0-9][0-9]/[0-9][0-9] [0-9][0-9]:[0-9][0-9]:[0-9][0-9]\\.[0-9][0-9][0-9][0-9][0-9][0-9] [A-Za-z0-9_\\-]+\\.go:(61|63): hello 23 world$" is "XXX2023/06/11 18:35:24.853693 ???:0: hello 23 world"
-        log output should match "^[0-9][0-9][0-9][0-9]/[0-9][0-9]/[0-9][0-9] [0-9][0-9]:[0-9][0-9]:[0-9][0-9]\\.[0-9][0-9][0-9][0-9][0-9][0-9] .*/[A-Za-z0-9_\\-]+\\.go:(61|63): XXXhello 23 world$" is "2023/06/11 18:35:24.854965 ???:0: XXXhello 23 world"
-        log output should match "^[0-9][0-9][0-9][0-9]/[0-9][0-9]/[0-9][0-9] [0-9][0-9]:[0-9][0-9]:[0-9][0-9]\\.[0-9][0-9][0-9][0-9][0-9][0-9] .*/[A-Za-z0-9_\\-]+\\.go:(61|63): XXXhello 23 world$" is "2023/06/11 18:35:24.855138 ???:0: XXXhello 23 world"
-        log output should match "^[0-9][0-9][0-9][0-9]/[0-9][0-9]/[0-9][0-9] [0-9][0-9]:[0-9][0-9]:[0-9][0-9]\\.[0-9][0-9][0-9][0-9][0-9][0-9] [A-Za-z0-9_\\-]+\\.go:(61|63): XXXhello 23 world$" is "2023/06/11 18:35:24.856385 ???:0: XXXhello 23 world"
-        log output should match "^[0-9][0-9][0-9][0-9]/[0-9][0-9]/[0-9][0-9] [0-9][0-9]:[0-9][0-9]:[0-9][0-9]\\.[0-9][0-9][0-9][0-9][0-9][0-9] [A-Za-z0-9_\\-]+\\.go:(61|63): XXXhello 23 world$" is "2023/06/11 18:35:24.856563 ???:0: XXXhello 23 world"
+    --- FAIL: TestAll (0.00s)
+        log output should match "^.*/[A-Za-z0-9_\\-]+\\.go:(63|65): hello 23 world$" is "???:0: hello 23 world"
+        log output should match "^.*/[A-Za-z0-9_\\-]+\\.go:(63|65): hello 23 world$" is "???:0: hello 23 world"
+        log output should match "^[A-Za-z0-9_\\-]+\\.go:(63|65): hello 23 world$" is "???:0: hello 23 world"
+        log output should match "^[A-Za-z0-9_\\-]+\\.go:(63|65): hello 23 world$" is "???:0: hello 23 world"
+        log output should match "^[A-Za-z0-9_\\-]+\\.go:(63|65): hello 23 world$" is "???:0: hello 23 world"
+        log output should match "^[A-Za-z0-9_\\-]+\\.go:(63|65): hello 23 world$" is "???:0: hello 23 world"
+        log output should match "^XXX[0-9][0-9][0-9][0-9]/[0-9][0-9]/[0-9][0-9] [0-9][0-9]:[0-9][0-9]:[0-9][0-9]\\.[0-9][0-9][0-9][0-9][0-9][0-9] .*/[A-Za-z0-9_\\-]+\\.go:(63|65): hello 23 world$" is "XXX2024/08/22 20:03:20.722555 ???:0: hello 23 world"
+        log output should match "^XXX[0-9][0-9][0-9][0-9]/[0-9][0-9]/[0-9][0-9] [0-9][0-9]:[0-9][0-9]:[0-9][0-9]\\.[0-9][0-9][0-9][0-9][0-9][0-9] .*/[A-Za-z0-9_\\-]+\\.go:(63|65): hello 23 world$" is "XXX2024/08/22 20:03:20.722586 ???:0: hello 23 world"
+        log output should match "^XXX[0-9][0-9][0-9][0-9]/[0-9][0-9]/[0-9][0-9] [0-9][0-9]:[0-9][0-9]:[0-9][0-9]\\.[0-9][0-9][0-9][0-9][0-9][0-9] [A-Za-z0-9_\\-]+\\.go:(63|65): hello 23 world$" is "XXX2024/08/22 20:03:20.722990 ???:0: hello 23 world"
+        log output should match "^XXX[0-9][0-9][0-9][0-9]/[0-9][0-9]/[0-9][0-9] [0-9][0-9]:[0-9][0-9]:[0-9][0-9]\\.[0-9][0-9][0-9][0-9][0-9][0-9] [A-Za-z0-9_\\-]+\\.go:(63|65): hello 23 world$" is "XXX2024/08/22 20:03:20.723033 ???:0: hello 23 world"
+        log output should match "^[0-9][0-9][0-9][0-9]/[0-9][0-9]/[0-9][0-9] [0-9][0-9]:[0-9][0-9]:[0-9][0-9]\\.[0-9][0-9][0-9][0-9][0-9][0-9] .*/[A-Za-z0-9_\\-]+\\.go:(63|65): XXXhello 23 world$" is "2024/08/22 20:03:20.723067 ???:0: XXXhello 23 world"
+        log output should match "^[0-9][0-9][0-9][0-9]/[0-9][0-9]/[0-9][0-9] [0-9][0-9]:[0-9][0-9]:[0-9][0-9]\\.[0-9][0-9][0-9][0-9][0-9][0-9] .*/[A-Za-z0-9_\\-]+\\.go:(63|65): XXXhello 23 world$" is "2024/08/22 20:03:20.723497 ???:0: XXXhello 23 world"
+        log output should match "^[0-9][0-9][0-9][0-9]/[0-9][0-9]/[0-9][0-9] [0-9][0-9]:[0-9][0-9]:[0-9][0-9]\\.[0-9][0-9][0-9][0-9][0-9][0-9] [A-Za-z0-9_\\-]+\\.go:(63|65): XXXhello 23 world$" is "2024/08/22 20:03:20.723537 ???:0: XXXhello 23 world"
+        log output should match "^[0-9][0-9][0-9][0-9]/[0-9][0-9]/[0-9][0-9] [0-9][0-9]:[0-9][0-9]:[0-9][0-9]\\.[0-9][0-9][0-9][0-9][0-9][0-9] [A-Za-z0-9_\\-]+\\.go:(63|65): XXXhello 23 world$" is "2024/08/22 20:03:20.723951 ???:0: XXXhello 23 world"
     [...more lines following...]
+
+
+
+
+
+
+## log/slog
+
+
+
+The compiler gave the following error when running the tests for this package:
+
+
+    panic: runtime.Caller failed
+    FAIL	log/slog	0.000s
 
 
 
@@ -1201,9 +1098,24 @@ The compiler gave the following error when running the tests for this package:
 
     FAIL	log/syslog	0.000s
     # log/syslog
-    /usr/local/go1.20/src/log/syslog/syslog_test.go:22:25: undefined: net.PacketConn
-    /usr/local/go1.20/src/log/syslog/syslog_test.go:35:21: oe.Temporary undefined (type *net.OpError has no field or method Temporary)
-    /usr/local/go1.20/src/log/syslog/syslog_test.go:110:15: undefined: net.ListenPacket
+    /home/ron/.gvm/gos/go1.23/src/log/syslog/syslog_test.go:35:21: oe.Temporary undefined (type *net.OpError has no field or method Temporary)
+    /home/ron/.gvm/gos/go1.23/src/log/syslog/syslog_test.go:110:15: undefined: net.ListenPacket
+
+
+
+
+
+
+## maps
+
+
+
+The compiler gave the following error when running the tests for this package:
+
+
+    FAIL	maps	0.000s
+    /home/ron/.gvm/gos/go1.23/src/maps/maps.go:55: linker could not find symbol maps.clone
+    /home/ron/.gvm/gos/go1.23/src/maps/maps.go:55: linker could not find symbol maps.clone
 
 
 
@@ -1221,19 +1133,19 @@ The compiler gave the following error when running the tests for this package:
 
     FAIL	math/big	0.000s
     # math/big
-    /usr/local/go1.20/src/math/bits/bits.go:472:10: interp: running for more than 3m0s, timing out (executed calls: 28656473)
-      <badref> = and half <badref>, <null operand!>fatal error: unexpected signal during runtime execution
-    [signal SIGSEGV: segmentation violation code=0x1 addr=0xfff12bed61e4 pc=0xffff100db604]
+    /home/ron/.gvm/gos/go1.23/src/math/bits/bits.go:472:10: interp: running for more than 3m0s, timing out (executed calls: 28856372)
+      %0 = and i64 %x, 4294967295, !dbg !30909
     
-    runtime stack:
-    runtime.throw({0x7e48c2?, 0xfffee2c86230?})
-    	/usr/local/go/src/runtime/panic.go:1047 +0x40 fp=0xfffee2c85ed0 sp=0xfffee2c85ea0 pc=0x44fa50
-    runtime.sigpanic()
-    	/usr/local/go/src/runtime/signal_unix.go:821 +0x240 fp=0xfffee2c85f10 sp=0xfffee2c85ed0 pc=0x466a90
-    
-    goroutine 8 [syscall]:
-    runtime.cgocall(0x72cb60, 0x400bb79bf8)
-    	/usr/local/go/src/runtime/cgocall.go:157 +0x50 fp=0x400bb79bc0 sp=0x400bb79b80 pc=0x4203e0
+    traceback:
+    /home/ron/.gvm/gos/go1.23/src/math/bits/bits.go:472:10:
+      %0 = and i64 %x, 4294967295, !dbg !30909
+    /home/ron/.gvm/gos/go1.23/src/math/bits/bits.go:450:15:
+      %9 = call { i64, i64 } @"math/bits.Mul64"(i64 %x, i64 %y, ptr undef), !dbg !30917
+    /home/ron/.gvm/gos/go1.23/src/math/big/arith.go:51:20:
+      %0 = call { i64, i64 } @"math/bits.Mul"(i64 %x, i64 %y, ptr undef), !dbg !30904
+    /home/ron/.gvm/gos/go1.23/src/math/big/arith.go:192:24:
+      %13 = call { i64, i64 } @"math/big.mulAddWWW_g"(i64 %12, i64 %y, i64 %6, ptr undef), !dbg !30922
+    /home/ron/.gvm/gos/go1.23/src/math/big/arith_decl_pure.go:44:20:
     [...more lines following...]
 
 
@@ -1248,8 +1160,9 @@ The compiler gave the following error when running the tests for this package:
 The compiler gave the following error when running the tests for this package:
 
 
-    panic: runtime error at 0x0000000000246ace: divide by zero
-    FAIL	math/bits	1.337s
+    [tinygo: panic at /home/ron/.gvm/gos/go1.23/src/math/bits/bits.go:510:21]
+    panic: runtime error at 0x000000000021dde5: divide by zero
+    FAIL	math/bits	0.002s
 
 
 
@@ -1266,22 +1179,26 @@ The compiler gave the following error when running the tests for this package:
 
 
     panic: unimplemented: (reflect.Type).Method()
-    FAIL	math/rand	26.906s
+    FAIL	math/rand	1.890s
 
 
 
 
 
 
-## mime
+## math/rand/v2
 
 
 
 The compiler gave the following error when running the tests for this package:
 
 
-    panic: runtime error at 0x000000000022dc26: deadlocked: no event source
-    FAIL	mime	1.292s
+    FAIL	math/rand/v2	0.000s
+    /home/ron/.gvm/gos/go1.23/src/internal/chacha8rand/chacha8.go:66: linker could not find symbol internal/chacha8rand.block
+    /home/ron/.gvm/gos/go1.23/src/internal/chacha8rand/chacha8.go:91: linker could not find symbol internal/chacha8rand.block
+    /home/ron/.gvm/gos/go1.23/src/internal/chacha8rand/chacha8.go:153: linker could not find symbol internal/chacha8rand.block
+
+
 
 
 
@@ -1299,7 +1216,6 @@ The compiler gave the following error when running the tests for this package:
 
 This package cannot be imported because the following dependencies cannot be compiled:
 
-  * [crypto/tls](#cryptotls)
   * [net/http/httptrace](#nethttphttptrace)
 
 
@@ -1311,7 +1227,6 @@ This package cannot be imported because the following dependencies cannot be com
 
 This package cannot be imported because the following dependencies cannot be compiled:
 
-  * [crypto/tls](#cryptotls)
   * [net/http](#nethttp)
 
 
@@ -1346,8 +1261,6 @@ This package cannot be imported because the following dependencies cannot be com
 
 This package cannot be imported because the following dependencies cannot be compiled:
 
-  * [crypto/tls](#cryptotls)
-  * [crypto/x509](#cryptox509)
   * [net/http](#nethttp)
 
 
@@ -1357,9 +1270,12 @@ This package cannot be imported because the following dependencies cannot be com
 ## net/http/httptrace
 
 
-This package cannot be imported because the following dependencies cannot be compiled:
 
-  * [crypto/tls](#cryptotls)
+The compiler gave the following error when this package was imported:
+
+
+    ../../../../../tmp/tinygo-test-713677031/main.go:2:8: package net/http/httptrace is not in std (/home/ron/.cache/tinygo/goroot-8dfa52493353b482ef2f92e428ccd70087bafb9ea49be4487874c40c866336de/src/net/http/httptrace)
+
 
 
 
@@ -1397,9 +1313,22 @@ This package cannot be imported because the following dependencies cannot be com
 The compiler gave the following error when running the tests for this package:
 
 
-    FAIL	net/netip	0.000s
-    # net/netip_test
-    /usr/local/go1.20/src/net/netip/fuzz_test.go:177:32: stdip.IsPrivate undefined (type net.IP has no field or method IsPrivate)
+    --- FAIL: TestInlining (0.00s)
+        skipping test: 'go build' unavailable: /home/ron/.gvm/gos/go1.23/bin/go tool -n compile: fork/exec /home/ron/.gvm/gos/go1.23/bin/go: operation not implemented
+        SkipNow is incomplete, requires runtime.Goexit()
+        skipping test: 'go build' unavailable: /home/ron/.gvm/gos/go1.23/bin/go tool -n compile: fork/exec /home/ron/.gvm/gos/go1.23/bin/go: operation not implemented
+        SkipNow is incomplete, requires runtime.Goexit()
+        platform cannot run go tool
+        FailNow is incomplete, requires runtime.Goexit()
+        go build: exec: no command, 
+        FailNow is incomplete, requires runtime.Goexit()
+        "(*uint128).halves" is no longer inlinable
+        "Addr.BitLen" is no longer inlinable
+        "Addr.hasZone" is no longer inlinable
+        "Addr.Is4" is no longer inlinable
+        "Addr.Is4In6" is no longer inlinable
+        "Addr.Is6" is no longer inlinable
+    [...more lines following...]
 
 
 
@@ -1431,9 +1360,14 @@ This package cannot be imported because the following dependencies cannot be com
 ## net/smtp
 
 
-This package cannot be imported because the following dependencies cannot be compiled:
 
-  * [crypto/tls](#cryptotls)
+The compiler gave the following error when this package was imported:
+
+
+    # net/smtp
+    /home/ron/.gvm/gos/go1.23/src/net/smtp/smtp.go:72:24: undefined: tls.Conn
+    /home/ron/.gvm/gos/go1.23/src/net/smtp/smtp.go:172:25: undefined: tls.Conn
+
 
 
 
@@ -1449,7 +1383,7 @@ The compiler gave the following error when running the tests for this package:
 
 
     panic: reflect: unimplemented: AssignableTo with interface
-    FAIL	net/url	1.292s
+    FAIL	net/url	0.001s
 
 
 
@@ -1465,9 +1399,8 @@ The compiler gave the following error when running the tests for this package:
 The compiler gave the following error when running the tests for this package:
 
 
-    FAIL	os/exec	0.000s
-    # os/user
-    ../../../../../../usr/local/go1.20/src/os/user/cgo_lookup_cgo.go:14:6: not implemented: build constraints in #cgo line
+    FAIL		0.000s
+    /home/ron/.gvm/gos/go1.23/src/os/exec/exec_test.go:23:2: package net/http/httptest is not in std (/home/ron/.cache/tinygo/goroot-8dfa52493353b482ef2f92e428ccd70087bafb9ea49be4487874c40c866336de/src/net/http/httptest)
 
 
 
@@ -1483,23 +1416,10 @@ The compiler gave the following error when running the tests for this package:
 
     FAIL	os/signal	0.000s
     # internal/testpty
-    ../../tinygo/lib/musl/include/fcntl.h:22:10: fatal: 'bits/fcntl.h' file not found
-    ../../../../../../usr/local/go1.20/src/internal/testpty/pty_cgo.go:11:10: note: in file included from pty_cgo.go!cgo.c:4:
+    /home/ron/.gvm/gos/go1.23/src/internal/testpty/pty_cgo.go:11:10: note: in file included from pty_cgo.go!cgo.c:4:
+    ../../tinygo/tinygo-122/lib/musl/include/fcntl.h:22:10: fatal: 'bits/fcntl.h' file not found
 
 
-
-
-
-
-## os/user
-
-
-
-The compiler gave the following error when this package was imported:
-
-
-    # os/user
-    ../../../../../../usr/local/go1.20/src/os/user/cgo_lookup_cgo.go:14:6: not implemented: build constraints in #cgo line
 
 
 
@@ -1515,7 +1435,7 @@ The compiler gave the following error when this package was imported:
 The compiler gave the following error when running the tests for this package:
 
 
-    FAIL	path/filepath	1.372s
+    FAIL	path/filepath	0.002s
 
 
 
@@ -1530,7 +1450,7 @@ The compiler gave the following error when this package was imported:
 
 
     # plugin
-    ../../../../../../usr/local/go1.20/src/plugin/plugin_dlopen.go:10:6: not implemented: build constraints in #cgo line
+    /home/ron/.gvm/gos/go1.23/src/plugin/plugin_dlopen.go:10:6: not implemented: build constraints in #cgo line
 
 
 
@@ -1546,9 +1466,25 @@ The compiler gave the following error when this package was imported:
 The compiler gave the following error when running the tests for this package:
 
 
-    FAIL	regexp	10.812s
+    FAIL	regexp	2.220s
 
 
+
+
+
+
+
+
+## slices
+
+
+
+The compiler gave the following error when running the tests for this package:
+
+
+    [tinygo: panic at /home/ron/.gvm/gos/go1.23/src/slices/slices.go]
+    panic: runtime error at 0x000000000027fd24: slice out of range
+    FAIL	slices	0.007s
 
 
 
@@ -1562,19 +1498,19 @@ The compiler gave the following error when running the tests for this package:
 The compiler gave the following error when running the tests for this package:
 
 
-    --- FAIL: TestCountStableOps (9.51s)
+    --- FAIL: TestCountStableOps (1.06s)
         Counting skipped as non-verbose mode.
         SkipNow is incomplete, requires runtime.Goexit()
-        Stable      100 elements:         930 Swap,        820 Less
-        Stable      300 elements:        3937 Swap,       2993 Less
-        Stable     1000 elements:       19510 Swap,      12224 Less
-        Stable     3000 elements:       82341 Swap,      43082 Less
-        Stable    10000 elements:      349590 Swap,     165816 Less
-        Stable    30000 elements:     1341046 Swap,     558467 Less
-        Stable   100000 elements:     5787139 Swap,    2084649 Less
-        Stable   300000 elements:    20447012 Swap,    6868979 Less
-        Stable  1000000 elements:    84481603 Swap,   25116491 Less
-    --- FAIL: TestCountSortOps (1.47s)
+        Stable      100 elements:         936 Swap,        803 Less
+        Stable      300 elements:        4036 Swap,       3116 Less
+        Stable     1000 elements:       19431 Swap,      12165 Less
+        Stable     3000 elements:       82543 Swap,      43007 Less
+        Stable    10000 elements:      348377 Swap,     165656 Less
+        Stable    30000 elements:     1341022 Swap,     558390 Less
+        Stable   100000 elements:     5786769 Swap,    2084974 Less
+        Stable   300000 elements:    20452019 Swap,    6869316 Less
+        Stable  1000000 elements:    84471267 Swap,   25121542 Less
+    --- FAIL: TestCountSortOps (0.61s)
         Counting skipped as non-verbose mode.
         SkipNow is incomplete, requires runtime.Goexit()
     [...more lines following...]
@@ -1593,15 +1529,11 @@ The compiler gave the following error when running the tests for this package:
 The compiler gave the following error when running the tests for this package:
 
 
-    --- FAIL: TestBuilderGrow (0.18s)
-        growLen=100: got 0 allocs during Write; want 1
-        growLen=1000: got 0 allocs during Write; want 1
-        growLen=10000: got 0 allocs during Write; want 1
-        growLen=100000: got 0 allocs during Write; want 1
-    --- FAIL: TestBuilderAllocs (0.02s)
-        Builder allocs = 0; want 1
-    FAIL
-    FAIL	strings	40.097s
+    [tinygo: panic at /home/ron/Development/tinygo/tinygo-122/src/internal/bytealg/bytealg.go:304:13]
+    panic: runtime error at 0x000000000022b226: out of memory
+    FAIL	strings	8.086s
+
+
 
 
 
@@ -1617,7 +1549,9 @@ The compiler gave the following error when running the tests for this package:
 The compiler gave the following error when running the tests for this package:
 
 
-    FAIL	sync/atomic	5.916s
+    [tinygo: panic at /home/ron/.gvm/gos/go1.23/src/sync/atomic/doc.go:94:6]
+    panic: runtime error at 0x00000000002502e8: caught signal SIGSEGV
+    FAIL	sync/atomic	0.939s
 
 
 
@@ -1632,12 +1566,31 @@ The compiler gave the following error when running the tests for this package:
 
 
     FAIL	syscall	0.000s
-    # os/user
-    ../../../../../../usr/local/go1.20/src/os/user/cgo_lookup_cgo.go:14:6: not implemented: build constraints in #cgo line
+    # syscall_test
+    /home/ron/.gvm/gos/go1.23/src/syscall/creds_test.go:53:19: undefined: net.FileConn
+    /home/ron/.gvm/gos/go1.23/src/syscall/creds_test.go:60:19: undefined: net.FileConn
+    /home/ron/.gvm/gos/go1.23/src/syscall/exec_linux_test.go:712:14: f.Chmod undefined (type *os.File has no field or method Chmod)
+    /home/ron/.gvm/gos/go1.23/src/syscall/syscall_unix_test.go:183:16: undefined: net.FileConn
+    /home/ron/.gvm/gos/go1.23/src/syscall/syscall_unix_test.go:238:14: undefined: net.UnixConn
+    /home/ron/.gvm/gos/go1.23/src/syscall/syscall_unix_test.go:242:18: undefined: net.FileConn
 
 
 
 
+
+
+
+
+## testing/fstest
+
+
+
+The compiler gave the following error when running the tests for this package:
+
+
+    [tinygo: panic at <Go interface method>]
+    panic: runtime error at 0x000000000022291a: nil pointer dereference
+    FAIL	testing/fstest	0.007s
 
 
 
@@ -1654,7 +1607,22 @@ The compiler gave the following error when running the tests for this package:
 
 
     panic: unimplemented: (reflect.Type).NumIn()
-    FAIL	testing/quick	0.972s
+    FAIL	testing/quick	0.001s
+
+
+
+
+
+
+## testing/slogtest
+
+
+
+The compiler gave the following error when running the tests for this package:
+
+
+    panic: runtime.Caller failed
+    FAIL	testing/slogtest	0.000s
 
 
 
@@ -1673,7 +1641,7 @@ The compiler gave the following error when running the tests for this package:
 
 
     panic: unimplemented: (reflect.Type).NumOut()
-    FAIL	text/template	1.088s
+    FAIL	text/template	0.001s
 
 
 
@@ -1691,12 +1659,12 @@ The compiler gave the following error when running the tests for this package:
 
     FAIL	time	0.000s
     # time_test
-    /usr/local/go1.20/src/time/sleep_test.go:714:4: b.ReportMetric undefined (type *testing.B has no field or method ReportMetric)
-    /usr/local/go1.20/src/time/sleep_test.go:715:4: b.ReportMetric undefined (type *testing.B has no field or method ReportMetric)
-    /usr/local/go1.20/src/time/sleep_test.go:716:4: b.ReportMetric undefined (type *testing.B has no field or method ReportMetric)
-    /usr/local/go1.20/src/time/sleep_test.go:787:8: b.ReportMetric undefined (type *testing.B has no field or method ReportMetric)
-    /usr/local/go1.20/src/time/sleep_test.go:788:8: b.ReportMetric undefined (type *testing.B has no field or method ReportMetric)
-    /usr/local/go1.20/src/time/sleep_test.go:789:8: b.ReportMetric undefined (type *testing.B has no field or method ReportMetric)
+    /home/ron/.gvm/gos/go1.23/src/time/sleep_test.go:866:4: b.ReportMetric undefined (type *testing.B has no field or method ReportMetric)
+    /home/ron/.gvm/gos/go1.23/src/time/sleep_test.go:867:4: b.ReportMetric undefined (type *testing.B has no field or method ReportMetric)
+    /home/ron/.gvm/gos/go1.23/src/time/sleep_test.go:868:4: b.ReportMetric undefined (type *testing.B has no field or method ReportMetric)
+    /home/ron/.gvm/gos/go1.23/src/time/sleep_test.go:939:8: b.ReportMetric undefined (type *testing.B has no field or method ReportMetric)
+    /home/ron/.gvm/gos/go1.23/src/time/sleep_test.go:940:8: b.ReportMetric undefined (type *testing.B has no field or method ReportMetric)
+    /home/ron/.gvm/gos/go1.23/src/time/sleep_test.go:941:8: b.ReportMetric undefined (type *testing.B has no field or method ReportMetric)
 
 
 
@@ -1710,10 +1678,9 @@ The compiler gave the following error when running the tests for this package:
 The compiler gave the following error when this package was imported:
 
 
-    ld.lld: error: undefined symbol: time.registerLoadFromEmbeddedTZData
-    >>> referenced by scheduler_any.go:24 (/home/ayke/src/tinygo/tinygo/src/runtime/scheduler_any.go:24)
-    >>>               /home/ayke/.cache/tinygo/thinlto/llvmcache-809755382705B4E52ACE223C1D98D60EC110E4FB:(runtime.run$1$gowrapper)
-    error: failed to link /tmp/tinygo4244802663/main: exit status 1
+    /home/ron/Development/tinygo/tinygo-122/src/runtime/scheduler_any.go:24: linker could not find symbol time.registerLoadFromEmbeddedTZData
+
+
 
 
 


### PR DESCRIPTION
This PR updates the `lang-support` info based on the latest TinyGo 0.33 with Go 1.23

Note the vastly improved errors displayed for the packages that are still not fully working. Good job on that @aykevl thank you!