### PR TITLE
Update on microcontrollers/arduino-mega2560, I2C support corrected

### DIFF
--- a/content/docs/reference/microcontrollers/arduino-mega2560.md
+++ b/content/docs/reference/microcontrollers/arduino-mega2560.md
@@ -14,7 +14,7 @@ Note: the AVR backend of LLVM is still experimental so you may encounter bugs.
 | GPIO      | YES | YES |
 | UART      | YES | YES |
 | SPI       | YES | YES |
-| I2C       | YES | YES |
+| I2C       | YES | Not yet |
 | ADC       | YES | YES |
 | PWM       | YES | Not yet |
 | USBDevice | NO  | NO  |


### PR DESCRIPTION
Hello after, a discussion in the tinygo slack, one of the maintainers said that the I2C support on [arduino-mega2560](https://tinygo.org/docs/reference/microcontrollers/arduino-mega2560/) was wrong indicating that it have support when it doesn't so I corrected the documentation page

![image](https://github.com/user-attachments/assets/f3652f76-0c11-478e-b47d-36bd12f9ab8f)


![image](https://github.com/user-attachments/assets/d9be2b58-63e3-41e6-8f4d-36f418ba2689)


I look forward to I2C support on tinygo, but until there the documentation page needs to be corrected, later i will see if I can use it with arduino-uno whose page also says to have I2C.

Thank you all for the support! :) 