### PR TITLE
content: add links to PIO support for all current rp2040 based boards

### DIFF
--- a/content/docs/reference/microcontrollers/badger2040-w.md
+++ b/content/docs/reference/microcontrollers/badger2040-w.md
@@ -74,3 +74,7 @@ Any troubleshooting tips go here.
 You can use the USB port to the Badger2040-W as a serial port.
 
 The Badger2040-W has an onboard CYW43439 wireless chip for WiFi and Bluetooth communication.
+
+TinyGo has support for the RP2040's on-board Programmable Input/Output (PIO) block.
+
+For more informantion, see [https://github.com/tinygo-org/pio](https://github.com/tinygo-org/pio)

--- a/content/docs/reference/microcontrollers/badger2040.md
+++ b/content/docs/reference/microcontrollers/badger2040.md
@@ -72,3 +72,7 @@ Any troubleshooting tips go here.
 ## Notes
 
 You can use the USB port to the Badger2040 as a serial port.
+
+TinyGo has support for the RP2040's on-board Programmable Input/Output (PIO) block.
+
+For more informantion, see [https://github.com/tinygo-org/pio](https://github.com/tinygo-org/pio)

--- a/content/docs/reference/microcontrollers/challenger-rp2040.md
+++ b/content/docs/reference/microcontrollers/challenger-rp2040.md
@@ -75,3 +75,7 @@ Any troubleshooting tips go here.
 ## Notes
 
 You can use the USB port to the Challenger RP2040 as a serial port.
+
+TinyGo has support for the RP2040's on-board Programmable Input/Output (PIO) block.
+
+For more informantion, see [https://github.com/tinygo-org/pio](https://github.com/tinygo-org/pio)

--- a/content/docs/reference/microcontrollers/feather-rp2040.md
+++ b/content/docs/reference/microcontrollers/feather-rp2040.md
@@ -70,3 +70,7 @@ Any troubleshooting tips go here.
 ## Notes
 
 You can use the USB port to the Feather RP2040 as a serial port.
+
+TinyGo has support for the RP2040's on-board Programmable Input/Output (PIO) block.
+
+For more informantion, see [https://github.com/tinygo-org/pio](https://github.com/tinygo-org/pio)

--- a/content/docs/reference/microcontrollers/macropad-rp2040.md
+++ b/content/docs/reference/microcontrollers/macropad-rp2040.md
@@ -77,3 +77,7 @@ Any troubleshooting tips go here.
 ## Notes
 
 You can use the USB port to the MacroPad RP2040 as a serial port.
+
+TinyGo has support for the RP2040's on-board Programmable Input/Output (PIO) block.
+
+For more informantion, see [https://github.com/tinygo-org/pio](https://github.com/tinygo-org/pio)

--- a/content/docs/reference/microcontrollers/nano-rp2040.md
+++ b/content/docs/reference/microcontrollers/nano-rp2040.md
@@ -82,3 +82,7 @@ Any troubleshooting tips go here.
 ## Notes
 
 You can use the USB port to the Nano RP2040 as a serial port.
+
+TinyGo has support for the RP2040's on-board Programmable Input/Output (PIO) block.
+
+For more informantion, see [https://github.com/tinygo-org/pio](https://github.com/tinygo-org/pio)

--- a/content/docs/reference/microcontrollers/pico.md
+++ b/content/docs/reference/microcontrollers/pico.md
@@ -78,4 +78,8 @@ Any troubleshooting tips go here.
 
 You can use the USB port to the Pico as a serial port.
 
+TinyGo has support for the RP2040's on-board Programmable Input/Output (PIO) block.
+
+For more informantion, see [https://github.com/tinygo-org/pio](https://github.com/tinygo-org/pio)
+
 You can refer to [getting started with Raspberry Pi Pico](https://datasheets.raspberrypi.org/pico/getting-started-with-pico.pdf) documentation on how to connect two Picos together (see Appendix A: Using Picoprobe) to debug and convert `UART0` output on target pico to USB output on picoprobe. You will need the [Picoprobe UF2](https://www.raspberrypi.org/documentation/rp2040/getting-started/#board-specifications), available on the Pico's website under "About" tab.

--- a/content/docs/reference/microcontrollers/qtpy-rp2040.md
+++ b/content/docs/reference/microcontrollers/qtpy-rp2040.md
@@ -64,3 +64,7 @@ Any troubleshooting tips go here.
 ## Notes
 
 You can use the USB port to the QT Py RP2040 as a serial port.
+
+TinyGo has support for the RP2040's on-board Programmable Input/Output (PIO) block.
+
+For more informantion, see [https://github.com/tinygo-org/pio](https://github.com/tinygo-org/pio)

--- a/content/docs/reference/microcontrollers/thingplus-rp2040.md
+++ b/content/docs/reference/microcontrollers/thingplus-rp2040.md
@@ -82,3 +82,7 @@ Any troubleshooting tips go here.
 You can use the USB port to the Thing Plus RP2040 as a serial port.
 
 The Neopixel LED and the SD Card are supported by [tinygo drivers](https://github.com/tinygo-org/drivers)
+
+TinyGo has support for the RP2040's on-board Programmable Input/Output (PIO) block.
+
+For more informantion, see [https://github.com/tinygo-org/pio](https://github.com/tinygo-org/pio)

--- a/content/docs/reference/microcontrollers/trinkey-qt2040.md
+++ b/content/docs/reference/microcontrollers/trinkey-qt2040.md
@@ -55,3 +55,7 @@ Any troubleshooting tips go here.
 ## Notes
 
 You can use the USB port to the Trinkey QT2040 as a serial port.
+
+TinyGo has support for the RP2040's on-board Programmable Input/Output (PIO) block.
+
+For more informantion, see [https://github.com/tinygo-org/pio](https://github.com/tinygo-org/pio)

--- a/content/docs/reference/microcontrollers/tufty2040.md
+++ b/content/docs/reference/microcontrollers/tufty2040.md
@@ -78,3 +78,9 @@ Any troubleshooting tips go here.
 ## Notes
 
 You can use the USB port to the Tufty2040 as a serial port.
+
+TinyGo has support for the RP2040's on-board Programmable Input/Output (PIO) block.
+
+For more informantion, see [https://github.com/tinygo-org/pio](https://github.com/tinygo-org/pio)
+
+For support for the Tufty's display please see [https://github.com/tinygo-org/pio/tree/main/rp2-pio/examples/tufty](https://github.com/tinygo-org/pio/tree/main/rp2-pio/examples/tufty)

--- a/content/docs/reference/microcontrollers/waveshare-rp2040-zero.md
+++ b/content/docs/reference/microcontrollers/waveshare-rp2040-zero.md
@@ -79,3 +79,7 @@ Any troubleshooting tips go here.
 ## Notes
 
 You can use the USB port to the Waveshare RP2040-Zero as a serial port.
+
+TinyGo has support for the RP2040's on-board Programmable Input/Output (PIO) block.
+
+For more informantion, see [https://github.com/tinygo-org/pio](https://github.com/tinygo-org/pio)

--- a/content/docs/reference/microcontrollers/xiao-rp2040.md
+++ b/content/docs/reference/microcontrollers/xiao-rp2040.md
@@ -65,3 +65,7 @@ Any troubleshooting tips go here.
 ## Notes
 
 You can use the USB port to the XIAO RP2040 as a serial port.
+
+TinyGo has support for the RP2040's on-board Programmable Input/Output (PIO) block.
+
+For more informantion, see [https://github.com/tinygo-org/pio](https://github.com/tinygo-org/pio)


### PR DESCRIPTION
This PR adds links to the PIO support for all current rp2040 based boards.

Fixes https://github.com/tinygo-org/tinygo/issues/2589