### PR TITLE
playground: update to include energy consumption

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -77,16 +77,25 @@ Ready to get started? [Click here](getting-started).
 						<button class="nav-link" id="simulator-properties-tab" data-bs-toggle="tab" data-bs-target="#simulator-panel-properties" type="button" role="tab" aria-controls="simulator-panel-properties" aria-selected="false">Properties</button>
 					</li>
 					<li class="nav-item" role="presentation">
+						<button class="nav-link" id="simulator-power-tab" data-bs-toggle="tab" data-bs-target="#simulator-panel-power" type="button" role="tab" aria-controls="simulator-panel-power" aria-selected="false">Power</button>
+					</li>
+					<li class="nav-item" role="presentation">
 						<button class="nav-link" id="simulator-add-tab" data-bs-toggle="tab" data-bs-target="#simulator-panel-add" type="button" role="tab" aria-controls="simulator-panel-add" aria-selected="false">Add</button>
 					</li>
 				</ul>
 			</div>
 			<div class="tab-content">
 				<div class="tab-pane active terminal-box" id="simulator-panel-terminal" role="tabpanel" aria-labelledby="simulator-tab-terminal">
-					<textarea class="terminal" readonly tabindex="0"></textarea>
+					<div class="terminal" tabindex="0"></div>
 				</div>
 				<div class="tab-pane panel-properties content" id="simulator-panel-properties" role="tabpanel" aria-labelledby="simulator-properties-tab">
 					<div class="content" tabindex="0"></div>
+				</div>
+				<div class="tab-pane panel-power content" id="simulator-panel-power" role="tabpanel" aria-labelledby="simulator-power-tab">
+					<div class="content" tabindex="0">
+						<div class="power-table">Loading...</div>
+						<p class="mb-0 mt-3"><strong>Note:</strong> these numbers are estimates, based on datasheets and measurements. They don't include everything and may be wrong.</p>
+					</div>
 				</div>
 				<div class="tab-pane" id="simulator-panel-add" role="tabpanel" aria-labelledby="simulator-add-tab" tabindex="0">
 					<div class="panel-add">

--- a/layouts/tour/baseof.html
+++ b/layouts/tour/baseof.html
@@ -64,16 +64,25 @@
                         <button class="nav-link" id="simulator-properties-tab" data-bs-toggle="tab" data-bs-target="#simulator-panel-properties" type="button" role="tab" aria-controls="simulator-panel-properties" aria-selected="false">Properties</button>
                       </li>
                       <li class="nav-item" role="presentation">
+                        <button class="nav-link" id="simulator-power-tab" data-bs-toggle="tab" data-bs-target="#simulator-panel-power" type="button" role="tab" aria-controls="simulator-panel-power" aria-selected="false">Power</button>
+                      </li>
+                      <li class="nav-item" role="presentation">
                         <button class="nav-link" id="simulator-add-tab" data-bs-toggle="tab" data-bs-target="#simulator-panel-add" type="button" role="tab" aria-controls="simulator-panel-add" aria-selected="false">Add</button>
                       </li>
                     </ul>
                   </div>
                   <div class="tab-content">
                     <div class="tab-pane active terminal-box" id="simulator-panel-terminal" role="tabpanel" aria-labelledby="simulator-tab-terminal">
-                      <textarea class="terminal" readonly tabindex="0"></textarea>
+                      <div class="terminal" tabindex="0"></div>
                     </div>
                     <div class="tab-pane panel-properties content" id="simulator-panel-properties" role="tabpanel" aria-labelledby="simulator-properties-tab">
                       <div class="content" tabindex="0"></div>
+                    </div>
+                    <div class="tab-pane panel-power content" id="simulator-panel-power" role="tabpanel" aria-labelledby="simulator-power-tab">
+                      <div class="content" tabindex="0">
+                        <div class="power-table">Loading...</div>
+                        <p class="mb-0 mt-3"><strong>Note:</strong> these numbers are estimates, based on datasheets and measurements. They don't include everything and may be wrong.</p>
+                      </div>
                     </div>
                     <div class="tab-pane" id="simulator-panel-add" role="tabpanel" aria-labelledby="simulator-add-tab" tabindex="0">
                       <div class="panel-add">


### PR DESCRIPTION
This updates the playground with a few interesting features:

  1. The terminal is replaced with a new system that should look a bit better. It also clearly shows when it has started and when stopped.
  2. There is a new 'Power' tab, for energy consumption estimation.

Of these, the power tab is the big one. It looks like this:

![Screenshot_20240907_165104](https://github.com/user-attachments/assets/34e9af6e-9edd-41d1-865d-c4d825fbb252)

The idea is that this could help people who want to control longer LED strips and want an idea how much power they're going to consume, and for people wanting to optimize battery life. Though if you really want to reduce current consumption, the information is probably not fine-grained enough yet.
Specifically, I'm planning on adding a tour on how to use WS2812 ("NeoPixel") LED strips, and having estimated current consumption seems helpful for that.

Questions/thoughts:

  * Maybe this is not the best name, what about "Energy"?
  * What about integrating this information directly into the properties tab? So that the devices listed there have both the current state (for example, for LEDS "on" or "off") and the current consumption. I'm just afraid it might become more difficult to read, especially for long LED strips.
  * I wanted to include how much current the MCU uses, but unfortunately that's near-impossible to measure on typical boards. So I just left them out. All current consumption that I couldn't attribute (including the MCU) is part of "Other".
  * The tree doesn't look very nice, I took the lazy way out. This could certainly be improved.
  * I'm using current (amperes, milliamps, etc) here. The main reason for this is that this is what most datasheets list, and because most devices use linear regulators. This means that the current (and therefore energy consumption) remains more or less constant across voltages, so using watts instead only makes things confusing. Batteries are also typically listed in mAh and not in Wh.
  * Most boards use a ton of energy, even when sleeping! For example, the pico uses way more than the datasheet is the lowest it can go. We might want to investigate this and try to optimize sleep current consumption.