### PR TITLE
guides/webassembly: use `//export` instead of `//go:export`

### DIFF
--- a/content/docs/guides/webassembly/wasm.md
+++ b/content/docs/guides/webassembly/wasm.md
@@ -19,13 +19,13 @@ func main() {
 // You should define a function named 'add' in the WebAssembly 'env'
 // module from JavaScript.
 //
-//go:export add
+//export add
 func add(x, y int) int
 
 // This function is exported to JavaScript, so can be called using
 // exports.multiply() in JavaScript.
 //
-//go:export multiply
+//export multiply
 func multiply(x, y int) int {
     return x * y;
 }


### PR DESCRIPTION
`//export` is the official 'big Go' pragma, `//go:export` only exists as an alias because I was lazy in the past and now it's probably too late to remove that pragma. But we should at least use the correct one in the documentation.