### PR TITLE
Be specific about universal location of wasm_exec.js

### DIFF
--- a/content/docs/guides/webassembly/wasm.md
+++ b/content/docs/guides/webassembly/wasm.md
@@ -66,7 +66,7 @@ debug symbols from the output. Also note that you must change the path to your W
 docker run -v $GOPATH:/go -e "GOPATH=/go" tinygo/tinygo:0.35.0 GOOS=js GOARCH=wasm tinygo build -o /go/src/github.com/myuser/myrepo/wasm.wasm --no-debug /go/src/github.com/myuser/myrepo/wasm-main.go
 ```
 
-Make sure you copy `wasm_exec.js` to your runtime environment:
+Make sure you copy `wasm_exec.js` to your runtime environment (always available at `$(tinygo env TINYGOROOT)/targets/wasm_exec.js`):
 
 ```
 docker run -v $GOPATH:/go -e "GOPATH=/go" tinygo/tinygo:0.35.0 /bin/bash -c "cp /usr/local/tinygo/targets/wasm_exec.js /go/src/github.com/myuser/myrepo/


### PR DESCRIPTION
I spent a long while trying to figure out how to find `wasm_exec.js` for my build script. The `docker` command below this edited line implies a universal location (of `/usr/local/tinygo/targets/wasm_exec.js`) which isn't true on many systems (eg. installed from zip, or by Homebrew, or on Windows).

This change ensures the intended "correct" way to find the file is easily visible in the docs.