### PR TITLE
Upgrade to Docsy 0.11.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,4 @@ module github.com/tinygo-org/tinygo-site
 
 go 1.22
 
-require (
-	github.com/google/docsy v0.10.0 // indirect
-)
+require github.com/google/docsy v0.11.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-github.com/FortAwesome/Font-Awesome v0.0.0-20240402185447-c0f460dca7f7/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
-github.com/google/docsy v0.10.0 h1:6tMDacPwAyRWNCfvsn/9qGOZDQ8b0aRzjRZvnZPY5dg=
-github.com/google/docsy v0.10.0/go.mod h1:c0nIAqmRTOuJ01F85U/wJPQtc3Zj9N58Kea9bOT2AJc=
+github.com/FortAwesome/Font-Awesome v0.0.0-20240716171331-37eff7fa00de/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
+github.com/google/docsy v0.11.0 h1:QnV40cc28QwS++kP9qINtrIv4hlASruhC/K3FqkHAmM=
+github.com/google/docsy v0.11.0/go.mod h1:hGGW0OjNuG5ZbH5JRtALY3yvN8ybbEP/v2iaK4bwOUI=
 github.com/twbs/bootstrap v5.3.3+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,7 +7,7 @@
 # "production" environment specific build settings
 [build.environment]
   NODE_VERSION = "20.16.0" # LTS version
-  HUGO_VERSION = "0.129.0"
+  HUGO_VERSION = "0.133.1"
   GO_VERSION = "1.22.x" # any reasonably recent version
 
 # "production" environment specific build settings


### PR DESCRIPTION
There isn't much new in this release relevant to us, but this version does support a newer Hugo version (v0.333). Apparently Hugo keeps breaking backwards compatibility so we need to keep the Docsy version somewhat up to date.