### PR TITLE
content: update references for all microcontrollers info for TinyGo 0.33

### DIFF
--- a/content/docs/reference/microcontrollers/badger2040.md
+++ b/content/docs/reference/microcontrollers/badger2040.md
@@ -35,15 +35,15 @@ The [Pimoroni Badger2040](https://shop.pimoroni.com/products/badger-2040) is a b
 | `EPD_SCK_PIN`     | `GPIO18`     | `SPI0_SCK_PIN`    | `PWM1` (channel A)   |
 | `EPD_SDO_PIN`     | `GPIO19`     | `SPI0_SDO_PIN`    | `PWM1` (channel B)   |
 | `VBUS_DETECT`     | `GPIO24`     |                   | `PWM4` (channel A)   |
-| `BATTERY`         | `GPIO29`     | `ADC3`            | `PWM6` (channel B)   |
+| `VREF_POWER`      | `GPIO27`     | `ADC1`            | `PWM5` (channel B)   |
+| `VREF_1V24`       | `GPIO28`     | `ADC2`            | `PWM6` (channel A)   |
+| `VBAT_SENSE`      | `GPIO29`     | `BATTERY`, `ADC3` | `PWM6` (channel B)   |
 | `ENABLE_3V3`      | `GPIO10`     |                   | `PWM5` (channel A)   |
 | `I2C0_SDA_PIN`    | `GPIO4`      |                   | `PWM2` (channel A)   |
 | `I2C0_SCL_PIN`    | `GPIO5`      |                   | `PWM2` (channel B)   |
 | `SPI0_SDI_PIN`    | `GPIO16`     |                   | `PWM0` (channel A)   |
 | `UART0_TX_PIN`    | `GPIO0`      | `UART_TX_PIN`     | `PWM0` (channel A)   |
 | `UART0_RX_PIN`    | `GPIO1`      | `UART_RX_PIN`     | `PWM0` (channel B)   |
-| `ADC1`            | `GPIO27`     |                   | `PWM5` (channel B)   |
-| `ADC2`            | `GPIO28`     |                   | `PWM6` (channel A)   |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/esp32-coreboard-v2.md
+++ b/content/docs/reference/microcontrollers/esp32-coreboard-v2.md
@@ -12,7 +12,7 @@ The esp32-coreboard-v2 is a development board based on the [Espressif ESP32](htt
 | GPIO      | YES | YES |
 | UART      | YES | YES |
 | SPI       | YES | YES |
-| I2C       | YES | Not yet |
+| I2C       | YES | YES |
 | ADC       | YES | Not yet |
 | PWM       | YES | Not yet |
 | USBDevice | NO  | NO  |

--- a/content/docs/reference/microcontrollers/esp32-mini32.md
+++ b/content/docs/reference/microcontrollers/esp32-mini32.md
@@ -12,7 +12,7 @@ The mini32 is a small development board based on the popular [Espressif ESP32](h
 | GPIO      | YES | YES |
 | UART      | YES | YES |
 | SPI       | YES | YES |
-| I2C       | YES | Not yet |
+| I2C       | YES | YES |
 | ADC       | YES | Not yet |
 | PWM       | YES | Not yet |
 | USBDevice | NO  | NO  |

--- a/content/docs/reference/microcontrollers/m5stack-core2.md
+++ b/content/docs/reference/microcontrollers/m5stack-core2.md
@@ -12,7 +12,7 @@ The [m5stack-core2](https://shop.m5stack.com/products/m5stack-core2-esp32-iot-de
 | GPIO      | YES | YES |
 | UART      | YES | YES |
 | SPI       | YES | YES |
-| I2C       | YES | Not yet |
+| I2C       | YES | YES |
 | ADC       | YES | Not yet |
 | PWM       | YES | Not yet |
 | USBDevice | NO  | NO  |

--- a/content/docs/reference/microcontrollers/m5stack.md
+++ b/content/docs/reference/microcontrollers/m5stack.md
@@ -12,7 +12,7 @@ The [m5stack](https://docs.m5stack.com/en/core/basic) is a development board bas
 | GPIO      | YES | YES |
 | UART      | YES | YES |
 | SPI       | YES | YES |
-| I2C       | YES | Not yet |
+| I2C       | YES | YES |
 | ADC       | YES | Not yet |
 | PWM       | YES | Not yet |
 | USBDevice | NO  | NO  |

--- a/content/docs/reference/microcontrollers/machine/arduino-mega1280.md
+++ b/content/docs/reference/microcontrollers/machine/arduino-mega1280.md
@@ -1065,7 +1065,7 @@ Transfer writes the byte into the register and returns the read content
 func (spi SPI) Tx(w, r []byte) error
 ```
 
-Tx handles read/write operation for SPI interface. Since SPI is a syncronous write/read
+Tx handles read/write operation for SPI interface. Since SPI is a synchronous write/read
 interface, there must always be the same number of bytes written as bytes read.
 The Tx method knows about this, and offers a few different ways of calling it.
 

--- a/content/docs/reference/microcontrollers/machine/arduino-mega2560.md
+++ b/content/docs/reference/microcontrollers/machine/arduino-mega2560.md
@@ -980,7 +980,7 @@ Transfer writes the byte into the register and returns the read content
 func (spi SPI) Tx(w, r []byte) error
 ```
 
-Tx handles read/write operation for SPI interface. Since SPI is a syncronous write/read
+Tx handles read/write operation for SPI interface. Since SPI is a synchronous write/read
 interface, there must always be the same number of bytes written as bytes read.
 The Tx method knows about this, and offers a few different ways of calling it.
 

--- a/content/docs/reference/microcontrollers/machine/arduino-mkr1000.md
+++ b/content/docs/reference/microcontrollers/machine/arduino-mkr1000.md
@@ -513,7 +513,7 @@ func EnableCDC(txHandler func(), rxHandler func([]byte), setupHandler func(usb.S
 func EnterBootloader()
 ```
 
-EnterBootloader should perform a system reset in preperation
+EnterBootloader should perform a system reset in preparation
 to switch to the bootloader to flash new firmware.
 
 
@@ -1292,7 +1292,7 @@ Transfer writes/reads a single byte using the SPI interface.
 func (spi SPI) Tx(w, r []byte) error
 ```
 
-Tx handles read/write operation for SPI interface. Since SPI is a syncronous write/read
+Tx handles read/write operation for SPI interface. Since SPI is a synchronous write/read
 interface, there must always be the same number of bytes written as bytes read.
 The Tx method knows about this, and offers a few different ways of calling it.
 

--- a/content/docs/reference/microcontrollers/machine/arduino-mkrwifi1010.md
+++ b/content/docs/reference/microcontrollers/machine/arduino-mkrwifi1010.md
@@ -566,7 +566,7 @@ func EnableCDC(txHandler func(), rxHandler func([]byte), setupHandler func(usb.S
 func EnterBootloader()
 ```
 
-EnterBootloader should perform a system reset in preperation
+EnterBootloader should perform a system reset in preparation
 to switch to the bootloader to flash new firmware.
 
 
@@ -1345,7 +1345,7 @@ Transfer writes/reads a single byte using the SPI interface.
 func (spi SPI) Tx(w, r []byte) error
 ```
 
-Tx handles read/write operation for SPI interface. Since SPI is a syncronous write/read
+Tx handles read/write operation for SPI interface. Since SPI is a synchronous write/read
 interface, there must always be the same number of bytes written as bytes read.
 The Tx method knows about this, and offers a few different ways of calling it.
 

--- a/content/docs/reference/microcontrollers/machine/arduino-nano.md
+++ b/content/docs/reference/microcontrollers/machine/arduino-nano.md
@@ -1030,7 +1030,7 @@ Transfer writes the byte into the register and returns the read content
 func (spi SPI) Tx(w, r []byte) error
 ```
 
-Tx handles read/write operation for SPI interface. Since SPI is a syncronous write/read
+Tx handles read/write operation for SPI interface. Since SPI is a synchronous write/read
 interface, there must always be the same number of bytes written as bytes read.
 The Tx method knows about this, and offers a few different ways of calling it.
 

--- a/content/docs/reference/microcontrollers/machine/arduino-nano33.md
+++ b/content/docs/reference/microcontrollers/machine/arduino-nano33.md
@@ -589,7 +589,7 @@ func EnableCDC(txHandler func(), rxHandler func([]byte), setupHandler func(usb.S
 func EnterBootloader()
 ```
 
-EnterBootloader should perform a system reset in preperation
+EnterBootloader should perform a system reset in preparation
 to switch to the bootloader to flash new firmware.
 
 
@@ -1368,7 +1368,7 @@ Transfer writes/reads a single byte using the SPI interface.
 func (spi SPI) Tx(w, r []byte) error
 ```
 
-Tx handles read/write operation for SPI interface. Since SPI is a syncronous write/read
+Tx handles read/write operation for SPI interface. Since SPI is a synchronous write/read
 interface, there must always be the same number of bytes written as bytes read.
 The Tx method knows about this, and offers a few different ways of calling it.
 

--- a/content/docs/reference/microcontrollers/machine/arduino-zero.md
+++ b/content/docs/reference/microcontrollers/machine/arduino-zero.md
@@ -541,7 +541,7 @@ func EnableCDC(txHandler func(), rxHandler func([]byte), setupHandler func(usb.S
 func EnterBootloader()
 ```
 
-EnterBootloader should perform a system reset in preperation
+EnterBootloader should perform a system reset in preparation
 to switch to the bootloader to flash new firmware.
 
 
@@ -1320,7 +1320,7 @@ Transfer writes/reads a single byte using the SPI interface.
 func (spi SPI) Tx(w, r []byte) error
 ```
 
-Tx handles read/write operation for SPI interface. Since SPI is a syncronous write/read
+Tx handles read/write operation for SPI interface. Since SPI is a synchronous write/read
 interface, there must always be the same number of bytes written as bytes read.
 The Tx method knows about this, and offers a few different ways of calling it.
 

--- a/content/docs/reference/microcontrollers/machine/arduino.md
+++ b/content/docs/reference/microcontrollers/machine/arduino.md
@@ -1030,7 +1030,7 @@ Transfer writes the byte into the register and returns the read content
 func (spi SPI) Tx(w, r []byte) error
 ```
 
-Tx handles read/write operation for SPI interface. Since SPI is a syncronous write/read
+Tx handles read/write operation for SPI interface. Since SPI is a synchronous write/read
 interface, there must always be the same number of bytes written as bytes read.
 The Tx method knows about this, and offers a few different ways of calling it.
 

--- a/content/docs/reference/microcontrollers/machine/atsame54-xpro.md
+++ b/content/docs/reference/microcontrollers/machine/atsame54-xpro.md
@@ -1175,6 +1175,15 @@ The Tx transmits CAN frames. It is easier to use than TxRaw, but not as
 flexible.
 
 
+### func (*CAN) TxFifoFreeLevel
+
+```go
+func (can *CAN) TxFifoFreeLevel() int
+```
+
+TxFifoFreeLevel returns how many messages can still be set in the TxFifo.
+
+
 ### func (*CAN) TxFifoIsFull
 
 ```go
@@ -1868,7 +1877,7 @@ Transfer writes/reads a single byte using the SPI interface.
 func (spi SPI) Tx(w, r []byte) error
 ```
 
-Tx handles read/write operation for SPI interface. Since SPI is a syncronous write/read
+Tx handles read/write operation for SPI interface. Since SPI is a synchronous write/read
 interface, there must always be the same number of bytes written as bytes read.
 The Tx method knows about this, and offers a few different ways of calling it.
 

--- a/content/docs/reference/microcontrollers/machine/badger2040.md
+++ b/content/docs/reference/microcontrollers/machine/badger2040.md
@@ -25,8 +25,12 @@ const (
 	EPD_SDO_PIN	Pin	= GPIO19
 
 	VBUS_DETECT	Pin	= GPIO24
-	BATTERY		Pin	= GPIO29
+	VREF_POWER	Pin	= GPIO27
+	VREF_1V24	Pin	= GPIO28
+	VBAT_SENSE	Pin	= GPIO29
 	ENABLE_3V3	Pin	= GPIO10
+
+	BATTERY	= VBAT_SENSE
 )
 ```
 
@@ -1400,7 +1404,7 @@ Write a single byte and read a single byte from TX/RX FIFO.
 func (spi SPI) Tx(w, r []byte) (err error)
 ```
 
-Tx handles read/write operation for SPI interface. Since SPI is a syncronous write/read
+Tx handles read/write operation for SPI interface. Since SPI is a synchronous write/read
 interface, there must always be the same number of bytes written as bytes read.
 The Tx method knows about this, and offers a few different ways of calling it.
 

--- a/content/docs/reference/microcontrollers/machine/bluepill.md
+++ b/content/docs/reference/microcontrollers/machine/bluepill.md
@@ -1288,7 +1288,7 @@ Transfer writes/reads a single byte using the SPI interface.
 func (spi SPI) Tx(w, r []byte) error
 ```
 
-Tx handles read/write operation for SPI interface. Since SPI is a syncronous write/read
+Tx handles read/write operation for SPI interface. Since SPI is a synchronous write/read
 interface, there must always be the same number of bytes written as bytes read.
 The Tx method knows about this, and offers a few different ways of calling it.
 

--- a/content/docs/reference/microcontrollers/machine/challenger-rp2040.md
+++ b/content/docs/reference/microcontrollers/machine/challenger-rp2040.md
@@ -1439,7 +1439,7 @@ Write a single byte and read a single byte from TX/RX FIFO.
 func (spi SPI) Tx(w, r []byte) (err error)
 ```
 
-Tx handles read/write operation for SPI interface. Since SPI is a syncronous write/read
+Tx handles read/write operation for SPI interface. Since SPI is a synchronous write/read
 interface, there must always be the same number of bytes written as bytes read.
 The Tx method knows about this, and offers a few different ways of calling it.
 

--- a/content/docs/reference/microcontrollers/machine/circuitplay-bluefruit.md
+++ b/content/docs/reference/microcontrollers/machine/circuitplay-bluefruit.md
@@ -1326,7 +1326,7 @@ Transfer writes/reads a single byte using the SPI interface.
 func (spi SPI) Tx(w, r []byte) error
 ```
 
-Tx handles read/write operation for SPI interface. Since SPI is a syncronous
+Tx handles read/write operation for SPI interface. Since SPI is a synchronous
 write/read interface, there must always be the same number of bytes written
 as bytes read. Therefore, if the number of bytes don't match it will be
 padded until they fit: if len(w) > len(r) the extra bytes received will be

--- a/content/docs/reference/microcontrollers/machine/circuitplay-express.md
+++ b/content/docs/reference/microcontrollers/machine/circuitplay-express.md
@@ -556,7 +556,7 @@ func EnableCDC(txHandler func(), rxHandler func([]byte), setupHandler func(usb.S
 func EnterBootloader()
 ```
 
-EnterBootloader should perform a system reset in preperation
+EnterBootloader should perform a system reset in preparation
 to switch to the bootloader to flash new firmware.
 
 
@@ -1335,7 +1335,7 @@ Transfer writes/reads a single byte using the SPI interface.
 func (spi SPI) Tx(w, r []byte) error
 ```
 
-Tx handles read/write operation for SPI interface. Since SPI is a syncronous write/read
+Tx handles read/write operation for SPI interface. Since SPI is a synchronous write/read
 interface, there must always be the same number of bytes written as bytes read.
 The Tx method knows about this, and offers a few different ways of calling it.
 

--- a/content/docs/reference/microcontrollers/machine/clue.md
+++ b/content/docs/reference/microcontrollers/machine/clue.md
@@ -1352,7 +1352,7 @@ Transfer writes/reads a single byte using the SPI interface.
 func (spi SPI) Tx(w, r []byte) error
 ```
 
-Tx handles read/write operation for SPI interface. Since SPI is a syncronous
+Tx handles read/write operation for SPI interface. Since SPI is a synchronous
 write/read interface, there must always be the same number of bytes written
 as bytes read. Therefore, if the number of bytes don't match it will be
 padded until they fit: if len(w) > len(r) the extra bytes received will be

--- a/content/docs/reference/microcontrollers/machine/esp32-coreboard-v2.md
+++ b/content/docs/reference/microcontrollers/machine/esp32-coreboard-v2.md
@@ -124,6 +124,49 @@ PWM pins
 
 
 ```go
+const (
+	TWI_FREQ_100KHZ	= 100000
+	TWI_FREQ_400KHZ	= 400000
+)
+```
+
+TWI_FREQ is the I2C bus speed. Normally either 100 kHz, or 400 kHz for high-speed bus.
+
+Deprecated: use 100 * machine.KHz or 400 * machine.KHz instead.
+
+
+```go
+const (
+	// I2CReceive indicates target has received a message from the controller.
+	I2CReceive	I2CTargetEvent	= iota
+
+	// I2CRequest indicates the controller is expecting a message from the target.
+	I2CRequest
+
+	// I2CFinish indicates the controller has ended the transaction.
+	//
+	// I2C controllers can chain multiple receive/request messages without
+	// relinquishing the bus by doing 'restarts'.  I2CFinish indicates the
+	// bus has been relinquished by an I2C 'stop'.
+	I2CFinish
+)
+```
+
+
+
+```go
+const (
+	// I2CModeController represents an I2C peripheral in controller mode.
+	I2CModeController	I2CMode	= iota
+
+	// I2CModeTarget represents an I2C peripheral in target mode.
+	I2CModeTarget
+)
+```
+
+
+
+```go
 const Device = deviceName
 ```
 
@@ -295,6 +338,15 @@ var (
 
 ```go
 var (
+	I2C0	= &I2C{Bus: esp.I2C0, funcSCL: 29, funcSDA: 30}
+	I2C1	= &I2C{Bus: esp.I2C1, funcSCL: 95, funcSDA: 96}
+)
+```
+
+
+
+```go
+var (
 	ErrPWMPeriodTooLong = errors.New("pwm: period too long")
 )
 ```
@@ -375,6 +427,127 @@ type ADCConfig struct {
 
 ADCConfig holds ADC configuration parameters. If left unspecified, the zero
 value of each parameter will use the peripheral's default settings.
+
+
+
+
+
+## type I2C
+
+```go
+type I2C struct {
+	Bus			*esp.I2C_Type
+	funcSCL, funcSDA	uint32
+	config			I2CConfig
+}
+```
+
+
+
+
+### func (*I2C) CheckDevice
+
+```go
+func (i2c *I2C) CheckDevice(addr uint16) bool
+```
+
+CheckDevice does an empty I2C transaction at the specified address.
+This can be used to find out if any device with that address is
+connected, e.g. for enumerating all devices on the bus.
+
+
+### func (*I2C) Configure
+
+```go
+func (i2c *I2C) Configure(config I2CConfig) error
+```
+
+
+
+### func (*I2C) ReadRegister
+
+```go
+func (i2c *I2C) ReadRegister(address uint8, register uint8, data []byte) error
+```
+
+ReadRegister transmits the register, restarts the connection as a read
+operation, and reads the response.
+
+Many I2C-compatible devices are organized in terms of registers. This method
+is a shortcut to easily read such registers. Also, it only works for devices
+with 7-bit addresses, which is the vast majority.
+
+
+### func (*I2C) SetBaudRate
+
+```go
+func (i2c *I2C) SetBaudRate(br uint32) error
+```
+
+
+
+### func (*I2C) Tx
+
+```go
+func (i2c *I2C) Tx(addr uint16, w, r []byte) (err error)
+```
+
+Tx does a single I2C transaction at the specified address.
+It clocks out the given address, writes the bytes in w, reads back len(r)
+bytes and stores them in r, and generates a stop condition on the bus.
+
+
+### func (*I2C) WriteRegister
+
+```go
+func (i2c *I2C) WriteRegister(address uint8, register uint8, data []byte) error
+```
+
+WriteRegister transmits first the register and then the data to the
+peripheral device.
+
+Many I2C-compatible devices are organized in terms of registers. This method
+is a shortcut to easily write to such registers. Also, it only works for
+devices with 7-bit addresses, which is the vast majority.
+
+
+
+
+## type I2CConfig
+
+```go
+type I2CConfig struct {
+	Frequency	uint32	// in Hz
+	SCL		Pin
+	SDA		Pin
+}
+```
+
+I2CConfig is used to store config info for I2C.
+
+
+
+
+
+## type I2CMode
+
+```go
+type I2CMode int
+```
+
+I2CMode determines if an I2C peripheral is in Controller or Target mode.
+
+
+
+
+
+## type I2CTargetEvent
+
+```go
+type I2CTargetEvent uint8
+```
+
+I2CTargetEvent reflects events on the I2C bus
 
 
 
@@ -687,7 +860,7 @@ transfer larger amounts of data, Tx will be faster.
 func (spi SPI) Tx(w, r []byte) error
 ```
 
-Tx handles read/write operation for SPI interface. Since SPI is a syncronous write/read
+Tx handles read/write operation for SPI interface. Since SPI is a synchronous write/read
 interface, there must always be the same number of bytes written as bytes read.
 This is accomplished by sending zero bits if r is bigger than w or discarding
 the incoming data if w is bigger than r.

--- a/content/docs/reference/microcontrollers/machine/esp32-mini32.md
+++ b/content/docs/reference/microcontrollers/machine/esp32-mini32.md
@@ -124,6 +124,49 @@ PWM pins
 
 
 ```go
+const (
+	TWI_FREQ_100KHZ	= 100000
+	TWI_FREQ_400KHZ	= 400000
+)
+```
+
+TWI_FREQ is the I2C bus speed. Normally either 100 kHz, or 400 kHz for high-speed bus.
+
+Deprecated: use 100 * machine.KHz or 400 * machine.KHz instead.
+
+
+```go
+const (
+	// I2CReceive indicates target has received a message from the controller.
+	I2CReceive	I2CTargetEvent	= iota
+
+	// I2CRequest indicates the controller is expecting a message from the target.
+	I2CRequest
+
+	// I2CFinish indicates the controller has ended the transaction.
+	//
+	// I2C controllers can chain multiple receive/request messages without
+	// relinquishing the bus by doing 'restarts'.  I2CFinish indicates the
+	// bus has been relinquished by an I2C 'stop'.
+	I2CFinish
+)
+```
+
+
+
+```go
+const (
+	// I2CModeController represents an I2C peripheral in controller mode.
+	I2CModeController	I2CMode	= iota
+
+	// I2CModeTarget represents an I2C peripheral in target mode.
+	I2CModeTarget
+)
+```
+
+
+
+```go
 const Device = deviceName
 ```
 
@@ -295,6 +338,15 @@ var (
 
 ```go
 var (
+	I2C0	= &I2C{Bus: esp.I2C0, funcSCL: 29, funcSDA: 30}
+	I2C1	= &I2C{Bus: esp.I2C1, funcSCL: 95, funcSDA: 96}
+)
+```
+
+
+
+```go
+var (
 	ErrPWMPeriodTooLong = errors.New("pwm: period too long")
 )
 ```
@@ -375,6 +427,127 @@ type ADCConfig struct {
 
 ADCConfig holds ADC configuration parameters. If left unspecified, the zero
 value of each parameter will use the peripheral's default settings.
+
+
+
+
+
+## type I2C
+
+```go
+type I2C struct {
+	Bus			*esp.I2C_Type
+	funcSCL, funcSDA	uint32
+	config			I2CConfig
+}
+```
+
+
+
+
+### func (*I2C) CheckDevice
+
+```go
+func (i2c *I2C) CheckDevice(addr uint16) bool
+```
+
+CheckDevice does an empty I2C transaction at the specified address.
+This can be used to find out if any device with that address is
+connected, e.g. for enumerating all devices on the bus.
+
+
+### func (*I2C) Configure
+
+```go
+func (i2c *I2C) Configure(config I2CConfig) error
+```
+
+
+
+### func (*I2C) ReadRegister
+
+```go
+func (i2c *I2C) ReadRegister(address uint8, register uint8, data []byte) error
+```
+
+ReadRegister transmits the register, restarts the connection as a read
+operation, and reads the response.
+
+Many I2C-compatible devices are organized in terms of registers. This method
+is a shortcut to easily read such registers. Also, it only works for devices
+with 7-bit addresses, which is the vast majority.
+
+
+### func (*I2C) SetBaudRate
+
+```go
+func (i2c *I2C) SetBaudRate(br uint32) error
+```
+
+
+
+### func (*I2C) Tx
+
+```go
+func (i2c *I2C) Tx(addr uint16, w, r []byte) (err error)
+```
+
+Tx does a single I2C transaction at the specified address.
+It clocks out the given address, writes the bytes in w, reads back len(r)
+bytes and stores them in r, and generates a stop condition on the bus.
+
+
+### func (*I2C) WriteRegister
+
+```go
+func (i2c *I2C) WriteRegister(address uint8, register uint8, data []byte) error
+```
+
+WriteRegister transmits first the register and then the data to the
+peripheral device.
+
+Many I2C-compatible devices are organized in terms of registers. This method
+is a shortcut to easily write to such registers. Also, it only works for
+devices with 7-bit addresses, which is the vast majority.
+
+
+
+
+## type I2CConfig
+
+```go
+type I2CConfig struct {
+	Frequency	uint32	// in Hz
+	SCL		Pin
+	SDA		Pin
+}
+```
+
+I2CConfig is used to store config info for I2C.
+
+
+
+
+
+## type I2CMode
+
+```go
+type I2CMode int
+```
+
+I2CMode determines if an I2C peripheral is in Controller or Target mode.
+
+
+
+
+
+## type I2CTargetEvent
+
+```go
+type I2CTargetEvent uint8
+```
+
+I2CTargetEvent reflects events on the I2C bus
 
 
 
@@ -687,7 +860,7 @@ transfer larger amounts of data, Tx will be faster.
 func (spi SPI) Tx(w, r []byte) error
 ```
 
-Tx handles read/write operation for SPI interface. Since SPI is a syncronous write/read
+Tx handles read/write operation for SPI interface. Since SPI is a synchronous write/read
 interface, there must always be the same number of bytes written as bytes read.
 This is accomplished by sending zero bits if r is bigger than w or discarding
 the incoming data if w is bigger than r.

--- a/content/docs/reference/microcontrollers/machine/feather-m0.md
+++ b/content/docs/reference/microcontrollers/machine/feather-m0.md
@@ -538,7 +538,7 @@ func EnableCDC(txHandler func(), rxHandler func([]byte), setupHandler func(usb.S
 func EnterBootloader()
 ```
 
-EnterBootloader should perform a system reset in preperation
+EnterBootloader should perform a system reset in preparation
 to switch to the bootloader to flash new firmware.
 
 
@@ -1317,7 +1317,7 @@ Transfer writes/reads a single byte using the SPI interface.
 func (spi SPI) Tx(w, r []byte) error
 ```
 
-Tx handles read/write operation for SPI interface. Since SPI is a syncronous write/read
+Tx handles read/write operation for SPI interface. Since SPI is a synchronous write/read
 interface, there must always be the same number of bytes written as bytes read.
 The Tx method knows about this, and offers a few different ways of calling it.
 

--- a/content/docs/reference/microcontrollers/machine/feather-m4-can.md
+++ b/content/docs/reference/microcontrollers/machine/feather-m4-can.md
@@ -1031,6 +1031,15 @@ The Tx transmits CAN frames. It is easier to use than TxRaw, but not as
 flexible.
 
 
+### func (*CAN) TxFifoFreeLevel
+
+```go
+func (can *CAN) TxFifoFreeLevel() int
+```
+
+TxFifoFreeLevel returns how many messages can still be set in the TxFifo.
+
+
 ### func (*CAN) TxFifoIsFull
 
 ```go
@@ -1724,7 +1733,7 @@ Transfer writes/reads a single byte using the SPI interface.
 func (spi SPI) Tx(w, r []byte) error
 ```
 
-Tx handles read/write operation for SPI interface. Since SPI is a syncronous write/read
+Tx handles read/write operation for SPI interface. Since SPI is a synchronous write/read
 interface, there must always be the same number of bytes written as bytes read.
 The Tx method knows about this, and offers a few different ways of calling it.
 

--- a/content/docs/reference/microcontrollers/machine/feather-m4.md
+++ b/content/docs/reference/microcontrollers/machine/feather-m4.md
@@ -1412,7 +1412,7 @@ Transfer writes/reads a single byte using the SPI interface.
 func (spi SPI) Tx(w, r []byte) error
 ```
 
-Tx handles read/write operation for SPI interface. Since SPI is a syncronous write/read
+Tx handles read/write operation for SPI interface. Since SPI is a synchronous write/read
 interface, there must always be the same number of bytes written as bytes read.
 The Tx method knows about this, and offers a few different ways of calling it.
 

--- a/content/docs/reference/microcontrollers/machine/feather-nrf52840-sense.md
+++ b/content/docs/reference/microcontrollers/machine/feather-nrf52840-sense.md
@@ -1332,7 +1332,7 @@ Transfer writes/reads a single byte using the SPI interface.
 func (spi SPI) Tx(w, r []byte) error
 ```
 
-Tx handles read/write operation for SPI interface. Since SPI is a syncronous
+Tx handles read/write operation for SPI interface. Since SPI is a synchronous
 write/read interface, there must always be the same number of bytes written
 as bytes read. Therefore, if the number of bytes don't match it will be
 padded until they fit: if len(w) > len(r) the extra bytes received will be

--- a/content/docs/reference/microcontrollers/machine/feather-nrf52840.md
+++ b/content/docs/reference/microcontrollers/machine/feather-nrf52840.md
@@ -1332,7 +1332,7 @@ Transfer writes/reads a single byte using the SPI interface.
 func (spi SPI) Tx(w, r []byte) error
 ```
 
-Tx handles read/write operation for SPI interface. Since SPI is a syncronous
+Tx handles read/write operation for SPI interface. Since SPI is a synchronous
 write/read interface, there must always be the same number of bytes written
 as bytes read. Therefore, if the number of bytes don't match it will be
 padded until they fit: if len(w) > len(r) the extra bytes received will be

--- a/content/docs/reference/microcontrollers/machine/feather-rp2040.md
+++ b/content/docs/reference/microcontrollers/machine/feather-rp2040.md
@@ -1421,7 +1421,7 @@ Write a single byte and read a single byte from TX/RX FIFO.
 func (spi SPI) Tx(w, r []byte) (err error)
 ```
 
-Tx handles read/write operation for SPI interface. Since SPI is a syncronous write/read
+Tx handles read/write operation for SPI interface. Since SPI is a synchronous write/read
 interface, there must always be the same number of bytes written as bytes read.
 The Tx method knows about this, and offers a few different ways of calling it.
 

--- a/content/docs/reference/microcontrollers/machine/feather-stm32f405.md
+++ b/content/docs/reference/microcontrollers/machine/feather-stm32f405.md
@@ -1576,7 +1576,7 @@ Transfer writes/reads a single byte using the SPI interface.
 func (spi SPI) Tx(w, r []byte) error
 ```
 
-Tx handles read/write operation for SPI interface. Since SPI is a syncronous write/read
+Tx handles read/write operation for SPI interface. Since SPI is a synchronous write/read
 interface, there must always be the same number of bytes written as bytes read.
 The Tx method knows about this, and offers a few different ways of calling it.
 

--- a/content/docs/reference/microcontrollers/machine/grandcentral-m4.md
+++ b/content/docs/reference/microcontrollers/machine/grandcentral-m4.md
@@ -1584,7 +1584,7 @@ Transfer writes/reads a single byte using the SPI interface.
 func (spi SPI) Tx(w, r []byte) error
 ```
 
-Tx handles read/write operation for SPI interface. Since SPI is a syncronous write/read
+Tx handles read/write operation for SPI interface. Since SPI is a synchronous write/read
 interface, there must always be the same number of bytes written as bytes read.
 The Tx method knows about this, and offers a few different ways of calling it.
 

--- a/content/docs/reference/microcontrollers/machine/hifive1b.md
+++ b/content/docs/reference/microcontrollers/machine/hifive1b.md
@@ -792,7 +792,7 @@ Transfer writes/reads a single byte using the SPI interface.
 func (spi SPI) Tx(w, r []byte) error
 ```
 
-Tx handles read/write operation for SPI interface. Since SPI is a syncronous write/read
+Tx handles read/write operation for SPI interface. Since SPI is a synchronous write/read
 interface, there must always be the same number of bytes written as bytes read.
 The Tx method knows about this, and offers a few different ways of calling it.
 

--- a/content/docs/reference/microcontrollers/machine/itsybitsy-m0.md
+++ b/content/docs/reference/microcontrollers/machine/itsybitsy-m0.md
@@ -559,7 +559,7 @@ func EnableCDC(txHandler func(), rxHandler func([]byte), setupHandler func(usb.S
 func EnterBootloader()
 ```
 
-EnterBootloader should perform a system reset in preperation
+EnterBootloader should perform a system reset in preparation
 to switch to the bootloader to flash new firmware.
 
 
@@ -1338,7 +1338,7 @@ Transfer writes/reads a single byte using the SPI interface.
 func (spi SPI) Tx(w, r []byte) error
 ```
 
-Tx handles read/write operation for SPI interface. Since SPI is a syncronous write/read
+Tx handles read/write operation for SPI interface. Since SPI is a synchronous write/read
 interface, there must always be the same number of bytes written as bytes read.
 The Tx method knows about this, and offers a few different ways of calling it.
 

--- a/content/docs/reference/microcontrollers/machine/itsybitsy-m4.md
+++ b/content/docs/reference/microcontrollers/machine/itsybitsy-m4.md
@@ -1408,7 +1408,7 @@ Transfer writes/reads a single byte using the SPI interface.
 func (spi SPI) Tx(w, r []byte) error
 ```
 
-Tx handles read/write operation for SPI interface. Since SPI is a syncronous write/read
+Tx handles read/write operation for SPI interface. Since SPI is a synchronous write/read
 interface, there must always be the same number of bytes written as bytes read.
 The Tx method knows about this, and offers a few different ways of calling it.
 

--- a/content/docs/reference/microcontrollers/machine/itsybitsy-nrf52840.md
+++ b/content/docs/reference/microcontrollers/machine/itsybitsy-nrf52840.md
@@ -1326,7 +1326,7 @@ Transfer writes/reads a single byte using the SPI interface.
 func (spi SPI) Tx(w, r []byte) error
 ```
 
-Tx handles read/write operation for SPI interface. Since SPI is a syncronous
+Tx handles read/write operation for SPI interface. Since SPI is a synchronous
 write/read interface, there must always be the same number of bytes written
 as bytes read. Therefore, if the number of bytes don't match it will be
 padded until they fit: if len(w) > len(r) the extra bytes received will be

--- a/content/docs/reference/microcontrollers/machine/lgt92.md
+++ b/content/docs/reference/microcontrollers/machine/lgt92.md
@@ -788,8 +788,9 @@ devices with 7-bit addresses, which is the vast majority.
 
 ```go
 type I2CConfig struct {
-	SCL	Pin
-	SDA	Pin
+	Frequency	uint32
+	SCL		Pin
+	SDA		Pin
 }
 ```
 
@@ -1187,7 +1188,7 @@ Transfer writes/reads a single byte using the SPI interface.
 func (spi SPI) Tx(w, r []byte) error
 ```
 
-Tx handles read/write operation for SPI interface. Since SPI is a syncronous write/read
+Tx handles read/write operation for SPI interface. Since SPI is a synchronous write/read
 interface, there must always be the same number of bytes written as bytes read.
 The Tx method knows about this, and offers a few different ways of calling it.
 

--- a/content/docs/reference/microcontrollers/machine/lorae5.md
+++ b/content/docs/reference/microcontrollers/machine/lorae5.md
@@ -734,8 +734,9 @@ devices with 7-bit addresses, which is the vast majority.
 
 ```go
 type I2CConfig struct {
-	SCL	Pin
-	SDA	Pin
+	Frequency	uint32
+	SCL		Pin
+	SDA		Pin
 }
 ```
 
@@ -1132,7 +1133,7 @@ Transfer writes/reads a single byte using the SPI interface.
 func (spi SPI) Tx(w, r []byte) error
 ```
 
-Tx handles read/write operation for SPI interface. Since SPI is a syncronous write/read
+Tx handles read/write operation for SPI interface. Since SPI is a synchronous write/read
 interface, there must always be the same number of bytes written as bytes read.
 The Tx method knows about this, and offers a few different ways of calling it.
 

--- a/content/docs/reference/microcontrollers/machine/m5stack-core2.md
+++ b/content/docs/reference/microcontrollers/machine/m5stack-core2.md
@@ -127,6 +127,49 @@ UART pins
 
 
 ```go
+const (
+	TWI_FREQ_100KHZ	= 100000
+	TWI_FREQ_400KHZ	= 400000
+)
+```
+
+TWI_FREQ is the I2C bus speed. Normally either 100 kHz, or 400 kHz for high-speed bus.
+
+Deprecated: use 100 * machine.KHz or 400 * machine.KHz instead.
+
+
+```go
+const (
+	// I2CReceive indicates target has received a message from the controller.
+	I2CReceive	I2CTargetEvent	= iota
+
+	// I2CRequest indicates the controller is expecting a message from the target.
+	I2CRequest
+
+	// I2CFinish indicates the controller has ended the transaction.
+	//
+	// I2C controllers can chain multiple receive/request messages without
+	// relinquishing the bus by doing 'restarts'.  I2CFinish indicates the
+	// bus has been relinquished by an I2C 'stop'.
+	I2CFinish
+)
+```
+
+
+
+```go
+const (
+	// I2CModeController represents an I2C peripheral in controller mode.
+	I2CModeController	I2CMode	= iota
+
+	// I2CModeTarget represents an I2C peripheral in target mode.
+	I2CModeTarget
+)
+```
+
+
+
+```go
 const Device = deviceName
 ```
 
@@ -298,6 +341,15 @@ var (
 
 ```go
 var (
+	I2C0	= &I2C{Bus: esp.I2C0, funcSCL: 29, funcSDA: 30}
+	I2C1	= &I2C{Bus: esp.I2C1, funcSCL: 95, funcSDA: 96}
+)
+```
+
+
+
+```go
+var (
 	ErrPWMPeriodTooLong = errors.New("pwm: period too long")
 )
 ```
@@ -378,6 +430,127 @@ type ADCConfig struct {
 
 ADCConfig holds ADC configuration parameters. If left unspecified, the zero
 value of each parameter will use the peripheral's default settings.
+
+
+
+
+
+## type I2C
+
+```go
+type I2C struct {
+	Bus			*esp.I2C_Type
+	funcSCL, funcSDA	uint32
+	config			I2CConfig
+}
+```
+
+
+
+
+### func (*I2C) CheckDevice
+
+```go
+func (i2c *I2C) CheckDevice(addr uint16) bool
+```
+
+CheckDevice does an empty I2C transaction at the specified address.
+This can be used to find out if any device with that address is
+connected, e.g. for enumerating all devices on the bus.
+
+
+### func (*I2C) Configure
+
+```go
+func (i2c *I2C) Configure(config I2CConfig) error
+```
+
+
+
+### func (*I2C) ReadRegister
+
+```go
+func (i2c *I2C) ReadRegister(address uint8, register uint8, data []byte) error
+```
+
+ReadRegister transmits the register, restarts the connection as a read
+operation, and reads the response.
+
+Many I2C-compatible devices are organized in terms of registers. This method
+is a shortcut to easily read such registers. Also, it only works for devices
+with 7-bit addresses, which is the vast majority.
+
+
+### func (*I2C) SetBaudRate
+
+```go
+func (i2c *I2C) SetBaudRate(br uint32) error
+```
+
+
+
+### func (*I2C) Tx
+
+```go
+func (i2c *I2C) Tx(addr uint16, w, r []byte) (err error)
+```
+
+Tx does a single I2C transaction at the specified address.
+It clocks out the given address, writes the bytes in w, reads back len(r)
+bytes and stores them in r, and generates a stop condition on the bus.
+
+
+### func (*I2C) WriteRegister
+
+```go
+func (i2c *I2C) WriteRegister(address uint8, register uint8, data []byte) error
+```
+
+WriteRegister transmits first the register and then the data to the
+peripheral device.
+
+Many I2C-compatible devices are organized in terms of registers. This method
+is a shortcut to easily write to such registers. Also, it only works for
+devices with 7-bit addresses, which is the vast majority.
+
+
+
+
+## type I2CConfig
+
+```go
+type I2CConfig struct {
+	Frequency	uint32	// in Hz
+	SCL		Pin
+	SDA		Pin
+}
+```
+
+I2CConfig is used to store config info for I2C.
+
+
+
+
+
+## type I2CMode
+
+```go
+type I2CMode int
+```
+
+I2CMode determines if an I2C peripheral is in Controller or Target mode.
+
+
+
+
+
+## type I2CTargetEvent
+
+```go
+type I2CTargetEvent uint8
+```
+
+I2CTargetEvent reflects events on the I2C bus
 
 
 
@@ -690,7 +863,7 @@ transfer larger amounts of data, Tx will be faster.
 func (spi SPI) Tx(w, r []byte) error
 ```
 
-Tx handles read/write operation for SPI interface. Since SPI is a syncronous write/read
+Tx handles read/write operation for SPI interface. Since SPI is a synchronous write/read
 interface, there must always be the same number of bytes written as bytes read.
 This is accomplished by sending zero bits if r is bigger than w or discarding
 the incoming data if w is bigger than r.

--- a/content/docs/reference/microcontrollers/machine/m5stamp-c3.md
+++ b/content/docs/reference/microcontrollers/machine/m5stamp-c3.md
@@ -684,7 +684,7 @@ transfer larger amounts of data, Tx will be faster.
 func (spi SPI) Tx(w, r []byte) error
 ```
 
-Tx handles read/write operation for SPI interface. Since SPI is a syncronous write/read
+Tx handles read/write operation for SPI interface. Since SPI is a synchronous write/read
 interface, there must always be the same number of bytes written as bytes read.
 This is accomplished by sending zero bits if r is bigger than w or discarding
 the incoming data if w is bigger than r.

--- a/content/docs/reference/microcontrollers/machine/macropad-rp2040.md
+++ b/content/docs/reference/microcontrollers/machine/macropad-rp2040.md
@@ -1425,7 +1425,7 @@ Write a single byte and read a single byte from TX/RX FIFO.
 func (spi SPI) Tx(w, r []byte) (err error)
 ```
 
-Tx handles read/write operation for SPI interface. Since SPI is a syncronous write/read
+Tx handles read/write operation for SPI interface. Since SPI is a synchronous write/read
 interface, there must always be the same number of bytes written as bytes read.
 The Tx method knows about this, and offers a few different ways of calling it.
 

--- a/content/docs/reference/microcontrollers/machine/maixbit.md
+++ b/content/docs/reference/microcontrollers/machine/maixbit.md
@@ -1146,7 +1146,7 @@ Transfer writes/reads a single byte using the SPI interface.
 func (spi SPI) Tx(w, r []byte) error
 ```
 
-Tx handles read/write operation for SPI interface. Since SPI is a syncronous write/read
+Tx handles read/write operation for SPI interface. Since SPI is a synchronous write/read
 interface, there must always be the same number of bytes written as bytes read.
 The Tx method knows about this, and offers a few different ways of calling it.
 

--- a/content/docs/reference/microcontrollers/machine/matrixportal-m4.md
+++ b/content/docs/reference/microcontrollers/machine/matrixportal-m4.md
@@ -1524,7 +1524,7 @@ Transfer writes/reads a single byte using the SPI interface.
 func (spi SPI) Tx(w, r []byte) error
 ```
 
-Tx handles read/write operation for SPI interface. Since SPI is a syncronous write/read
+Tx handles read/write operation for SPI interface. Since SPI is a synchronous write/read
 interface, there must always be the same number of bytes written as bytes read.
 The Tx method knows about this, and offers a few different ways of calling it.
 

--- a/content/docs/reference/microcontrollers/machine/metro-m4-airlift.md
+++ b/content/docs/reference/microcontrollers/machine/metro-m4-airlift.md
@@ -1468,7 +1468,7 @@ Transfer writes/reads a single byte using the SPI interface.
 func (spi SPI) Tx(w, r []byte) error
 ```
 
-Tx handles read/write operation for SPI interface. Since SPI is a syncronous write/read
+Tx handles read/write operation for SPI interface. Since SPI is a synchronous write/read
 interface, there must always be the same number of bytes written as bytes read.
 The Tx method knows about this, and offers a few different ways of calling it.
 

--- a/content/docs/reference/microcontrollers/machine/microbit.md
+++ b/content/docs/reference/microcontrollers/machine/microbit.md
@@ -999,7 +999,7 @@ Transfer writes/reads a single byte using the SPI interface.
 func (spi SPI) Tx(w, r []byte) error
 ```
 
-Tx handles read/write operation for SPI interface. Since SPI is a syncronous write/read
+Tx handles read/write operation for SPI interface. Since SPI is a synchronous write/read
 interface, there must always be the same number of bytes written as bytes read.
 The Tx method knows about this, and offers a few different ways of calling it.
 

--- a/content/docs/reference/microcontrollers/machine/nano-33-ble.md
+++ b/content/docs/reference/microcontrollers/machine/nano-33-ble.md
@@ -1327,7 +1327,7 @@ Transfer writes/reads a single byte using the SPI interface.
 func (spi SPI) Tx(w, r []byte) error
 ```
 
-Tx handles read/write operation for SPI interface. Since SPI is a syncronous
+Tx handles read/write operation for SPI interface. Since SPI is a synchronous
 write/read interface, there must always be the same number of bytes written
 as bytes read. Therefore, if the number of bytes don't match it will be
 padded until they fit: if len(w) > len(r) the extra bytes received will be

--- a/content/docs/reference/microcontrollers/machine/nano-rp2040.md
+++ b/content/docs/reference/microcontrollers/machine/nano-rp2040.md
@@ -1469,7 +1469,7 @@ Write a single byte and read a single byte from TX/RX FIFO.
 func (spi SPI) Tx(w, r []byte) (err error)
 ```
 
-Tx handles read/write operation for SPI interface. Since SPI is a syncronous write/read
+Tx handles read/write operation for SPI interface. Since SPI is a synchronous write/read
 interface, there must always be the same number of bytes written as bytes read.
 The Tx method knows about this, and offers a few different ways of calling it.
 

--- a/content/docs/reference/microcontrollers/machine/nicenano.md
+++ b/content/docs/reference/microcontrollers/machine/nicenano.md
@@ -1302,7 +1302,7 @@ Transfer writes/reads a single byte using the SPI interface.
 func (spi SPI) Tx(w, r []byte) error
 ```
 
-Tx handles read/write operation for SPI interface. Since SPI is a syncronous
+Tx handles read/write operation for SPI interface. Since SPI is a synchronous
 write/read interface, there must always be the same number of bytes written
 as bytes read. Therefore, if the number of bytes don't match it will be
 padded until they fit: if len(w) > len(r) the extra bytes received will be

--- a/content/docs/reference/microcontrollers/machine/nrf52840-mdk-usb-dongle.md
+++ b/content/docs/reference/microcontrollers/machine/nrf52840-mdk-usb-dongle.md
@@ -1267,7 +1267,7 @@ Transfer writes/reads a single byte using the SPI interface.
 func (spi SPI) Tx(w, r []byte) error
 ```
 
-Tx handles read/write operation for SPI interface. Since SPI is a syncronous
+Tx handles read/write operation for SPI interface. Since SPI is a synchronous
 write/read interface, there must always be the same number of bytes written
 as bytes read. Therefore, if the number of bytes don't match it will be
 padded until they fit: if len(w) > len(r) the extra bytes received will be

--- a/content/docs/reference/microcontrollers/machine/nrf52840-mdk.md
+++ b/content/docs/reference/microcontrollers/machine/nrf52840-mdk.md
@@ -1257,7 +1257,7 @@ Transfer writes/reads a single byte using the SPI interface.
 func (spi SPI) Tx(w, r []byte) error
 ```
 
-Tx handles read/write operation for SPI interface. Since SPI is a syncronous
+Tx handles read/write operation for SPI interface. Since SPI is a synchronous
 write/read interface, there must always be the same number of bytes written
 as bytes read. Therefore, if the number of bytes don't match it will be
 padded until they fit: if len(w) > len(r) the extra bytes received will be

--- a/content/docs/reference/microcontrollers/machine/nucleo-f103rb.md
+++ b/content/docs/reference/microcontrollers/machine/nucleo-f103rb.md
@@ -1226,7 +1226,7 @@ Transfer writes/reads a single byte using the SPI interface.
 func (spi SPI) Tx(w, r []byte) error
 ```
 
-Tx handles read/write operation for SPI interface. Since SPI is a syncronous write/read
+Tx handles read/write operation for SPI interface. Since SPI is a synchronous write/read
 interface, there must always be the same number of bytes written as bytes read.
 The Tx method knows about this, and offers a few different ways of calling it.
 

--- a/content/docs/reference/microcontrollers/machine/nucleo-f722ze.md
+++ b/content/docs/reference/microcontrollers/machine/nucleo-f722ze.md
@@ -976,8 +976,9 @@ devices with 7-bit addresses, which is the vast majority.
 
 ```go
 type I2CConfig struct {
-	SCL	Pin
-	SDA	Pin
+	Frequency	uint32
+	SCL		Pin
+	SDA		Pin
 }
 ```
 

--- a/content/docs/reference/microcontrollers/machine/nucleo-l031k6.md
+++ b/content/docs/reference/microcontrollers/machine/nucleo-l031k6.md
@@ -729,8 +729,9 @@ devices with 7-bit addresses, which is the vast majority.
 
 ```go
 type I2CConfig struct {
-	SCL	Pin
-	SDA	Pin
+	Frequency	uint32
+	SCL		Pin
+	SDA		Pin
 }
 ```
 
@@ -1128,7 +1129,7 @@ Transfer writes/reads a single byte using the SPI interface.
 func (spi SPI) Tx(w, r []byte) error
 ```
 
-Tx handles read/write operation for SPI interface. Since SPI is a syncronous write/read
+Tx handles read/write operation for SPI interface. Since SPI is a synchronous write/read
 interface, there must always be the same number of bytes written as bytes read.
 The Tx method knows about this, and offers a few different ways of calling it.
 

--- a/content/docs/reference/microcontrollers/machine/nucleo-l432kc.md
+++ b/content/docs/reference/microcontrollers/machine/nucleo-l432kc.md
@@ -851,8 +851,9 @@ devices with 7-bit addresses, which is the vast majority.
 
 ```go
 type I2CConfig struct {
-	SCL	Pin
-	SDA	Pin
+	Frequency	uint32
+	SCL		Pin
+	SDA		Pin
 }
 ```
 
@@ -1250,7 +1251,7 @@ Transfer writes/reads a single byte using the SPI interface.
 func (spi SPI) Tx(w, r []byte) error
 ```
 
-Tx handles read/write operation for SPI interface. Since SPI is a syncronous write/read
+Tx handles read/write operation for SPI interface. Since SPI is a synchronous write/read
 interface, there must always be the same number of bytes written as bytes read.
 The Tx method knows about this, and offers a few different ways of calling it.
 

--- a/content/docs/reference/microcontrollers/machine/nucleo-l552ze.md
+++ b/content/docs/reference/microcontrollers/machine/nucleo-l552ze.md
@@ -796,8 +796,9 @@ devices with 7-bit addresses, which is the vast majority.
 
 ```go
 type I2CConfig struct {
-	SCL	Pin
-	SDA	Pin
+	Frequency	uint32
+	SCL		Pin
+	SDA		Pin
 }
 ```
 

--- a/content/docs/reference/microcontrollers/machine/nucleo-wl55jc.md
+++ b/content/docs/reference/microcontrollers/machine/nucleo-wl55jc.md
@@ -725,8 +725,9 @@ devices with 7-bit addresses, which is the vast majority.
 
 ```go
 type I2CConfig struct {
-	SCL	Pin
-	SDA	Pin
+	Frequency	uint32
+	SCL		Pin
+	SDA		Pin
 }
 ```
 
@@ -1123,7 +1124,7 @@ Transfer writes/reads a single byte using the SPI interface.
 func (spi SPI) Tx(w, r []byte) error
 ```
 
-Tx handles read/write operation for SPI interface. Since SPI is a syncronous write/read
+Tx handles read/write operation for SPI interface. Since SPI is a synchronous write/read
 interface, there must always be the same number of bytes written as bytes read.
 The Tx method knows about this, and offers a few different ways of calling it.
 

--- a/content/docs/reference/microcontrollers/machine/p1am-100.md
+++ b/content/docs/reference/microcontrollers/machine/p1am-100.md
@@ -583,7 +583,7 @@ func EnableCDC(txHandler func(), rxHandler func([]byte), setupHandler func(usb.S
 func EnterBootloader()
 ```
 
-EnterBootloader should perform a system reset in preperation
+EnterBootloader should perform a system reset in preparation
 to switch to the bootloader to flash new firmware.
 
 
@@ -1362,7 +1362,7 @@ Transfer writes/reads a single byte using the SPI interface.
 func (spi SPI) Tx(w, r []byte) error
 ```
 
-Tx handles read/write operation for SPI interface. Since SPI is a syncronous write/read
+Tx handles read/write operation for SPI interface. Since SPI is a synchronous write/read
 interface, there must always be the same number of bytes written as bytes read.
 The Tx method knows about this, and offers a few different ways of calling it.
 

--- a/content/docs/reference/microcontrollers/machine/particle-argon.md
+++ b/content/docs/reference/microcontrollers/machine/particle-argon.md
@@ -1337,7 +1337,7 @@ Transfer writes/reads a single byte using the SPI interface.
 func (spi SPI) Tx(w, r []byte) error
 ```
 
-Tx handles read/write operation for SPI interface. Since SPI is a syncronous
+Tx handles read/write operation for SPI interface. Since SPI is a synchronous
 write/read interface, there must always be the same number of bytes written
 as bytes read. Therefore, if the number of bytes don't match it will be
 padded until they fit: if len(w) > len(r) the extra bytes received will be

--- a/content/docs/reference/microcontrollers/machine/particle-boron.md
+++ b/content/docs/reference/microcontrollers/machine/particle-boron.md
@@ -1340,7 +1340,7 @@ Transfer writes/reads a single byte using the SPI interface.
 func (spi SPI) Tx(w, r []byte) error
 ```
 
-Tx handles read/write operation for SPI interface. Since SPI is a syncronous
+Tx handles read/write operation for SPI interface. Since SPI is a synchronous
 write/read interface, there must always be the same number of bytes written
 as bytes read. Therefore, if the number of bytes don't match it will be
 padded until they fit: if len(w) > len(r) the extra bytes received will be

--- a/content/docs/reference/microcontrollers/machine/particle-xenon.md
+++ b/content/docs/reference/microcontrollers/machine/particle-xenon.md
@@ -1322,7 +1322,7 @@ Transfer writes/reads a single byte using the SPI interface.
 func (spi SPI) Tx(w, r []byte) error
 ```
 
-Tx handles read/write operation for SPI interface. Since SPI is a syncronous
+Tx handles read/write operation for SPI interface. Since SPI is a synchronous
 write/read interface, there must always be the same number of bytes written
 as bytes read. Therefore, if the number of bytes don't match it will be
 padded until they fit: if len(w) > len(r) the extra bytes received will be

--- a/content/docs/reference/microcontrollers/machine/pca10031.md
+++ b/content/docs/reference/microcontrollers/machine/pca10031.md
@@ -947,7 +947,7 @@ Transfer writes/reads a single byte using the SPI interface.
 func (spi SPI) Tx(w, r []byte) error
 ```
 
-Tx handles read/write operation for SPI interface. Since SPI is a syncronous write/read
+Tx handles read/write operation for SPI interface. Since SPI is a synchronous write/read
 interface, there must always be the same number of bytes written as bytes read.
 The Tx method knows about this, and offers a few different ways of calling it.
 

--- a/content/docs/reference/microcontrollers/machine/pca10040.md
+++ b/content/docs/reference/microcontrollers/machine/pca10040.md
@@ -1089,7 +1089,7 @@ Transfer writes/reads a single byte using the SPI interface.
 func (spi SPI) Tx(w, r []byte) error
 ```
 
-Tx handles read/write operation for SPI interface. Since SPI is a syncronous
+Tx handles read/write operation for SPI interface. Since SPI is a synchronous
 write/read interface, there must always be the same number of bytes written
 as bytes read. Therefore, if the number of bytes don't match it will be
 padded until they fit: if len(w) > len(r) the extra bytes received will be

--- a/content/docs/reference/microcontrollers/machine/pca10056.md
+++ b/content/docs/reference/microcontrollers/machine/pca10056.md
@@ -1291,7 +1291,7 @@ Transfer writes/reads a single byte using the SPI interface.
 func (spi SPI) Tx(w, r []byte) error
 ```
 
-Tx handles read/write operation for SPI interface. Since SPI is a syncronous
+Tx handles read/write operation for SPI interface. Since SPI is a synchronous
 write/read interface, there must always be the same number of bytes written
 as bytes read. Therefore, if the number of bytes don't match it will be
 padded until they fit: if len(w) > len(r) the extra bytes received will be

--- a/content/docs/reference/microcontrollers/machine/pca10059.md
+++ b/content/docs/reference/microcontrollers/machine/pca10059.md
@@ -1281,7 +1281,7 @@ Transfer writes/reads a single byte using the SPI interface.
 func (spi SPI) Tx(w, r []byte) error
 ```
 
-Tx handles read/write operation for SPI interface. Since SPI is a syncronous
+Tx handles read/write operation for SPI interface. Since SPI is a synchronous
 write/read interface, there must always be the same number of bytes written
 as bytes read. Therefore, if the number of bytes don't match it will be
 padded until they fit: if len(w) > len(r) the extra bytes received will be

--- a/content/docs/reference/microcontrollers/machine/pico.md
+++ b/content/docs/reference/microcontrollers/machine/pico.md
@@ -1422,7 +1422,7 @@ Write a single byte and read a single byte from TX/RX FIFO.
 func (spi SPI) Tx(w, r []byte) (err error)
 ```
 
-Tx handles read/write operation for SPI interface. Since SPI is a syncronous write/read
+Tx handles read/write operation for SPI interface. Since SPI is a synchronous write/read
 interface, there must always be the same number of bytes written as bytes read.
 The Tx method knows about this, and offers a few different ways of calling it.
 

--- a/content/docs/reference/microcontrollers/machine/pybadge.md
+++ b/content/docs/reference/microcontrollers/machine/pybadge.md
@@ -1502,7 +1502,7 @@ Transfer writes/reads a single byte using the SPI interface.
 func (spi SPI) Tx(w, r []byte) error
 ```
 
-Tx handles read/write operation for SPI interface. Since SPI is a syncronous write/read
+Tx handles read/write operation for SPI interface. Since SPI is a synchronous write/read
 interface, there must always be the same number of bytes written as bytes read.
 The Tx method knows about this, and offers a few different ways of calling it.
 

--- a/content/docs/reference/microcontrollers/machine/pygamer.md
+++ b/content/docs/reference/microcontrollers/machine/pygamer.md
@@ -1453,7 +1453,7 @@ Transfer writes/reads a single byte using the SPI interface.
 func (spi SPI) Tx(w, r []byte) error
 ```
 
-Tx handles read/write operation for SPI interface. Since SPI is a syncronous write/read
+Tx handles read/write operation for SPI interface. Since SPI is a synchronous write/read
 interface, there must always be the same number of bytes written as bytes read.
 The Tx method knows about this, and offers a few different ways of calling it.
 

--- a/content/docs/reference/microcontrollers/machine/pyportal.md
+++ b/content/docs/reference/microcontrollers/machine/pyportal.md
@@ -1481,7 +1481,7 @@ Transfer writes/reads a single byte using the SPI interface.
 func (spi SPI) Tx(w, r []byte) error
 ```
 
-Tx handles read/write operation for SPI interface. Since SPI is a syncronous write/read
+Tx handles read/write operation for SPI interface. Since SPI is a synchronous write/read
 interface, there must always be the same number of bytes written as bytes read.
 The Tx method knows about this, and offers a few different ways of calling it.
 

--- a/content/docs/reference/microcontrollers/machine/qtpy-rp2040.md
+++ b/content/docs/reference/microcontrollers/machine/qtpy-rp2040.md
@@ -1432,7 +1432,7 @@ Write a single byte and read a single byte from TX/RX FIFO.
 func (spi SPI) Tx(w, r []byte) (err error)
 ```
 
-Tx handles read/write operation for SPI interface. Since SPI is a syncronous write/read
+Tx handles read/write operation for SPI interface. Since SPI is a synchronous write/read
 interface, there must always be the same number of bytes written as bytes read.
 The Tx method knows about this, and offers a few different ways of calling it.
 

--- a/content/docs/reference/microcontrollers/machine/qtpy.md
+++ b/content/docs/reference/microcontrollers/machine/qtpy.md
@@ -543,7 +543,7 @@ func EnableCDC(txHandler func(), rxHandler func([]byte), setupHandler func(usb.S
 func EnterBootloader()
 ```
 
-EnterBootloader should perform a system reset in preperation
+EnterBootloader should perform a system reset in preparation
 to switch to the bootloader to flash new firmware.
 
 
@@ -1322,7 +1322,7 @@ Transfer writes/reads a single byte using the SPI interface.
 func (spi SPI) Tx(w, r []byte) error
 ```
 
-Tx handles read/write operation for SPI interface. Since SPI is a syncronous write/read
+Tx handles read/write operation for SPI interface. Since SPI is a synchronous write/read
 interface, there must always be the same number of bytes written as bytes read.
 The Tx method knows about this, and offers a few different ways of calling it.
 

--- a/content/docs/reference/microcontrollers/machine/reelboard.md
+++ b/content/docs/reference/microcontrollers/machine/reelboard.md
@@ -1295,7 +1295,7 @@ Transfer writes/reads a single byte using the SPI interface.
 func (spi SPI) Tx(w, r []byte) error
 ```
 
-Tx handles read/write operation for SPI interface. Since SPI is a syncronous
+Tx handles read/write operation for SPI interface. Since SPI is a synchronous
 write/read interface, there must always be the same number of bytes written
 as bytes read. Therefore, if the number of bytes don't match it will be
 padded until they fit: if len(w) > len(r) the extra bytes received will be

--- a/content/docs/reference/microcontrollers/machine/stm32f4disco.md
+++ b/content/docs/reference/microcontrollers/machine/stm32f4disco.md
@@ -1449,7 +1449,7 @@ Transfer writes/reads a single byte using the SPI interface.
 func (spi SPI) Tx(w, r []byte) error
 ```
 
-Tx handles read/write operation for SPI interface. Since SPI is a syncronous write/read
+Tx handles read/write operation for SPI interface. Since SPI is a synchronous write/read
 interface, there must always be the same number of bytes written as bytes read.
 The Tx method knows about this, and offers a few different ways of calling it.
 

--- a/content/docs/reference/microcontrollers/machine/swan.md
+++ b/content/docs/reference/microcontrollers/machine/swan.md
@@ -801,8 +801,9 @@ devices with 7-bit addresses, which is the vast majority.
 
 ```go
 type I2CConfig struct {
-	SCL	Pin
-	SDA	Pin
+	Frequency	uint32
+	SCL		Pin
+	SDA		Pin
 }
 ```
 
@@ -1200,7 +1201,7 @@ Transfer writes/reads a single byte using the SPI interface.
 func (spi SPI) Tx(w, r []byte) error
 ```
 
-Tx handles read/write operation for SPI interface. Since SPI is a syncronous write/read
+Tx handles read/write operation for SPI interface. Since SPI is a synchronous write/read
 interface, there must always be the same number of bytes written as bytes read.
 The Tx method knows about this, and offers a few different ways of calling it.
 

--- a/content/docs/reference/microcontrollers/machine/teensy40.md
+++ b/content/docs/reference/microcontrollers/machine/teensy40.md
@@ -1332,7 +1332,7 @@ Transfer writes/reads a single byte using the SPI interface.
 func (spi SPI) Tx(w, r []byte) error
 ```
 
-Tx handles read/write operation for SPI interface. Since SPI is a syncronous write/read
+Tx handles read/write operation for SPI interface. Since SPI is a synchronous write/read
 interface, there must always be the same number of bytes written as bytes read.
 The Tx method knows about this, and offers a few different ways of calling it.
 

--- a/content/docs/reference/microcontrollers/machine/thingplus-rp2040.md
+++ b/content/docs/reference/microcontrollers/machine/thingplus-rp2040.md
@@ -56,9 +56,13 @@ Analog pins
 
 
 ```go
-const LED = GPIO25
+const (
+	LED	= GPIO25
+	WS2812	= GPIO8
+)
 ```
 
+Onboard LEDs
 
 
 ```go
@@ -1438,7 +1442,7 @@ Write a single byte and read a single byte from TX/RX FIFO.
 func (spi SPI) Tx(w, r []byte) (err error)
 ```
 
-Tx handles read/write operation for SPI interface. Since SPI is a syncronous write/read
+Tx handles read/write operation for SPI interface. Since SPI is a synchronous write/read
 interface, there must always be the same number of bytes written as bytes read.
 The Tx method knows about this, and offers a few different ways of calling it.
 

--- a/content/docs/reference/microcontrollers/machine/trinket-m0.md
+++ b/content/docs/reference/microcontrollers/machine/trinket-m0.md
@@ -529,7 +529,7 @@ func EnableCDC(txHandler func(), rxHandler func([]byte), setupHandler func(usb.S
 func EnterBootloader()
 ```
 
-EnterBootloader should perform a system reset in preperation
+EnterBootloader should perform a system reset in preparation
 to switch to the bootloader to flash new firmware.
 
 
@@ -1308,7 +1308,7 @@ Transfer writes/reads a single byte using the SPI interface.
 func (spi SPI) Tx(w, r []byte) error
 ```
 
-Tx handles read/write operation for SPI interface. Since SPI is a syncronous write/read
+Tx handles read/write operation for SPI interface. Since SPI is a synchronous write/read
 interface, there must always be the same number of bytes written as bytes read.
 The Tx method knows about this, and offers a few different ways of calling it.
 

--- a/content/docs/reference/microcontrollers/machine/trinkey-qt2040.md
+++ b/content/docs/reference/microcontrollers/machine/trinkey-qt2040.md
@@ -1378,7 +1378,7 @@ Write a single byte and read a single byte from TX/RX FIFO.
 func (spi SPI) Tx(w, r []byte) (err error)
 ```
 
-Tx handles read/write operation for SPI interface. Since SPI is a syncronous write/read
+Tx handles read/write operation for SPI interface. Since SPI is a synchronous write/read
 interface, there must always be the same number of bytes written as bytes read.
 The Tx method knows about this, and offers a few different ways of calling it.
 

--- a/content/docs/reference/microcontrollers/machine/tufty2040.md
+++ b/content/docs/reference/microcontrollers/machine/tufty2040.md
@@ -1409,7 +1409,7 @@ Write a single byte and read a single byte from TX/RX FIFO.
 func (spi SPI) Tx(w, r []byte) (err error)
 ```
 
-Tx handles read/write operation for SPI interface. Since SPI is a syncronous write/read
+Tx handles read/write operation for SPI interface. Since SPI is a synchronous write/read
 interface, there must always be the same number of bytes written as bytes read.
 The Tx method knows about this, and offers a few different ways of calling it.
 

--- a/content/docs/reference/microcontrollers/machine/waveshare-rp2040-zero.md
+++ b/content/docs/reference/microcontrollers/machine/waveshare-rp2040-zero.md
@@ -58,7 +58,8 @@ Analog pins
 
 ```go
 const (
-	NEOPIXEL = GPIO16
+	NEOPIXEL	= GPIO16
+	WS2812		= GPIO16
 )
 ```
 
@@ -1435,7 +1436,7 @@ Write a single byte and read a single byte from TX/RX FIFO.
 func (spi SPI) Tx(w, r []byte) (err error)
 ```
 
-Tx handles read/write operation for SPI interface. Since SPI is a syncronous write/read
+Tx handles read/write operation for SPI interface. Since SPI is a synchronous write/read
 interface, there must always be the same number of bytes written as bytes read.
 The Tx method knows about this, and offers a few different ways of calling it.
 

--- a/content/docs/reference/microcontrollers/machine/wioterminal.md
+++ b/content/docs/reference/microcontrollers/machine/wioterminal.md
@@ -1706,7 +1706,7 @@ Transfer writes/reads a single byte using the SPI interface.
 func (spi SPI) Tx(w, r []byte) error
 ```
 
-Tx handles read/write operation for SPI interface. Since SPI is a syncronous write/read
+Tx handles read/write operation for SPI interface. Since SPI is a synchronous write/read
 interface, there must always be the same number of bytes written as bytes read.
 The Tx method knows about this, and offers a few different ways of calling it.
 

--- a/content/docs/reference/microcontrollers/machine/x9pro.md
+++ b/content/docs/reference/microcontrollers/machine/x9pro.md
@@ -1048,7 +1048,7 @@ Transfer writes/reads a single byte using the SPI interface.
 func (spi SPI) Tx(w, r []byte) error
 ```
 
-Tx handles read/write operation for SPI interface. Since SPI is a syncronous
+Tx handles read/write operation for SPI interface. Since SPI is a synchronous
 write/read interface, there must always be the same number of bytes written
 as bytes read. Therefore, if the number of bytes don't match it will be
 padded until they fit: if len(w) > len(r) the extra bytes received will be

--- a/content/docs/reference/microcontrollers/machine/xiao-ble.md
+++ b/content/docs/reference/microcontrollers/machine/xiao-ble.md
@@ -1326,7 +1326,7 @@ Transfer writes/reads a single byte using the SPI interface.
 func (spi SPI) Tx(w, r []byte) error
 ```
 
-Tx handles read/write operation for SPI interface. Since SPI is a syncronous
+Tx handles read/write operation for SPI interface. Since SPI is a synchronous
 write/read interface, there must always be the same number of bytes written
 as bytes read. Therefore, if the number of bytes don't match it will be
 padded until they fit: if len(w) > len(r) the extra bytes received will be

--- a/content/docs/reference/microcontrollers/machine/xiao-rp2040.md
+++ b/content/docs/reference/microcontrollers/machine/xiao-rp2040.md
@@ -1422,7 +1422,7 @@ Write a single byte and read a single byte from TX/RX FIFO.
 func (spi SPI) Tx(w, r []byte) (err error)
 ```
 
-Tx handles read/write operation for SPI interface. Since SPI is a syncronous write/read
+Tx handles read/write operation for SPI interface. Since SPI is a synchronous write/read
 interface, there must always be the same number of bytes written as bytes read.
 The Tx method knows about this, and offers a few different ways of calling it.
 

--- a/content/docs/reference/microcontrollers/machine/xiao.md
+++ b/content/docs/reference/microcontrollers/machine/xiao.md
@@ -544,7 +544,7 @@ func EnableCDC(txHandler func(), rxHandler func([]byte), setupHandler func(usb.S
 func EnterBootloader()
 ```
 
-EnterBootloader should perform a system reset in preperation
+EnterBootloader should perform a system reset in preparation
 to switch to the bootloader to flash new firmware.
 
 
@@ -1323,7 +1323,7 @@ Transfer writes/reads a single byte using the SPI interface.
 func (spi SPI) Tx(w, r []byte) error
 ```
 
-Tx handles read/write operation for SPI interface. Since SPI is a syncronous write/read
+Tx handles read/write operation for SPI interface. Since SPI is a synchronous write/read
 interface, there must always be the same number of bytes written as bytes read.
 The Tx method knows about this, and offers a few different ways of calling it.
 

--- a/content/docs/reference/microcontrollers/thingplus-rp2040.md
+++ b/content/docs/reference/microcontrollers/thingplus-rp2040.md
@@ -32,7 +32,7 @@ Peripherals:
 | `GP4`             | `GPIO4`      | `SPI0_SDI_PIN`    | `PWM2` (channel A)   |
 | `GP6`             | `GPIO6`      | `I2C0_SCL_PIN`, `I2C1_SDA_PIN`, `SDA_PIN` | `PWM3` (channel A)   |
 | `GP7`             | `GPIO7`      | `I2C0_SDA_PIN`, `I2C1_SCL_PIN`, `SCL_PIN` | `PWM3` (channel B)   |
-| `GP8`             | `GPIO8`      |                   | `PWM4` (channel A)   |
+| `GP8`             | `GPIO8`      | `WS2812`          | `PWM4` (channel A)   |
 | `GP9`             | `GPIO9`      |                   | `PWM4` (channel B)   |
 | `GP10`            | `GPIO10`     |                   | `PWM5` (channel A)   |
 | `GP11`            | `GPIO11`     |                   | `PWM5` (channel B)   |

--- a/content/docs/reference/microcontrollers/waveshare-rp2040-zero.md
+++ b/content/docs/reference/microcontrollers/waveshare-rp2040-zero.md
@@ -37,7 +37,7 @@ The [Waveshare RP2040-Zero](https://www.waveshare.com/wiki/RP2040-Zero) is a tin
 | `D13`             | `GPIO13`     |                   | `PWM6` (channel B)   |
 | `D14`             | `GPIO14`     |                   | `PWM7` (channel A)   |
 | `D15`             | `GPIO15`     |                   | `PWM7` (channel B)   |
-| `D16`             | `GPIO16`     | `NEOPIXEL`        | `PWM0` (channel A)   |
+| `D16`             | `GPIO16`     | `NEOPIXEL`, `WS2812` | `PWM0` (channel A)   |
 | `D17`             | `GPIO17`     |                   | `PWM0` (channel B)   |
 | `D18`             | `GPIO18`     |                   | `PWM1` (channel A)   |
 | `D19`             | `GPIO19`     |                   | `PWM1` (channel B)   |


### PR DESCRIPTION
This PR updates the references for all microcontrollers using the info for TinyGo 0.33