### PR TITLE
all: add Bluesky link

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -66,10 +66,10 @@ showLightDarkModeMenu = true
 	icon = "fab fa-mastodon"
 		desc = "Follow us on Mastodon to get the latest news!"
 [[params.links.user]]
-	name ="Twitter"
-	url = "https://twitter.com/TinyGolang"
-	icon = "fab fa-twitter"
-		desc = "You can also follow us on Twitter"
+	name ="Bluesky"
+	url = "https://bsky.app/profile/tinygo.org"
+	icon = "fab fa-bluesky"
+		desc = "You can also follow us on Bluesky"
 [[params.links.user]]
 	name ="Go Pkg Docs"
 	url = "https://pkg.go.dev/github.com/tinygo-org/tinygo?tab=doc"


### PR DESCRIPTION
This PR adds a link to Bluesky account for TinyGo.