### PR TITLE
microcontrollers: add I2C to listed pins

### DIFF
--- a/content/docs/reference/microcontrollers/arduino-mega1280.md
+++ b/content/docs/reference/microcontrollers/arduino-mega1280.md
@@ -21,78 +21,78 @@ Note: the AVR backend of LLVM is still experimental so you may encounter bugs.
 
 ## Pins
 
-| Pin               | Hardware pin | Alternative names | PWM                  |
-| ----------------- | ------------ | ----------------- | -------------------- |
-| `A0`              | `PF0`        | `ADC0`            |                      |
-| `A1`              | `PF1`        | `ADC1`            |                      |
-| `A2`              | `PF2`        | `ADC2`            |                      |
-| `A3`              | `PF3`        | `ADC3`            |                      |
-| `A4`              | `PF4`        | `ADC4`            |                      |
-| `A5`              | `PF5`        | `ADC5`            |                      |
-| `A6`              | `PF6`        | `ADC6`            |                      |
-| `A7`              | `PF7`        | `ADC7`            |                      |
-| `A8`              | `PK0`        | `ADC8`            |                      |
-| `A9`              | `PK1`        | `ADC9`            |                      |
-| `A10`             | `PK2`        | `ADC10`           |                      |
-| `A11`             | `PK3`        | `ADC11`           |                      |
-| `A12`             | `PK4`        | `ADC12`           |                      |
-| `A13`             | `PK5`        | `ADC13`           |                      |
-| `A14`             | `PK6`        | `ADC14`           |                      |
-| `A15`             | `PK7`        | `ADC15`           |                      |
-| `D0`              | `PE0`        |                   |                      |
-| `D1`              | `PE1`        |                   |                      |
-| `D2`              | `PE4`        |                   | `Timer3` (channel B) |
-| `D3`              | `PE5`        |                   | `Timer3` (channel C) |
-| `D4`              | `PG5`        |                   | `Timer0` (channel B) |
-| `D5`              | `PE3`        |                   | `Timer3` (channel A) |
-| `D6`              | `PH3`        |                   | `Timer4` (channel A) |
-| `D7`              | `PH4`        |                   | `Timer4` (channel B) |
-| `D8`              | `PH5`        |                   | `Timer4` (channel C) |
-| `D9`              | `PH6`        |                   | `Timer0` (channel B) |
-| `D10`             | `PB4`        |                   | `Timer2` (channel A) |
-| `D11`             | `PB5`        |                   | `Timer1` (channel A) |
-| `D12`             | `PB6`        |                   | `Timer1` (channel B) |
-| `D13`             | `PB7`        | `LED`             | `Timer0` (channel A) |
-| `D14`             | `PJ1`        |                   |                      |
-| `D15`             | `PJ0`        |                   |                      |
-| `D16`             | `PH1`        |                   |                      |
-| `D17`             | `PH0`        |                   |                      |
-| `D18`             | `PD3`        |                   |                      |
-| `D19`             | `PD2`        |                   |                      |
-| `D20`             | `PD1`        |                   |                      |
-| `D21`             | `PD0`        |                   |                      |
-| `D22`             | `PA0`        |                   |                      |
-| `D23`             | `PA1`        |                   |                      |
-| `D24`             | `PA2`        |                   |                      |
-| `D25`             | `PA3`        |                   |                      |
-| `D26`             | `PA4`        |                   |                      |
-| `D27`             | `PA5`        |                   |                      |
-| `D28`             | `PA6`        |                   |                      |
-| `D29`             | `PA7`        |                   |                      |
-| `D30`             | `PC7`        |                   |                      |
-| `D31`             | `PC6`        |                   |                      |
-| `D32`             | `PC5`        |                   |                      |
-| `D33`             | `PC4`        |                   |                      |
-| `D34`             | `PC3`        |                   |                      |
-| `D35`             | `PC2`        |                   |                      |
-| `D36`             | `PC1`        |                   |                      |
-| `D37`             | `PC0`        |                   |                      |
-| `D38`             | `PD7`        |                   |                      |
-| `D39`             | `PG2`        |                   |                      |
-| `D40`             | `PG1`        |                   |                      |
-| `D41`             | `PG0`        |                   |                      |
-| `D42`             | `PL7`        |                   |                      |
-| `D43`             | `PL6`        |                   |                      |
-| `D44`             | `PL5`        |                   | `Timer5` (channel C) |
-| `D45`             | `PL4`        |                   | `Timer5` (channel B) |
-| `D46`             | `PL3`        |                   | `Timer5` (channel A) |
-| `D47`             | `PL2`        |                   |                      |
-| `D48`             | `PL1`        |                   |                      |
-| `D49`             | `PL0`        |                   |                      |
-| `D50`             | `PB3`        |                   |                      |
-| `D51`             | `PB2`        |                   |                      |
-| `D52`             | `PB1`        |                   |                      |
-| `D53`             | `PB0`        |                   |                      |
+| Pin               | Hardware pin | Alternative names | I2C                  | PWM                  |
+| ----------------- | ------------ | ----------------- | -------------------- | -------------------- |
+| `A0`              | `PF0`        | `ADC0`            |                      |                      |
+| `A1`              | `PF1`        | `ADC1`            |                      |                      |
+| `A2`              | `PF2`        | `ADC2`            |                      |                      |
+| `A3`              | `PF3`        | `ADC3`            |                      |                      |
+| `A4`              | `PF4`        | `ADC4`            |                      |                      |
+| `A5`              | `PF5`        | `ADC5`            |                      |                      |
+| `A6`              | `PF6`        | `ADC6`            |                      |                      |
+| `A7`              | `PF7`        | `ADC7`            |                      |                      |
+| `A8`              | `PK0`        | `ADC8`            |                      |                      |
+| `A9`              | `PK1`        | `ADC9`            |                      |                      |
+| `A10`             | `PK2`        | `ADC10`           |                      |                      |
+| `A11`             | `PK3`        | `ADC11`           |                      |                      |
+| `A12`             | `PK4`        | `ADC12`           |                      |                      |
+| `A13`             | `PK5`        | `ADC13`           |                      |                      |
+| `A14`             | `PK6`        | `ADC14`           |                      |                      |
+| `A15`             | `PK7`        | `ADC15`           |                      |                      |
+| `D0`              | `PE0`        |                   |                      |                      |
+| `D1`              | `PE1`        |                   |                      |                      |
+| `D2`              | `PE4`        |                   |                      | `Timer3` (channel B) |
+| `D3`              | `PE5`        |                   |                      | `Timer3` (channel C) |
+| `D4`              | `PG5`        |                   |                      | `Timer0` (channel B) |
+| `D5`              | `PE3`        |                   |                      | `Timer3` (channel A) |
+| `D6`              | `PH3`        |                   |                      | `Timer4` (channel A) |
+| `D7`              | `PH4`        |                   |                      | `Timer4` (channel B) |
+| `D8`              | `PH5`        |                   |                      | `Timer4` (channel C) |
+| `D9`              | `PH6`        |                   |                      | `Timer0` (channel B) |
+| `D10`             | `PB4`        |                   |                      | `Timer2` (channel A) |
+| `D11`             | `PB5`        |                   |                      | `Timer1` (channel A) |
+| `D12`             | `PB6`        |                   |                      | `Timer1` (channel B) |
+| `D13`             | `PB7`        | `LED`             |                      | `Timer0` (channel A) |
+| `D14`             | `PJ1`        |                   |                      |                      |
+| `D15`             | `PJ0`        |                   |                      |                      |
+| `D16`             | `PH1`        |                   |                      |                      |
+| `D17`             | `PH0`        |                   |                      |                      |
+| `D18`             | `PD3`        |                   |                      |                      |
+| `D19`             | `PD2`        |                   |                      |                      |
+| `D20`             | `PD1`        |                   | `I2C0` (SDA)         |                      |
+| `D21`             | `PD0`        |                   | `I2C0` (SCL)         |                      |
+| `D22`             | `PA0`        |                   |                      |                      |
+| `D23`             | `PA1`        |                   |                      |                      |
+| `D24`             | `PA2`        |                   |                      |                      |
+| `D25`             | `PA3`        |                   |                      |                      |
+| `D26`             | `PA4`        |                   |                      |                      |
+| `D27`             | `PA5`        |                   |                      |                      |
+| `D28`             | `PA6`        |                   |                      |                      |
+| `D29`             | `PA7`        |                   |                      |                      |
+| `D30`             | `PC7`        |                   |                      |                      |
+| `D31`             | `PC6`        |                   |                      |                      |
+| `D32`             | `PC5`        |                   |                      |                      |
+| `D33`             | `PC4`        |                   |                      |                      |
+| `D34`             | `PC3`        |                   |                      |                      |
+| `D35`             | `PC2`        |                   |                      |                      |
+| `D36`             | `PC1`        |                   |                      |                      |
+| `D37`             | `PC0`        |                   |                      |                      |
+| `D38`             | `PD7`        |                   |                      |                      |
+| `D39`             | `PG2`        |                   |                      |                      |
+| `D40`             | `PG1`        |                   |                      |                      |
+| `D41`             | `PG0`        |                   |                      |                      |
+| `D42`             | `PL7`        |                   |                      |                      |
+| `D43`             | `PL6`        |                   |                      |                      |
+| `D44`             | `PL5`        |                   |                      | `Timer5` (channel C) |
+| `D45`             | `PL4`        |                   |                      | `Timer5` (channel B) |
+| `D46`             | `PL3`        |                   |                      | `Timer5` (channel A) |
+| `D47`             | `PL2`        |                   |                      |                      |
+| `D48`             | `PL1`        |                   |                      |                      |
+| `D49`             | `PL0`        |                   |                      |                      |
+| `D50`             | `PB3`        |                   |                      |                      |
+| `D51`             | `PB2`        |                   |                      |                      |
+| `D52`             | `PB1`        |                   |                      |                      |
+| `D53`             | `PB0`        |                   |                      |                      |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/arduino-mkrwifi1010.md
+++ b/content/docs/reference/microcontrollers/arduino-mkrwifi1010.md
@@ -19,39 +19,39 @@ The [Arduino MKR WiFi 1010](https://store.arduino.cc/usa/mkr-wifi-1010) is a ver
 
 ## Pins
 
-| Pin               | Hardware pin | Alternative names | PWM                  |
-| ----------------- | ------------ | ----------------- | -------------------- |
-| `D0`              | `PA22`       | `NINA_TX`         | `TCC0` (channel 0)   |
-| `D1`              | `PA23`       | `NINA_RX`         | `TCC0` (channel 1)   |
-| `D2`              | `PA10`       | `I2S_SCK_PIN`     | `TCC1` (channel 0), `TCC0` (channel 2) |
-| `D3`              | `PA11`       |                   | `TCC1` (channel 1), `TCC0` (channel 3) |
-| `D4`              | `PB10`       |                   | `TCC0` (channel 0)   |
-| `D5`              | `PB11`       |                   | `TCC0` (channel 1)   |
-| `D6`              | `PA20`       | `LED`             | `TCC0` (channel 2)   |
-| `D7`              | `PA21`       |                   | `TCC0` (channel 3)   |
-| `D8`              | `PA16`       | `SPI0_SDO_PIN`    | `TCC2` (channel 0), `TCC0` (channel 2) |
-| `D9`              | `PA17`       | `SPI0_SCK_PIN`    | `TCC2` (channel 1), `TCC0` (channel 3) |
-| `D10`             | `PA19`       | `SPI0_SDI_PIN`    | `TCC0` (channel 3)   |
-| `D11`             | `PA08`       | `SDA_PIN`         | `TCC0` (channel 0), `TCC1` (channel 2) |
-| `D12`             | `PA09`       | `SCL_PIN`         | `TCC0` (channel 1), `TCC1` (channel 3) |
-| `D13`             | `PB23`       | `RX0`, `UART_RX_PIN` |                      |
-| `D14`             | `PB22`       | `TX1`, `UART_TX_PIN` |                      |
-| `A0`              | `PA02`       |                   |                      |
-| `A1`              | `PB02`       |                   |                      |
-| `A2`              | `PB03`       |                   |                      |
-| `A3`              | `PA04`       |                   | `TCC0` (channel 0)   |
-| `A4`              | `PA05`       |                   | `TCC0` (channel 1)   |
-| `A5`              | `PA06`       |                   | `TCC1` (channel 0)   |
-| `A6`              | `PA07`       | `I2S_SDO_PIN`     | `TCC1` (channel 1)   |
-| `USBCDC_DM_PIN`   | `PA24`       |                   | `TCC1` (channel 2)   |
-| `USBCDC_DP_PIN`   | `PA25`       |                   | `TCC1` (channel 3)   |
-| `NINA_SDO`        | `PA12`       |                   | `TCC2` (channel 0), `TCC0` (channel 2) |
-| `NINA_SDI`        | `PA13`       |                   | `TCC2` (channel 1), `TCC0` (channel 3) |
-| `NINA_CS`         | `PA14`       |                   | `TCC0` (channel 0)   |
-| `NINA_SCK`        | `PA15`       |                   | `TCC0` (channel 1)   |
-| `NINA_GPIO0`      | `PA27`       |                   |                      |
-| `NINA_RESETN`     | `PB08`       |                   |                      |
-| `NINA_ACK`        | `PA28`       |                   |                      |
+| Pin               | Hardware pin | Alternative names | I2C                  | PWM                  |
+| ----------------- | ------------ | ----------------- | -------------------- | -------------------- |
+| `D0`              | `PA22`       | `NINA_TX`         |                      | `TCC0` (channel 0)   |
+| `D1`              | `PA23`       | `NINA_RX`         |                      | `TCC0` (channel 1)   |
+| `D2`              | `PA10`       | `I2S_SCK_PIN`     |                      | `TCC1` (channel 0), `TCC0` (channel 2) |
+| `D3`              | `PA11`       |                   |                      | `TCC1` (channel 1), `TCC0` (channel 3) |
+| `D4`              | `PB10`       |                   |                      | `TCC0` (channel 0)   |
+| `D5`              | `PB11`       |                   |                      | `TCC0` (channel 1)   |
+| `D6`              | `PA20`       | `LED`             |                      | `TCC0` (channel 2)   |
+| `D7`              | `PA21`       |                   |                      | `TCC0` (channel 3)   |
+| `D8`              | `PA16`       | `SPI0_SDO_PIN`    |                      | `TCC2` (channel 0), `TCC0` (channel 2) |
+| `D9`              | `PA17`       | `SPI0_SCK_PIN`    |                      | `TCC2` (channel 1), `TCC0` (channel 3) |
+| `D10`             | `PA19`       | `SPI0_SDI_PIN`    |                      | `TCC0` (channel 3)   |
+| `D11`             | `PA08`       | `SDA_PIN`         | `I2C0` (SDA)         | `TCC0` (channel 0), `TCC1` (channel 2) |
+| `D12`             | `PA09`       | `SCL_PIN`         | `I2C0` (SCL)         | `TCC0` (channel 1), `TCC1` (channel 3) |
+| `D13`             | `PB23`       | `RX0`, `UART_RX_PIN` |                      |                      |
+| `D14`             | `PB22`       | `TX1`, `UART_TX_PIN` |                      |                      |
+| `A0`              | `PA02`       |                   |                      |                      |
+| `A1`              | `PB02`       |                   |                      |                      |
+| `A2`              | `PB03`       |                   |                      |                      |
+| `A3`              | `PA04`       |                   |                      | `TCC0` (channel 0)   |
+| `A4`              | `PA05`       |                   |                      | `TCC0` (channel 1)   |
+| `A5`              | `PA06`       |                   |                      | `TCC1` (channel 0)   |
+| `A6`              | `PA07`       | `I2S_SDO_PIN`     |                      | `TCC1` (channel 1)   |
+| `USBCDC_DM_PIN`   | `PA24`       |                   |                      | `TCC1` (channel 2)   |
+| `USBCDC_DP_PIN`   | `PA25`       |                   |                      | `TCC1` (channel 3)   |
+| `NINA_SDO`        | `PA12`       |                   | `I2C0` (SDA)         | `TCC2` (channel 0), `TCC0` (channel 2) |
+| `NINA_SDI`        | `PA13`       |                   | `I2C0` (SCL)         | `TCC2` (channel 1), `TCC0` (channel 3) |
+| `NINA_CS`         | `PA14`       |                   |                      | `TCC0` (channel 0)   |
+| `NINA_SCK`        | `PA15`       |                   |                      | `TCC0` (channel 1)   |
+| `NINA_GPIO0`      | `PA27`       |                   |                      |                      |
+| `NINA_RESETN`     | `PB08`       |                   |                      |                      |
+| `NINA_ACK`        | `PA28`       |                   |                      |                      |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/arduino-nano.md
+++ b/content/docs/reference/microcontrollers/arduino-nano.md
@@ -21,28 +21,28 @@ Note: the AVR backend of LLVM is still experimental so you may encounter bugs.
 
 ## Pins
 
-| Pin               | Hardware pin | Alternative names | PWM                  |
-| ----------------- | ------------ | ----------------- | -------------------- |
-| `D0`              | `PD0`        | `UART_RX_PIN`     |                      |
-| `D1`              | `PD1`        | `UART_TX_PIN`     |                      |
-| `D2`              | `PD2`        |                   |                      |
-| `D3`              | `PD3`        |                   | `Timer2` (channel B) |
-| `D4`              | `PD4`        |                   |                      |
-| `D5`              | `PD5`        |                   | `Timer0` (channel B) |
-| `D6`              | `PD6`        |                   | `Timer0` (channel A) |
-| `D7`              | `PD7`        |                   |                      |
-| `D8`              | `PB0`        |                   |                      |
-| `D9`              | `PB1`        |                   | `Timer1` (channel A) |
-| `D10`             | `PB2`        |                   | `Timer1` (channel B) |
-| `D11`             | `PB3`        |                   | `Timer2` (channel A) |
-| `D12`             | `PB4`        |                   |                      |
-| `D13`             | `PB5`        | `LED`             |                      |
-| `ADC0`            | `PC0`        |                   |                      |
-| `ADC1`            | `PC1`        |                   |                      |
-| `ADC2`            | `PC2`        |                   |                      |
-| `ADC3`            | `PC3`        |                   |                      |
-| `ADC4`            | `PC4`        |                   |                      |
-| `ADC5`            | `PC5`        |                   |                      |
+| Pin               | Hardware pin | Alternative names | I2C                  | PWM                  |
+| ----------------- | ------------ | ----------------- | -------------------- | -------------------- |
+| `D0`              | `PD0`        | `UART_RX_PIN`     |                      |                      |
+| `D1`              | `PD1`        | `UART_TX_PIN`     |                      |                      |
+| `D2`              | `PD2`        |                   |                      |                      |
+| `D3`              | `PD3`        |                   |                      | `Timer2` (channel B) |
+| `D4`              | `PD4`        |                   |                      |                      |
+| `D5`              | `PD5`        |                   |                      | `Timer0` (channel B) |
+| `D6`              | `PD6`        |                   |                      | `Timer0` (channel A) |
+| `D7`              | `PD7`        |                   |                      |                      |
+| `D8`              | `PB0`        |                   |                      |                      |
+| `D9`              | `PB1`        |                   |                      | `Timer1` (channel A) |
+| `D10`             | `PB2`        |                   |                      | `Timer1` (channel B) |
+| `D11`             | `PB3`        |                   |                      | `Timer2` (channel A) |
+| `D12`             | `PB4`        |                   |                      |                      |
+| `D13`             | `PB5`        | `LED`             |                      |                      |
+| `ADC0`            | `PC0`        |                   |                      |                      |
+| `ADC1`            | `PC1`        |                   |                      |                      |
+| `ADC2`            | `PC2`        |                   |                      |                      |
+| `ADC3`            | `PC3`        |                   |                      |                      |
+| `ADC4`            | `PC4`        |                   | `I2C0` (SDA)         |                      |
+| `ADC5`            | `PC5`        |                   | `I2C0` (SCL)         |                      |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/arduino-nano33.md
+++ b/content/docs/reference/microcontrollers/arduino-nano33.md
@@ -23,41 +23,41 @@ Peripherals:
 
 ## Pins
 
-| Pin               | Hardware pin | Alternative names | PWM                  |
-| ----------------- | ------------ | ----------------- | -------------------- |
-| `RX0`             | `PB23`       |                   |                      |
-| `TX1`             | `PB22`       |                   |                      |
-| `D2`              | `PB10`       |                   | `TCC0` (channel 0)   |
-| `D3`              | `PB11`       |                   | `TCC0` (channel 1)   |
-| `D4`              | `PA07`       |                   | `TCC1` (channel 1)   |
-| `D5`              | `PA05`       |                   | `TCC0` (channel 1)   |
-| `D6`              | `PA04`       |                   | `TCC0` (channel 0)   |
-| `D7`              | `PA06`       |                   | `TCC1` (channel 0)   |
-| `D8`              | `PA18`       |                   | `TCC0` (channel 2)   |
-| `D9`              | `PA20`       |                   | `TCC0` (channel 2)   |
-| `D10`             | `PA21`       |                   | `TCC0` (channel 3)   |
-| `D11`             | `PA16`       | `SPI0_SDO_PIN`    | `TCC2` (channel 0), `TCC0` (channel 2) |
-| `D12`             | `PA19`       | `SPI0_SDI_PIN`    | `TCC0` (channel 3)   |
-| `D13`             | `PA17`       | `LED`, `SPI0_SCK_PIN` | `TCC2` (channel 1), `TCC0` (channel 3) |
-| `A0`              | `PA02`       |                   |                      |
-| `A1`              | `PB02`       |                   |                      |
-| `A2`              | `PA11`       |                   | `TCC1` (channel 1), `TCC0` (channel 3) |
-| `A3`              | `PA10`       | `I2S_SCK_PIN`     | `TCC1` (channel 0), `TCC0` (channel 2) |
-| `A4`              | `PB08`       | `SDA_PIN`         |                      |
-| `A5`              | `PB09`       | `SCL_PIN`         |                      |
-| `A6`              | `PA09`       |                   | `TCC0` (channel 1), `TCC1` (channel 3) |
-| `A7`              | `PB03`       |                   |                      |
-| `USBCDC_DM_PIN`   | `PA24`       |                   | `TCC1` (channel 2)   |
-| `USBCDC_DP_PIN`   | `PA25`       |                   | `TCC1` (channel 3)   |
-| `UART_TX_PIN`     | `PA22`       |                   | `TCC0` (channel 0)   |
-| `UART_RX_PIN`     | `PA23`       |                   | `TCC0` (channel 1)   |
-| `NINA_SDO`        | `PA12`       | `NINA_TX`         | `TCC2` (channel 0), `TCC0` (channel 2) |
-| `NINA_SDI`        | `PA13`       | `NINA_RX`         | `TCC2` (channel 1), `TCC0` (channel 3) |
-| `NINA_CS`         | `PA14`       | `NINA_RTS`        | `TCC0` (channel 0)   |
-| `NINA_SCK`        | `PA15`       | `NINA_CTS`        | `TCC0` (channel 1)   |
-| `NINA_GPIO0`      | `PA27`       |                   |                      |
-| `NINA_RESETN`     | `PA08`       | `I2S_SDO_PIN`     | `TCC0` (channel 0), `TCC1` (channel 2) |
-| `NINA_ACK`        | `PA28`       |                   |                      |
+| Pin               | Hardware pin | Alternative names | I2C                  | PWM                  |
+| ----------------- | ------------ | ----------------- | -------------------- | -------------------- |
+| `RX0`             | `PB23`       |                   |                      |                      |
+| `TX1`             | `PB22`       |                   |                      |                      |
+| `D2`              | `PB10`       |                   |                      | `TCC0` (channel 0)   |
+| `D3`              | `PB11`       |                   |                      | `TCC0` (channel 1)   |
+| `D4`              | `PA07`       |                   |                      | `TCC1` (channel 1)   |
+| `D5`              | `PA05`       |                   |                      | `TCC0` (channel 1)   |
+| `D6`              | `PA04`       |                   |                      | `TCC0` (channel 0)   |
+| `D7`              | `PA06`       |                   |                      | `TCC1` (channel 0)   |
+| `D8`              | `PA18`       |                   |                      | `TCC0` (channel 2)   |
+| `D9`              | `PA20`       |                   |                      | `TCC0` (channel 2)   |
+| `D10`             | `PA21`       |                   |                      | `TCC0` (channel 3)   |
+| `D11`             | `PA16`       | `SPI0_SDO_PIN`    |                      | `TCC2` (channel 0), `TCC0` (channel 2) |
+| `D12`             | `PA19`       | `SPI0_SDI_PIN`    |                      | `TCC0` (channel 3)   |
+| `D13`             | `PA17`       | `LED`, `SPI0_SCK_PIN` |                      | `TCC2` (channel 1), `TCC0` (channel 3) |
+| `A0`              | `PA02`       |                   |                      |                      |
+| `A1`              | `PB02`       |                   |                      |                      |
+| `A2`              | `PA11`       |                   |                      | `TCC1` (channel 1), `TCC0` (channel 3) |
+| `A3`              | `PA10`       | `I2S_SCK_PIN`     |                      | `TCC1` (channel 0), `TCC0` (channel 2) |
+| `A4`              | `PB08`       | `SDA_PIN`         | `I2C0` (SDA)         |                      |
+| `A5`              | `PB09`       | `SCL_PIN`         | `I2C0` (SCL)         |                      |
+| `A6`              | `PA09`       |                   |                      | `TCC0` (channel 1), `TCC1` (channel 3) |
+| `A7`              | `PB03`       |                   |                      |                      |
+| `USBCDC_DM_PIN`   | `PA24`       |                   |                      | `TCC1` (channel 2)   |
+| `USBCDC_DP_PIN`   | `PA25`       |                   |                      | `TCC1` (channel 3)   |
+| `UART_TX_PIN`     | `PA22`       |                   |                      | `TCC0` (channel 0)   |
+| `UART_RX_PIN`     | `PA23`       |                   |                      | `TCC0` (channel 1)   |
+| `NINA_SDO`        | `PA12`       | `NINA_TX`         | `I2C0` (SDA)         | `TCC2` (channel 0), `TCC0` (channel 2) |
+| `NINA_SDI`        | `PA13`       | `NINA_RX`         | `I2C0` (SCL)         | `TCC2` (channel 1), `TCC0` (channel 3) |
+| `NINA_CS`         | `PA14`       | `NINA_RTS`        |                      | `TCC0` (channel 0)   |
+| `NINA_SCK`        | `PA15`       | `NINA_CTS`        |                      | `TCC0` (channel 1)   |
+| `NINA_GPIO0`      | `PA27`       |                   |                      |                      |
+| `NINA_RESETN`     | `PA08`       | `I2S_SDO_PIN`     |                      | `TCC0` (channel 0), `TCC1` (channel 2) |
+| `NINA_ACK`        | `PA28`       |                   |                      |                      |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/arduino.md
+++ b/content/docs/reference/microcontrollers/arduino.md
@@ -21,28 +21,28 @@ Note: the AVR backend of LLVM is still experimental so you may encounter bugs.
 
 ## Pins
 
-| Pin               | Hardware pin | Alternative names | PWM                  |
-| ----------------- | ------------ | ----------------- | -------------------- |
-| `D0`              | `PD0`        | `UART_RX_PIN`     |                      |
-| `D1`              | `PD1`        | `UART_TX_PIN`     |                      |
-| `D2`              | `PD2`        |                   |                      |
-| `D3`              | `PD3`        |                   | `Timer2` (channel B) |
-| `D4`              | `PD4`        |                   |                      |
-| `D5`              | `PD5`        |                   | `Timer0` (channel B) |
-| `D6`              | `PD6`        |                   | `Timer0` (channel A) |
-| `D7`              | `PD7`        |                   |                      |
-| `D8`              | `PB0`        |                   |                      |
-| `D9`              | `PB1`        |                   | `Timer1` (channel A) |
-| `D10`             | `PB2`        |                   | `Timer1` (channel B) |
-| `D11`             | `PB3`        |                   | `Timer2` (channel A) |
-| `D12`             | `PB4`        |                   |                      |
-| `D13`             | `PB5`        | `LED`             |                      |
-| `ADC0`            | `PC0`        |                   |                      |
-| `ADC1`            | `PC1`        |                   |                      |
-| `ADC2`            | `PC2`        |                   |                      |
-| `ADC3`            | `PC3`        |                   |                      |
-| `ADC4`            | `PC4`        |                   |                      |
-| `ADC5`            | `PC5`        |                   |                      |
+| Pin               | Hardware pin | Alternative names | I2C                  | PWM                  |
+| ----------------- | ------------ | ----------------- | -------------------- | -------------------- |
+| `D0`              | `PD0`        | `UART_RX_PIN`     |                      |                      |
+| `D1`              | `PD1`        | `UART_TX_PIN`     |                      |                      |
+| `D2`              | `PD2`        |                   |                      |                      |
+| `D3`              | `PD3`        |                   |                      | `Timer2` (channel B) |
+| `D4`              | `PD4`        |                   |                      |                      |
+| `D5`              | `PD5`        |                   |                      | `Timer0` (channel B) |
+| `D6`              | `PD6`        |                   |                      | `Timer0` (channel A) |
+| `D7`              | `PD7`        |                   |                      |                      |
+| `D8`              | `PB0`        |                   |                      |                      |
+| `D9`              | `PB1`        |                   |                      | `Timer1` (channel A) |
+| `D10`             | `PB2`        |                   |                      | `Timer1` (channel B) |
+| `D11`             | `PB3`        |                   |                      | `Timer2` (channel A) |
+| `D12`             | `PB4`        |                   |                      |                      |
+| `D13`             | `PB5`        | `LED`             |                      |                      |
+| `ADC0`            | `PC0`        |                   |                      |                      |
+| `ADC1`            | `PC1`        |                   |                      |                      |
+| `ADC2`            | `PC2`        |                   |                      |                      |
+| `ADC3`            | `PC3`        |                   |                      |                      |
+| `ADC4`            | `PC4`        |                   | `I2C0` (SDA)         |                      |
+| `ADC5`            | `PC5`        |                   | `I2C0` (SCL)         |                      |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/atsame54-xpro.md
+++ b/content/docs/reference/microcontrollers/atsame54-xpro.md
@@ -19,94 +19,94 @@ The [Microchip SAM E54 Xplained Pro](https://www.microchip.com/developmenttools/
 
 ## Pins
 
-| Pin               | Hardware pin | Alternative names | PWM                  |
-| ----------------- | ------------ | ----------------- | -------------------- |
-| `LED`             | `PC18`       | `PDEC_INDEX`, `PIN_LED0` | `TCC0` (channel 2)   |
-| `BUTTON`          | `PB31`       | `PIN_BTN0`        | `TCC4` (channel 1), `TCC0` (channel 7) |
-| `EXT1_PIN3_ADC_P` | `PB04`       |                   |                      |
-| `EXT1_PIN4_ADC_N` | `PB05`       |                   |                      |
-| `EXT1_PIN5_GPIO1` | `PA06`       |                   |                      |
-| `EXT1_PIN6_GPIO2` | `PA07`       |                   |                      |
-| `EXT1_PIN7_PWM_P` | `PB08`       |                   |                      |
-| `EXT1_PIN8_PWM_N` | `PB09`       |                   |                      |
-| `EXT1_PIN9_IRQ`   | `PB07`       | `EXT1_PIN9_GPIO`  |                      |
-| `EXT1_PIN10_SPI_SS_B` | `PA27`       | `EXT1_PIN10_GPIO` |                      |
-| `EXT1_PIN11_TWI_SDA` | `PA22`       | `CAN0_TX`, `PCC_DATA06`, `SDA0_PIN`, `SDA_PIN` | `TCC1` (channel 6), `TCC0` (channel 2) |
-| `EXT1_PIN12_TWI_SCL` | `PA23`       | `CAN0_RX`, `PCC_DATA07`, `SCL0_PIN`, `SCL_PIN` | `TCC1` (channel 7), `TCC0` (channel 3) |
-| `EXT1_PIN13_UART_RX` | `PA05`       | `UART_RX_PIN`     |                      |
-| `EXT1_PIN14_UART_TX` | `PA04`       | `UART_TX_PIN`     |                      |
-| `EXT1_PIN15_SPI_SS_A` | `PB28`       | `SPI0_SS_PIN`     | `TCC1` (channel 4)   |
-| `EXT1_PIN16_SPI_SDO` | `PB27`       | `SPI0_SDO_PIN`    | `TCC1` (channel 3)   |
-| `EXT1_PIN17_SPI_SDI` | `PB29`       | `SPI0_SDI_PIN`    | `TCC1` (channel 5)   |
-| `EXT1_PIN18_SPI_SCK` | `PB26`       | `SPI0_SCK_PIN`    | `TCC1` (channel 2)   |
-| `EXT2_PIN3_ADC_P` | `PB00`       |                   |                      |
-| `EXT2_PIN4_ADC_N` | `PA03`       |                   |                      |
-| `EXT2_PIN5_GPIO1` | `PB01`       |                   |                      |
-| `EXT2_PIN6_GPIO2` | `PB06`       |                   |                      |
-| `EXT2_PIN7_PWM_P` | `PB14`       | `PCC_DATA08`      | `TCC4` (channel 0), `TCC0` (channel 2) |
-| `EXT2_PIN8_PWM_N` | `PB15`       | `PCC_DATA09`      | `TCC4` (channel 1), `TCC0` (channel 3) |
-| `EXT2_PIN9_IRQ`   | `PD00`       | `EXT2_PIN9_GPIO`  |                      |
-| `EXT2_PIN10_SPI_SS_B` | `PB02`       | `EXT2_PIN10_GPIO` | `TCC2` (channel 2)   |
-| `EXT2_PIN11_TWI_SDA` | `PD08`       | `EXT3_PIN11_TWI_SDA`, `I2C_SDA`, `PCC_I2C_SDA`, `SDA1_PIN`, `SDA2_PIN`, `SDA_DGI_PIN` | `TCC0` (channel 1)   |
-| `EXT2_PIN12_TWI_SCL` | `PD09`       | `EXT3_PIN12_TWI_SCL`, `I2C_SCL`, `PCC_I2C_SCL`, `SCL1_PIN`, `SCL2_PIN`, `SCL_DGI_PIN` | `TCC0` (channel 2)   |
-| `EXT2_PIN13_UART_RX` | `PB17`       | `UART2_RX_PIN`    | `TCC3` (channel 1), `TCC0` (channel 5) |
-| `EXT2_PIN14_UART_TX` | `PB16`       | `UART2_TX_PIN`    | `TCC3` (channel 0), `TCC0` (channel 4) |
-| `EXT2_PIN15_SPI_SS_A` | `PC06`       | `SPI1_SS_PIN`     |                      |
-| `EXT2_PIN16_SPI_SDO` | `PC04`       | `EXT3_PIN16_SPI_SDO`, `SPI1_SDO_PIN`, `SPI2_SDO_PIN`, `SPI_DGI_SDO_PIN` | `TCC0` (channel 0)   |
-| `EXT2_PIN17_SPI_SDI` | `PC07`       | `EXT3_PIN17_SPI_SDI`, `SPI1_SDI_PIN`, `SPI2_SDI_PIN`, `SPI_DGI_SDI_PIN` |                      |
-| `EXT2_PIN18_SPI_SCK` | `PC05`       | `EXT3_PIN18_SPI_SCK`, `SPI1_SCK_PIN`, `SPI2_SCK_PIN`, `SPI_DGI_SCK_PIN` | `TCC0` (channel 1)   |
-| `EXT3_PIN3_ADC_P` | `PC02`       |                   |                      |
-| `EXT3_PIN4_ADC_N` | `PC03`       |                   |                      |
-| `EXT3_PIN5_GPIO1` | `PC01`       |                   |                      |
-| `EXT3_PIN6_GPIO2` | `PC10`       |                   | `TCC0` (channel 0), `TCC1` (channel 4) |
-| `EXT3_PIN7_PWM_P` | `PD10`       |                   | `TCC0` (channel 3)   |
-| `EXT3_PIN8_PWM_N` | `PD11`       |                   | `TCC0` (channel 4)   |
-| `EXT3_PIN9_IRQ`   | `PC30`       | `EXT3_PIN9_GPIO`  |                      |
-| `EXT3_PIN10_SPI_SS_B` | `PC31`       | `EXT3_PIN10_GPIO` |                      |
-| `EXT3_PIN13_UART_RX` | `PC23`       | `UART3_RX_PIN`    | `TCC0` (channel 7)   |
-| `EXT3_PIN14_UART_TX` | `PC22`       | `UART3_TX_PIN`    | `TCC0` (channel 6)   |
-| `EXT3_PIN15_SPI_SS_A` | `PC14`       | `SPI2_SS_PIN`     | `TCC0` (channel 4), `TCC1` (channel 0) |
-| `SD_CARD_MCDA0`   | `PB18`       |                   | `TCC1` (channel 0)   |
-| `SD_CARD_MCDA1`   | `PB19`       |                   | `TCC1` (channel 1)   |
-| `SD_CARD_MCDA2`   | `PB20`       |                   | `TCC1` (channel 2)   |
-| `SD_CARD_MCDA3`   | `PB21`       |                   | `TCC1` (channel 3)   |
-| `SD_CARD_MCCK`    | `PA21`       | `PCC_DATA05`      | `TCC1` (channel 5), `TCC0` (channel 1) |
-| `SD_CARD_MCCDA`   | `PA20`       | `PCC_DATA04`      | `TCC1` (channel 4), `TCC0` (channel 0) |
-| `SD_CARD_DETECT`  | `PD20`       |                   | `TCC1` (channel 0)   |
-| `SD_CARD_PROTECT` | `PD21`       |                   | `TCC1` (channel 1)   |
-| `CAN1_STANDBY`    | `PC13`       | `CAN_STANDBY`     | `TCC0` (channel 3), `TCC1` (channel 7) |
-| `CAN1_TX`         | `PB12`       | `CAN_TX`          | `TCC3` (channel 0), `TCC0` (channel 0) |
-| `CAN1_RX`         | `PB13`       | `CAN_RX`          | `TCC3` (channel 1), `TCC0` (channel 1) |
-| `PDEC_PHASE_A`    | `PC16`       |                   | `TCC0` (channel 0)   |
-| `PDEC_PHASE_B`    | `PC17`       |                   | `TCC0` (channel 1)   |
-| `PCC_VSYNC_DEN1`  | `PA12`       | `ETHERNET_RX1`    | `TCC0` (channel 6), `TCC1` (channel 2) |
-| `PCC_HSYNC_DEN2`  | `PA13`       | `ETHERNET_RX0`    | `TCC0` (channel 7), `TCC1` (channel 3) |
-| `PCC_CLK`         | `PA14`       | `ETHERNET_TXCK`   | `TCC2` (channel 0), `TCC1` (channel 2) |
-| `PCC_XCLK`        | `PA15`       | `ETHERNET_RXER`   | `TCC2` (channel 1), `TCC1` (channel 3) |
-| `PCC_DATA00`      | `PA16`       | `PIN_QT_BUTTON`   | `TCC1` (channel 0), `TCC0` (channel 4) |
-| `PCC_DATA01`      | `PA17`       | `ETHERNET_TXEN`   | `TCC1` (channel 1), `TCC0` (channel 5) |
-| `PCC_DATA02`      | `PA18`       | `ETHERNET_TX0`    | `TCC1` (channel 2), `TCC0` (channel 6) |
-| `PCC_DATA03`      | `PA19`       | `ETHERNET_TX1`    | `TCC1` (channel 3), `TCC0` (channel 7) |
-| `PCC_RESET`       | `PC12`       | `ETHERNET_MDIO`   | `TCC0` (channel 2), `TCC1` (channel 6) |
-| `PCC_PWDN`        | `PC11`       | `ETHERNET_MDC`    | `TCC0` (channel 1), `TCC1` (channel 5) |
-| `ETHERNET_RXDV`   | `PC20`       |                   | `TCC0` (channel 4)   |
-| `ETHERNET_INT`    | `PD12`       |                   | `TCC0` (channel 5)   |
-| `ETHERNET_RESET`  | `PC21`       |                   | `TCC0` (channel 5)   |
-| `PIN_ETH_LED`     | `PC15`       |                   | `TCC0` (channel 5), `TCC1` (channel 1) |
-| `PIN_ADC_DAC`     | `PA02`       |                   |                      |
-| `PIN_VBUS_DETECT` | `PC00`       |                   |                      |
-| `PIN_USB_ID`      | `PC19`       |                   | `TCC0` (channel 3)   |
-| `USBCDC_DM_PIN`   | `PA24`       |                   | `TCC2` (channel 2)   |
-| `USBCDC_DP_PIN`   | `PA25`       |                   | `TCC2` (channel 3)   |
-| `UART4_TX_PIN`    | `PB25`       |                   |                      |
-| `UART4_RX_PIN`    | `PB24`       |                   |                      |
-| `SPI_DGI_SS_PIN`  | `PD01`       |                   |                      |
-| `QSPI_SCK`        | `PB10`       |                   | `TCC0` (channel 4), `TCC1` (channel 0) |
-| `QSPI_CS`         | `PB11`       |                   | `TCC0` (channel 5), `TCC1` (channel 1) |
-| `QSPI_DATA0`      | `PA08`       |                   | `TCC0` (channel 0), `TCC1` (channel 4) |
-| `QSPI_DATA1`      | `PA09`       |                   | `TCC0` (channel 1), `TCC1` (channel 5) |
-| `QSPI_DATA2`      | `PA10`       |                   | `TCC0` (channel 2), `TCC1` (channel 6) |
-| `QSPI_DATA3`      | `PA11`       |                   | `TCC0` (channel 3), `TCC1` (channel 7) |
+| Pin               | Hardware pin | Alternative names | I2C                  | PWM                  |
+| ----------------- | ------------ | ----------------- | -------------------- | -------------------- |
+| `LED`             | `PC18`       | `PDEC_INDEX`, `PIN_LED0` |                      | `TCC0` (channel 2)   |
+| `BUTTON`          | `PB31`       | `PIN_BTN0`        |                      | `TCC4` (channel 1), `TCC0` (channel 7) |
+| `EXT1_PIN3_ADC_P` | `PB04`       |                   |                      |                      |
+| `EXT1_PIN4_ADC_N` | `PB05`       |                   |                      |                      |
+| `EXT1_PIN5_GPIO1` | `PA06`       |                   |                      |                      |
+| `EXT1_PIN6_GPIO2` | `PA07`       |                   |                      |                      |
+| `EXT1_PIN7_PWM_P` | `PB08`       |                   |                      |                      |
+| `EXT1_PIN8_PWM_N` | `PB09`       |                   |                      |                      |
+| `EXT1_PIN9_IRQ`   | `PB07`       | `EXT1_PIN9_GPIO`  |                      |                      |
+| `EXT1_PIN10_SPI_SS_B` | `PA27`       | `EXT1_PIN10_GPIO` |                      |                      |
+| `EXT1_PIN11_TWI_SDA` | `PA22`       | `CAN0_TX`, `PCC_DATA06`, `SDA0_PIN`, `SDA_PIN` | `I2C0` (SDA)         | `TCC1` (channel 6), `TCC0` (channel 2) |
+| `EXT1_PIN12_TWI_SCL` | `PA23`       | `CAN0_RX`, `PCC_DATA07`, `SCL0_PIN`, `SCL_PIN` | `I2C0` (SCL)         | `TCC1` (channel 7), `TCC0` (channel 3) |
+| `EXT1_PIN13_UART_RX` | `PA05`       | `UART_RX_PIN`     |                      |                      |
+| `EXT1_PIN14_UART_TX` | `PA04`       | `UART_TX_PIN`     |                      |                      |
+| `EXT1_PIN15_SPI_SS_A` | `PB28`       | `SPI0_SS_PIN`     |                      | `TCC1` (channel 4)   |
+| `EXT1_PIN16_SPI_SDO` | `PB27`       | `SPI0_SDO_PIN`    |                      | `TCC1` (channel 3)   |
+| `EXT1_PIN17_SPI_SDI` | `PB29`       | `SPI0_SDI_PIN`    |                      | `TCC1` (channel 5)   |
+| `EXT1_PIN18_SPI_SCK` | `PB26`       | `SPI0_SCK_PIN`    |                      | `TCC1` (channel 2)   |
+| `EXT2_PIN3_ADC_P` | `PB00`       |                   |                      |                      |
+| `EXT2_PIN4_ADC_N` | `PA03`       |                   |                      |                      |
+| `EXT2_PIN5_GPIO1` | `PB01`       |                   |                      |                      |
+| `EXT2_PIN6_GPIO2` | `PB06`       |                   |                      |                      |
+| `EXT2_PIN7_PWM_P` | `PB14`       | `PCC_DATA08`      |                      | `TCC4` (channel 0), `TCC0` (channel 2) |
+| `EXT2_PIN8_PWM_N` | `PB15`       | `PCC_DATA09`      |                      | `TCC4` (channel 1), `TCC0` (channel 3) |
+| `EXT2_PIN9_IRQ`   | `PD00`       | `EXT2_PIN9_GPIO`  |                      |                      |
+| `EXT2_PIN10_SPI_SS_B` | `PB02`       | `EXT2_PIN10_GPIO` |                      | `TCC2` (channel 2)   |
+| `EXT2_PIN11_TWI_SDA` | `PD08`       | `EXT3_PIN11_TWI_SDA`, `I2C_SDA`, `PCC_I2C_SDA`, `SDA1_PIN`, `SDA2_PIN`, `SDA_DGI_PIN` | `I2C1` (SDA), `I2C2` (SDA), `I2C3` (SDA) | `TCC0` (channel 1)   |
+| `EXT2_PIN12_TWI_SCL` | `PD09`       | `EXT3_PIN12_TWI_SCL`, `I2C_SCL`, `PCC_I2C_SCL`, `SCL1_PIN`, `SCL2_PIN`, `SCL_DGI_PIN` | `I2C1` (SCL), `I2C2` (SCL), `I2C3` (SCL) | `TCC0` (channel 2)   |
+| `EXT2_PIN13_UART_RX` | `PB17`       | `UART2_RX_PIN`    |                      | `TCC3` (channel 1), `TCC0` (channel 5) |
+| `EXT2_PIN14_UART_TX` | `PB16`       | `UART2_TX_PIN`    |                      | `TCC3` (channel 0), `TCC0` (channel 4) |
+| `EXT2_PIN15_SPI_SS_A` | `PC06`       | `SPI1_SS_PIN`     |                      |                      |
+| `EXT2_PIN16_SPI_SDO` | `PC04`       | `EXT3_PIN16_SPI_SDO`, `SPI1_SDO_PIN`, `SPI2_SDO_PIN`, `SPI_DGI_SDO_PIN` |                      | `TCC0` (channel 0)   |
+| `EXT2_PIN17_SPI_SDI` | `PC07`       | `EXT3_PIN17_SPI_SDI`, `SPI1_SDI_PIN`, `SPI2_SDI_PIN`, `SPI_DGI_SDI_PIN` |                      |                      |
+| `EXT2_PIN18_SPI_SCK` | `PC05`       | `EXT3_PIN18_SPI_SCK`, `SPI1_SCK_PIN`, `SPI2_SCK_PIN`, `SPI_DGI_SCK_PIN` |                      | `TCC0` (channel 1)   |
+| `EXT3_PIN3_ADC_P` | `PC02`       |                   |                      |                      |
+| `EXT3_PIN4_ADC_N` | `PC03`       |                   |                      |                      |
+| `EXT3_PIN5_GPIO1` | `PC01`       |                   |                      |                      |
+| `EXT3_PIN6_GPIO2` | `PC10`       |                   |                      | `TCC0` (channel 0), `TCC1` (channel 4) |
+| `EXT3_PIN7_PWM_P` | `PD10`       |                   |                      | `TCC0` (channel 3)   |
+| `EXT3_PIN8_PWM_N` | `PD11`       |                   |                      | `TCC0` (channel 4)   |
+| `EXT3_PIN9_IRQ`   | `PC30`       | `EXT3_PIN9_GPIO`  |                      |                      |
+| `EXT3_PIN10_SPI_SS_B` | `PC31`       | `EXT3_PIN10_GPIO` |                      |                      |
+| `EXT3_PIN13_UART_RX` | `PC23`       | `UART3_RX_PIN`    |                      | `TCC0` (channel 7)   |
+| `EXT3_PIN14_UART_TX` | `PC22`       | `UART3_TX_PIN`    |                      | `TCC0` (channel 6)   |
+| `EXT3_PIN15_SPI_SS_A` | `PC14`       | `SPI2_SS_PIN`     |                      | `TCC0` (channel 4), `TCC1` (channel 0) |
+| `SD_CARD_MCDA0`   | `PB18`       |                   |                      | `TCC1` (channel 0)   |
+| `SD_CARD_MCDA1`   | `PB19`       |                   |                      | `TCC1` (channel 1)   |
+| `SD_CARD_MCDA2`   | `PB20`       |                   |                      | `TCC1` (channel 2)   |
+| `SD_CARD_MCDA3`   | `PB21`       |                   |                      | `TCC1` (channel 3)   |
+| `SD_CARD_MCCK`    | `PA21`       | `PCC_DATA05`      |                      | `TCC1` (channel 5), `TCC0` (channel 1) |
+| `SD_CARD_MCCDA`   | `PA20`       | `PCC_DATA04`      |                      | `TCC1` (channel 4), `TCC0` (channel 0) |
+| `SD_CARD_DETECT`  | `PD20`       |                   |                      | `TCC1` (channel 0)   |
+| `SD_CARD_PROTECT` | `PD21`       |                   |                      | `TCC1` (channel 1)   |
+| `CAN1_STANDBY`    | `PC13`       | `CAN_STANDBY`     |                      | `TCC0` (channel 3), `TCC1` (channel 7) |
+| `CAN1_TX`         | `PB12`       | `CAN_TX`          |                      | `TCC3` (channel 0), `TCC0` (channel 0) |
+| `CAN1_RX`         | `PB13`       | `CAN_RX`          |                      | `TCC3` (channel 1), `TCC0` (channel 1) |
+| `PDEC_PHASE_A`    | `PC16`       |                   |                      | `TCC0` (channel 0)   |
+| `PDEC_PHASE_B`    | `PC17`       |                   |                      | `TCC0` (channel 1)   |
+| `PCC_VSYNC_DEN1`  | `PA12`       | `ETHERNET_RX1`    |                      | `TCC0` (channel 6), `TCC1` (channel 2) |
+| `PCC_HSYNC_DEN2`  | `PA13`       | `ETHERNET_RX0`    |                      | `TCC0` (channel 7), `TCC1` (channel 3) |
+| `PCC_CLK`         | `PA14`       | `ETHERNET_TXCK`   |                      | `TCC2` (channel 0), `TCC1` (channel 2) |
+| `PCC_XCLK`        | `PA15`       | `ETHERNET_RXER`   |                      | `TCC2` (channel 1), `TCC1` (channel 3) |
+| `PCC_DATA00`      | `PA16`       | `PIN_QT_BUTTON`   | `I2C0` (SDA)         | `TCC1` (channel 0), `TCC0` (channel 4) |
+| `PCC_DATA01`      | `PA17`       | `ETHERNET_TXEN`   | `I2C0` (SCL)         | `TCC1` (channel 1), `TCC0` (channel 5) |
+| `PCC_DATA02`      | `PA18`       | `ETHERNET_TX0`    |                      | `TCC1` (channel 2), `TCC0` (channel 6) |
+| `PCC_DATA03`      | `PA19`       | `ETHERNET_TX1`    |                      | `TCC1` (channel 3), `TCC0` (channel 7) |
+| `PCC_RESET`       | `PC12`       | `ETHERNET_MDIO`   |                      | `TCC0` (channel 2), `TCC1` (channel 6) |
+| `PCC_PWDN`        | `PC11`       | `ETHERNET_MDC`    |                      | `TCC0` (channel 1), `TCC1` (channel 5) |
+| `ETHERNET_RXDV`   | `PC20`       |                   |                      | `TCC0` (channel 4)   |
+| `ETHERNET_INT`    | `PD12`       |                   |                      | `TCC0` (channel 5)   |
+| `ETHERNET_RESET`  | `PC21`       |                   |                      | `TCC0` (channel 5)   |
+| `PIN_ETH_LED`     | `PC15`       |                   |                      | `TCC0` (channel 5), `TCC1` (channel 1) |
+| `PIN_ADC_DAC`     | `PA02`       |                   |                      |                      |
+| `PIN_VBUS_DETECT` | `PC00`       |                   |                      |                      |
+| `PIN_USB_ID`      | `PC19`       |                   |                      | `TCC0` (channel 3)   |
+| `USBCDC_DM_PIN`   | `PA24`       |                   |                      | `TCC2` (channel 2)   |
+| `USBCDC_DP_PIN`   | `PA25`       |                   |                      | `TCC2` (channel 3)   |
+| `UART4_TX_PIN`    | `PB25`       |                   |                      |                      |
+| `UART4_RX_PIN`    | `PB24`       |                   |                      |                      |
+| `SPI_DGI_SS_PIN`  | `PD01`       |                   |                      |                      |
+| `QSPI_SCK`        | `PB10`       |                   |                      | `TCC0` (channel 4), `TCC1` (channel 0) |
+| `QSPI_CS`         | `PB11`       |                   |                      | `TCC0` (channel 5), `TCC1` (channel 1) |
+| `QSPI_DATA0`      | `PA08`       |                   |                      | `TCC0` (channel 0), `TCC1` (channel 4) |
+| `QSPI_DATA1`      | `PA09`       |                   |                      | `TCC0` (channel 1), `TCC1` (channel 5) |
+| `QSPI_DATA2`      | `PA10`       |                   |                      | `TCC0` (channel 2), `TCC1` (channel 6) |
+| `QSPI_DATA3`      | `PA11`       |                   |                      | `TCC0` (channel 3), `TCC1` (channel 7) |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/badger2040-w.md
+++ b/content/docs/reference/microcontrollers/badger2040-w.md
@@ -19,31 +19,31 @@ The [Pimoroni Badger2040-W](https://shop.pimoroni.com/products/badger-2040-w) is
 
 ## Pins
 
-| Pin               | Hardware pin | Alternative names | PWM                  |
-| ----------------- | ------------ | ----------------- | -------------------- |
-| `LED`             | `GPIO22`     |                   | `PWM3` (channel A)   |
-| `BUTTON_A`        | `GPIO12`     |                   | `PWM6` (channel A)   |
-| `BUTTON_B`        | `GPIO13`     |                   | `PWM6` (channel B)   |
-| `BUTTON_C`        | `GPIO14`     |                   | `PWM7` (channel A)   |
-| `BUTTON_UP`       | `GPIO15`     |                   | `PWM7` (channel B)   |
-| `BUTTON_DOWN`     | `GPIO11`     |                   | `PWM5` (channel B)   |
-| `EPD_BUSY_PIN`    | `GPIO26`     | `ADC0`            | `PWM5` (channel A)   |
-| `EPD_RESET_PIN`   | `GPIO21`     |                   | `PWM2` (channel B)   |
-| `EPD_DC_PIN`      | `GPIO20`     |                   | `PWM2` (channel A)   |
-| `EPD_CS_PIN`      | `GPIO17`     |                   | `PWM0` (channel B)   |
-| `EPD_SCK_PIN`     | `GPIO18`     | `SPI0_SCK_PIN`    | `PWM1` (channel A)   |
-| `EPD_SDO_PIN`     | `GPIO19`     | `SPI0_SDO_PIN`    | `PWM1` (channel B)   |
-| `VBUS_DETECT`     | `GPIO24`     |                   | `PWM4` (channel A)   |
-| `VREF_POWER`      | `GPIO27`     | `ADC1`            | `PWM5` (channel B)   |
-| `VREF_1V24`       | `GPIO28`     | `ADC2`            | `PWM6` (channel A)   |
-| `VBAT_SENSE`      | `GPIO29`     | `BATTERY`, `ADC3` | `PWM6` (channel B)   |
-| `ENABLE_3V3`      | `GPIO10`     |                   | `PWM5` (channel A)   |
-| `RTC_ALARM`       | `GPIO8`      |                   | `PWM4` (channel A)   |
-| `I2C0_SDA_PIN`    | `GPIO4`      |                   | `PWM2` (channel A)   |
-| `I2C0_SCL_PIN`    | `GPIO5`      |                   | `PWM2` (channel B)   |
-| `SPI0_SDI_PIN`    | `GPIO16`     |                   | `PWM0` (channel A)   |
-| `UART0_TX_PIN`    | `GPIO0`      | `UART_TX_PIN`     | `PWM0` (channel A)   |
-| `UART0_RX_PIN`    | `GPIO1`      | `UART_RX_PIN`     | `PWM0` (channel B)   |
+| Pin               | Hardware pin | Alternative names | I2C                  | PWM                  |
+| ----------------- | ------------ | ----------------- | -------------------- | -------------------- |
+| `LED`             | `GPIO22`     |                   |                      | `PWM3` (channel A)   |
+| `BUTTON_A`        | `GPIO12`     |                   | `I2C0` (SDA)         | `PWM6` (channel A)   |
+| `BUTTON_B`        | `GPIO13`     |                   | `I2C0` (SCL)         | `PWM6` (channel B)   |
+| `BUTTON_C`        | `GPIO14`     |                   | `I2C1` (SDA)         | `PWM7` (channel A)   |
+| `BUTTON_UP`       | `GPIO15`     |                   | `I2C1` (SCL)         | `PWM7` (channel B)   |
+| `BUTTON_DOWN`     | `GPIO11`     |                   | `I2C1` (SCL)         | `PWM5` (channel B)   |
+| `EPD_BUSY_PIN`    | `GPIO26`     | `ADC0`            | `I2C1` (SDA)         | `PWM5` (channel A)   |
+| `EPD_RESET_PIN`   | `GPIO21`     |                   | `I2C0` (SCL)         | `PWM2` (channel B)   |
+| `EPD_DC_PIN`      | `GPIO20`     |                   | `I2C0` (SDA)         | `PWM2` (channel A)   |
+| `EPD_CS_PIN`      | `GPIO17`     |                   | `I2C0` (SCL)         | `PWM0` (channel B)   |
+| `EPD_SCK_PIN`     | `GPIO18`     | `SPI0_SCK_PIN`    | `I2C1` (SDA)         | `PWM1` (channel A)   |
+| `EPD_SDO_PIN`     | `GPIO19`     | `SPI0_SDO_PIN`    | `I2C1` (SCL)         | `PWM1` (channel B)   |
+| `VBUS_DETECT`     | `GPIO24`     |                   |                      | `PWM4` (channel A)   |
+| `VREF_POWER`      | `GPIO27`     | `ADC1`            | `I2C1` (SCL)         | `PWM5` (channel B)   |
+| `VREF_1V24`       | `GPIO28`     | `ADC2`            |                      | `PWM6` (channel A)   |
+| `VBAT_SENSE`      | `GPIO29`     | `BATTERY`, `ADC3` |                      | `PWM6` (channel B)   |
+| `ENABLE_3V3`      | `GPIO10`     |                   | `I2C1` (SDA)         | `PWM5` (channel A)   |
+| `RTC_ALARM`       | `GPIO8`      |                   | `I2C0` (SDA)         | `PWM4` (channel A)   |
+| `I2C0_SDA_PIN`    | `GPIO4`      |                   | `I2C0` (SDA)         | `PWM2` (channel A)   |
+| `I2C0_SCL_PIN`    | `GPIO5`      |                   | `I2C0` (SCL)         | `PWM2` (channel B)   |
+| `SPI0_SDI_PIN`    | `GPIO16`     |                   | `I2C0` (SDA)         | `PWM0` (channel A)   |
+| `UART0_TX_PIN`    | `GPIO0`      | `UART_TX_PIN`     | `I2C0` (SDA)         | `PWM0` (channel A)   |
+| `UART0_RX_PIN`    | `GPIO1`      | `UART_RX_PIN`     | `I2C0` (SCL)         | `PWM0` (channel B)   |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/badger2040.md
+++ b/content/docs/reference/microcontrollers/badger2040.md
@@ -19,31 +19,31 @@ The [Pimoroni Badger2040](https://shop.pimoroni.com/products/badger-2040) is a b
 
 ## Pins
 
-| Pin               | Hardware pin | Alternative names | PWM                  |
-| ----------------- | ------------ | ----------------- | -------------------- |
-| `LED`             | `GPIO25`     |                   | `PWM4` (channel B)   |
-| `BUTTON_A`        | `GPIO12`     |                   | `PWM6` (channel A)   |
-| `BUTTON_B`        | `GPIO13`     |                   | `PWM6` (channel B)   |
-| `BUTTON_C`        | `GPIO14`     |                   | `PWM7` (channel A)   |
-| `BUTTON_UP`       | `GPIO15`     |                   | `PWM7` (channel B)   |
-| `BUTTON_DOWN`     | `GPIO11`     |                   | `PWM5` (channel B)   |
-| `BUTTON_USER`     | `GPIO23`     |                   | `PWM3` (channel B)   |
-| `EPD_BUSY_PIN`    | `GPIO26`     | `ADC0`            | `PWM5` (channel A)   |
-| `EPD_RESET_PIN`   | `GPIO21`     |                   | `PWM2` (channel B)   |
-| `EPD_DC_PIN`      | `GPIO20`     |                   | `PWM2` (channel A)   |
-| `EPD_CS_PIN`      | `GPIO17`     |                   | `PWM0` (channel B)   |
-| `EPD_SCK_PIN`     | `GPIO18`     | `SPI0_SCK_PIN`    | `PWM1` (channel A)   |
-| `EPD_SDO_PIN`     | `GPIO19`     | `SPI0_SDO_PIN`    | `PWM1` (channel B)   |
-| `VBUS_DETECT`     | `GPIO24`     |                   | `PWM4` (channel A)   |
-| `VREF_POWER`      | `GPIO27`     | `ADC1`            | `PWM5` (channel B)   |
-| `VREF_1V24`       | `GPIO28`     | `ADC2`            | `PWM6` (channel A)   |
-| `VBAT_SENSE`      | `GPIO29`     | `BATTERY`, `ADC3` | `PWM6` (channel B)   |
-| `ENABLE_3V3`      | `GPIO10`     |                   | `PWM5` (channel A)   |
-| `I2C0_SDA_PIN`    | `GPIO4`      |                   | `PWM2` (channel A)   |
-| `I2C0_SCL_PIN`    | `GPIO5`      |                   | `PWM2` (channel B)   |
-| `SPI0_SDI_PIN`    | `GPIO16`     |                   | `PWM0` (channel A)   |
-| `UART0_TX_PIN`    | `GPIO0`      | `UART_TX_PIN`     | `PWM0` (channel A)   |
-| `UART0_RX_PIN`    | `GPIO1`      | `UART_RX_PIN`     | `PWM0` (channel B)   |
+| Pin               | Hardware pin | Alternative names | I2C                  | PWM                  |
+| ----------------- | ------------ | ----------------- | -------------------- | -------------------- |
+| `LED`             | `GPIO25`     |                   |                      | `PWM4` (channel B)   |
+| `BUTTON_A`        | `GPIO12`     |                   | `I2C0` (SDA)         | `PWM6` (channel A)   |
+| `BUTTON_B`        | `GPIO13`     |                   | `I2C0` (SCL)         | `PWM6` (channel B)   |
+| `BUTTON_C`        | `GPIO14`     |                   | `I2C1` (SDA)         | `PWM7` (channel A)   |
+| `BUTTON_UP`       | `GPIO15`     |                   | `I2C1` (SCL)         | `PWM7` (channel B)   |
+| `BUTTON_DOWN`     | `GPIO11`     |                   | `I2C1` (SCL)         | `PWM5` (channel B)   |
+| `BUTTON_USER`     | `GPIO23`     |                   |                      | `PWM3` (channel B)   |
+| `EPD_BUSY_PIN`    | `GPIO26`     | `ADC0`            | `I2C1` (SDA)         | `PWM5` (channel A)   |
+| `EPD_RESET_PIN`   | `GPIO21`     |                   | `I2C0` (SCL)         | `PWM2` (channel B)   |
+| `EPD_DC_PIN`      | `GPIO20`     |                   | `I2C0` (SDA)         | `PWM2` (channel A)   |
+| `EPD_CS_PIN`      | `GPIO17`     |                   | `I2C0` (SCL)         | `PWM0` (channel B)   |
+| `EPD_SCK_PIN`     | `GPIO18`     | `SPI0_SCK_PIN`    | `I2C1` (SDA)         | `PWM1` (channel A)   |
+| `EPD_SDO_PIN`     | `GPIO19`     | `SPI0_SDO_PIN`    | `I2C1` (SCL)         | `PWM1` (channel B)   |
+| `VBUS_DETECT`     | `GPIO24`     |                   |                      | `PWM4` (channel A)   |
+| `VREF_POWER`      | `GPIO27`     | `ADC1`            | `I2C1` (SCL)         | `PWM5` (channel B)   |
+| `VREF_1V24`       | `GPIO28`     | `ADC2`            |                      | `PWM6` (channel A)   |
+| `VBAT_SENSE`      | `GPIO29`     | `BATTERY`, `ADC3` |                      | `PWM6` (channel B)   |
+| `ENABLE_3V3`      | `GPIO10`     |                   | `I2C1` (SDA)         | `PWM5` (channel A)   |
+| `I2C0_SDA_PIN`    | `GPIO4`      |                   | `I2C0` (SDA)         | `PWM2` (channel A)   |
+| `I2C0_SCL_PIN`    | `GPIO5`      |                   | `I2C0` (SCL)         | `PWM2` (channel B)   |
+| `SPI0_SDI_PIN`    | `GPIO16`     |                   | `I2C0` (SDA)         | `PWM0` (channel A)   |
+| `UART0_TX_PIN`    | `GPIO0`      | `UART_TX_PIN`     | `I2C0` (SDA)         | `PWM0` (channel A)   |
+| `UART0_RX_PIN`    | `GPIO1`      | `UART_RX_PIN`     | `I2C0` (SCL)         | `PWM0` (channel B)   |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/challenger-rp2040.md
+++ b/content/docs/reference/microcontrollers/challenger-rp2040.md
@@ -19,34 +19,34 @@ The [iLabs Challenger RP2040 LoRa](https://ilabs.se/product/challenger-rp2040-lo
 
 ## Pins
 
-| Pin               | Hardware pin | Alternative names | PWM                  |
-| ----------------- | ------------ | ----------------- | -------------------- |
-| `LED`             | `GPIO24`     | `I2C0_SDA_PIN`    | `PWM4` (channel A)   |
-| `D5`              | `GPIO2`      | `I2C1_SDA_PIN`, `SDA_PIN` | `PWM1` (channel A)   |
-| `D6`              | `GPIO3`      | `I2C1_SCL_PIN`, `SCL_PIN` | `PWM1` (channel B)   |
-| `D9`              | `GPIO4`      | `UART1_TX_PIN`    | `PWM2` (channel A)   |
-| `D10`             | `GPIO5`      | `UART1_RX_PIN`    | `PWM2` (channel B)   |
-| `D11`             | `GPIO6`      |                   | `PWM3` (channel A)   |
-| `D12`             | `GPIO7`      |                   | `PWM3` (channel B)   |
-| `D13`             | `GPIO8`      |                   | `PWM4` (channel A)   |
-| `A0`              | `GPIO26`     | `ADC0`            | `PWM5` (channel A)   |
-| `A1`              | `GPIO27`     | `ADC1`            | `PWM5` (channel B)   |
-| `A2`              | `GPIO28`     | `ADC2`            | `PWM6` (channel A)   |
-| `A3`              | `GPIO29`     | `ADC3`            | `PWM6` (channel B)   |
-| `I2C0_SCL_PIN`    | `GPIO25`     |                   | `PWM4` (channel B)   |
-| `SPI0_SCK_PIN`    | `GPIO22`     |                   | `PWM3` (channel A)   |
-| `SPI0_SDO_PIN`    | `GPIO23`     |                   | `PWM3` (channel B)   |
-| `SPI0_SDI_PIN`    | `GPIO20`     |                   | `PWM2` (channel A)   |
-| `SPI1_SCK_PIN`    | `GPIO10`     | `LORA_SCK`        | `PWM5` (channel A)   |
-| `SPI1_SDO_PIN`    | `GPIO11`     | `LORA_SDO`        | `PWM5` (channel B)   |
-| `SPI1_SDI_PIN`    | `GPIO12`     | `LORA_SDI`        | `PWM6` (channel A)   |
-| `LORA_CS`         | `GPIO9`      |                   | `PWM4` (channel B)   |
-| `LORA_RESET`      | `GPIO13`     |                   | `PWM6` (channel B)   |
-| `LORA_DIO0`       | `GPIO14`     |                   | `PWM7` (channel A)   |
-| `LORA_DIO1`       | `GPIO15`     |                   | `PWM7` (channel B)   |
-| `LORA_DIO2`       | `GPIO18`     |                   | `PWM1` (channel A)   |
-| `UART0_TX_PIN`    | `GPIO16`     | `UART_TX_PIN`     | `PWM0` (channel A)   |
-| `UART0_RX_PIN`    | `GPIO17`     | `UART_RX_PIN`     | `PWM0` (channel B)   |
+| Pin               | Hardware pin | Alternative names | I2C                  | PWM                  |
+| ----------------- | ------------ | ----------------- | -------------------- | -------------------- |
+| `LED`             | `GPIO24`     | `I2C0_SDA_PIN`    |                      | `PWM4` (channel A)   |
+| `D5`              | `GPIO2`      | `I2C1_SDA_PIN`, `SDA_PIN` | `I2C1` (SDA)         | `PWM1` (channel A)   |
+| `D6`              | `GPIO3`      | `I2C1_SCL_PIN`, `SCL_PIN` | `I2C1` (SCL)         | `PWM1` (channel B)   |
+| `D9`              | `GPIO4`      | `UART1_TX_PIN`    | `I2C0` (SDA)         | `PWM2` (channel A)   |
+| `D10`             | `GPIO5`      | `UART1_RX_PIN`    | `I2C0` (SCL)         | `PWM2` (channel B)   |
+| `D11`             | `GPIO6`      |                   | `I2C1` (SDA)         | `PWM3` (channel A)   |
+| `D12`             | `GPIO7`      |                   | `I2C1` (SCL)         | `PWM3` (channel B)   |
+| `D13`             | `GPIO8`      |                   | `I2C0` (SDA)         | `PWM4` (channel A)   |
+| `A0`              | `GPIO26`     | `ADC0`            | `I2C1` (SDA)         | `PWM5` (channel A)   |
+| `A1`              | `GPIO27`     | `ADC1`            | `I2C1` (SCL)         | `PWM5` (channel B)   |
+| `A2`              | `GPIO28`     | `ADC2`            |                      | `PWM6` (channel A)   |
+| `A3`              | `GPIO29`     | `ADC3`            |                      | `PWM6` (channel B)   |
+| `I2C0_SCL_PIN`    | `GPIO25`     |                   |                      | `PWM4` (channel B)   |
+| `SPI0_SCK_PIN`    | `GPIO22`     |                   |                      | `PWM3` (channel A)   |
+| `SPI0_SDO_PIN`    | `GPIO23`     |                   |                      | `PWM3` (channel B)   |
+| `SPI0_SDI_PIN`    | `GPIO20`     |                   | `I2C0` (SDA)         | `PWM2` (channel A)   |
+| `SPI1_SCK_PIN`    | `GPIO10`     | `LORA_SCK`        | `I2C1` (SDA)         | `PWM5` (channel A)   |
+| `SPI1_SDO_PIN`    | `GPIO11`     | `LORA_SDO`        | `I2C1` (SCL)         | `PWM5` (channel B)   |
+| `SPI1_SDI_PIN`    | `GPIO12`     | `LORA_SDI`        | `I2C0` (SDA)         | `PWM6` (channel A)   |
+| `LORA_CS`         | `GPIO9`      |                   | `I2C0` (SCL)         | `PWM4` (channel B)   |
+| `LORA_RESET`      | `GPIO13`     |                   | `I2C0` (SCL)         | `PWM6` (channel B)   |
+| `LORA_DIO0`       | `GPIO14`     |                   | `I2C1` (SDA)         | `PWM7` (channel A)   |
+| `LORA_DIO1`       | `GPIO15`     |                   | `I2C1` (SCL)         | `PWM7` (channel B)   |
+| `LORA_DIO2`       | `GPIO18`     |                   | `I2C1` (SDA)         | `PWM1` (channel A)   |
+| `UART0_TX_PIN`    | `GPIO16`     | `UART_TX_PIN`     | `I2C0` (SDA)         | `PWM0` (channel A)   |
+| `UART0_RX_PIN`    | `GPIO17`     | `UART_RX_PIN`     | `I2C0` (SCL)         | `PWM0` (channel B)   |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/circuitplay-express.md
+++ b/content/docs/reference/microcontrollers/circuitplay-express.md
@@ -19,33 +19,33 @@ The [Adafruit Circuit Playground Express](https://www.adafruit.com/product/3333)
 
 ## Pins
 
-| Pin               | Hardware pin | Alternative names | PWM                  |
-| ----------------- | ------------ | ----------------- | -------------------- |
-| `D0`              | `PB09`       | `A6`, `UART_RX_PIN` |                      |
-| `D1`              | `PB08`       | `A7`, `UART_TX_PIN` |                      |
-| `D2`              | `PB02`       | `A5`, `SDA_PIN`   |                      |
-| `D3`              | `PB03`       | `A4`, `SCL_PIN`   |                      |
-| `D4`              | `PA28`       | `BUTTONA`, `BUTTON` |                      |
-| `D5`              | `PA14`       | `BUTTONB`, `BUTTON1` | `TCC0` (channel 0)   |
-| `D6`              | `PA05`       | `A1`              | `TCC0` (channel 1)   |
-| `D7`              | `PA15`       | `SLIDER`          | `TCC0` (channel 1)   |
-| `D8`              | `PB23`       | `NEOPIXELS`, `WS2812` |                      |
-| `D9`              | `PA06`       | `A2`              | `TCC1` (channel 0)   |
-| `D10`             | `PA07`       | `A3`              | `TCC1` (channel 1)   |
-| `D12`             | `PA02`       | `A0`              |                      |
-| `D13`             | `PA17`       | `LED`             | `TCC2` (channel 1), `TCC0` (channel 3) |
-| `A8`              | `PA11`       | `LIGHTSENSOR`     | `TCC1` (channel 1), `TCC0` (channel 3) |
-| `A9`              | `PA09`       | `TEMPSENSOR`      | `TCC0` (channel 1), `TCC1` (channel 3) |
-| `A10`             | `PA04`       | `PROXIMITY`       | `TCC0` (channel 0)   |
-| `USBCDC_DM_PIN`   | `PA24`       |                   | `TCC1` (channel 2)   |
-| `USBCDC_DP_PIN`   | `PA25`       |                   | `TCC1` (channel 3)   |
-| `SDA1_PIN`        | `PA00`       |                   | `TCC2` (channel 0)   |
-| `SCL1_PIN`        | `PA01`       |                   | `TCC2` (channel 1)   |
-| `SPI0_SCK_PIN`    | `PA21`       |                   | `TCC0` (channel 3)   |
-| `SPI0_SDO_PIN`    | `PA20`       |                   | `TCC0` (channel 2)   |
-| `SPI0_SDI_PIN`    | `PA16`       |                   | `TCC2` (channel 0), `TCC0` (channel 2) |
-| `I2S_SCK_PIN`     | `PA10`       |                   | `TCC1` (channel 0), `TCC0` (channel 2) |
-| `I2S_SDO_PIN`     | `PA08`       |                   | `TCC0` (channel 0), `TCC1` (channel 2) |
+| Pin               | Hardware pin | Alternative names | I2C                  | PWM                  |
+| ----------------- | ------------ | ----------------- | -------------------- | -------------------- |
+| `D0`              | `PB09`       | `A6`, `UART_RX_PIN` |                      |                      |
+| `D1`              | `PB08`       | `A7`, `UART_TX_PIN` |                      |                      |
+| `D2`              | `PB02`       | `A5`, `SDA_PIN`   | `I2C0` (SDA)         |                      |
+| `D3`              | `PB03`       | `A4`, `SCL_PIN`   | `I2C0` (SCL)         |                      |
+| `D4`              | `PA28`       | `BUTTONA`, `BUTTON` |                      |                      |
+| `D5`              | `PA14`       | `BUTTONB`, `BUTTON1` |                      | `TCC0` (channel 0)   |
+| `D6`              | `PA05`       | `A1`              |                      | `TCC0` (channel 1)   |
+| `D7`              | `PA15`       | `SLIDER`          |                      | `TCC0` (channel 1)   |
+| `D8`              | `PB23`       | `NEOPIXELS`, `WS2812` |                      |                      |
+| `D9`              | `PA06`       | `A2`              |                      | `TCC1` (channel 0)   |
+| `D10`             | `PA07`       | `A3`              |                      | `TCC1` (channel 1)   |
+| `D12`             | `PA02`       | `A0`              |                      |                      |
+| `D13`             | `PA17`       | `LED`             | `I2C1` (SCL)         | `TCC2` (channel 1), `TCC0` (channel 3) |
+| `A8`              | `PA11`       | `LIGHTSENSOR`     |                      | `TCC1` (channel 1), `TCC0` (channel 3) |
+| `A9`              | `PA09`       | `TEMPSENSOR`      |                      | `TCC0` (channel 1), `TCC1` (channel 3) |
+| `A10`             | `PA04`       | `PROXIMITY`       |                      | `TCC0` (channel 0)   |
+| `USBCDC_DM_PIN`   | `PA24`       |                   |                      | `TCC1` (channel 2)   |
+| `USBCDC_DP_PIN`   | `PA25`       |                   |                      | `TCC1` (channel 3)   |
+| `SDA1_PIN`        | `PA00`       |                   | `I2C1` (SDA)         | `TCC2` (channel 0)   |
+| `SCL1_PIN`        | `PA01`       |                   | `I2C1` (SCL)         | `TCC2` (channel 1)   |
+| `SPI0_SCK_PIN`    | `PA21`       |                   |                      | `TCC0` (channel 3)   |
+| `SPI0_SDO_PIN`    | `PA20`       |                   |                      | `TCC0` (channel 2)   |
+| `SPI0_SDI_PIN`    | `PA16`       |                   | `I2C1` (SDA)         | `TCC2` (channel 0), `TCC0` (channel 2) |
+| `I2S_SCK_PIN`     | `PA10`       |                   |                      | `TCC1` (channel 0), `TCC0` (channel 2) |
+| `I2S_SDO_PIN`     | `PA08`       |                   |                      | `TCC0` (channel 0), `TCC1` (channel 2) |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/feather-m0.md
+++ b/content/docs/reference/microcontrollers/feather-m0.md
@@ -19,33 +19,33 @@ The [Adafruit Feather M0](https://www.adafruit.com/product/3403) is a tiny ARM d
 
 ## Pins
 
-| Pin               | Hardware pin | Alternative names | PWM                  |
-| ----------------- | ------------ | ----------------- | -------------------- |
-| `D0`              | `PA11`       |                   | `TCC1` (channel 1), `TCC0` (channel 3) |
-| `D1`              | `PA10`       | `I2S_SCK_PIN`     | `TCC1` (channel 0), `TCC0` (channel 2) |
-| `D3`              | `PA09`       |                   | `TCC0` (channel 1), `TCC1` (channel 3) |
-| `D4`              | `PA08`       | `I2S_SDO_PIN`     | `TCC0` (channel 0), `TCC1` (channel 2) |
-| `D5`              | `PA15`       |                   | `TCC0` (channel 1)   |
-| `D6`              | `PA20`       |                   | `TCC0` (channel 2)   |
-| `D8`              | `PA06`       |                   | `TCC1` (channel 0)   |
-| `D9`              | `PA07`       |                   | `TCC1` (channel 1)   |
-| `D10`             | `PA18`       | `UART_TX_PIN`     | `TCC0` (channel 2)   |
-| `D11`             | `PA16`       | `UART_RX_PIN`     | `TCC2` (channel 0), `TCC0` (channel 2) |
-| `D12`             | `PA19`       |                   | `TCC0` (channel 3)   |
-| `D13`             | `PA17`       | `LED`             | `TCC2` (channel 1), `TCC0` (channel 3) |
-| `A0`              | `PA02`       |                   |                      |
-| `A1`              | `PB08`       |                   |                      |
-| `A2`              | `PB09`       |                   |                      |
-| `A3`              | `PA04`       |                   | `TCC0` (channel 0)   |
-| `A4`              | `PA05`       |                   | `TCC0` (channel 1)   |
-| `A5`              | `PB02`       |                   |                      |
-| `USBCDC_DM_PIN`   | `PA24`       |                   | `TCC1` (channel 2)   |
-| `USBCDC_DP_PIN`   | `PA25`       |                   | `TCC1` (channel 3)   |
-| `SDA_PIN`         | `PA22`       |                   | `TCC0` (channel 0)   |
-| `SCL_PIN`         | `PA23`       |                   | `TCC0` (channel 1)   |
-| `SPI0_SCK_PIN`    | `PB11`       |                   | `TCC0` (channel 1)   |
-| `SPI0_SDO_PIN`    | `PB10`       |                   | `TCC0` (channel 0)   |
-| `SPI0_SDI_PIN`    | `PA12`       |                   | `TCC2` (channel 0), `TCC0` (channel 2) |
+| Pin               | Hardware pin | Alternative names | I2C                  | PWM                  |
+| ----------------- | ------------ | ----------------- | -------------------- | -------------------- |
+| `D0`              | `PA11`       |                   |                      | `TCC1` (channel 1), `TCC0` (channel 3) |
+| `D1`              | `PA10`       | `I2S_SCK_PIN`     |                      | `TCC1` (channel 0), `TCC0` (channel 2) |
+| `D3`              | `PA09`       |                   |                      | `TCC0` (channel 1), `TCC1` (channel 3) |
+| `D4`              | `PA08`       | `I2S_SDO_PIN`     |                      | `TCC0` (channel 0), `TCC1` (channel 2) |
+| `D5`              | `PA15`       |                   |                      | `TCC0` (channel 1)   |
+| `D6`              | `PA20`       |                   |                      | `TCC0` (channel 2)   |
+| `D8`              | `PA06`       |                   |                      | `TCC1` (channel 0)   |
+| `D9`              | `PA07`       |                   |                      | `TCC1` (channel 1)   |
+| `D10`             | `PA18`       | `UART_TX_PIN`     |                      | `TCC0` (channel 2)   |
+| `D11`             | `PA16`       | `UART_RX_PIN`     | `I2C0` (SDA)         | `TCC2` (channel 0), `TCC0` (channel 2) |
+| `D12`             | `PA19`       |                   |                      | `TCC0` (channel 3)   |
+| `D13`             | `PA17`       | `LED`             | `I2C0` (SCL)         | `TCC2` (channel 1), `TCC0` (channel 3) |
+| `A0`              | `PA02`       |                   |                      |                      |
+| `A1`              | `PB08`       |                   |                      |                      |
+| `A2`              | `PB09`       |                   |                      |                      |
+| `A3`              | `PA04`       |                   |                      | `TCC0` (channel 0)   |
+| `A4`              | `PA05`       |                   |                      | `TCC0` (channel 1)   |
+| `A5`              | `PB02`       |                   |                      |                      |
+| `USBCDC_DM_PIN`   | `PA24`       |                   |                      | `TCC1` (channel 2)   |
+| `USBCDC_DP_PIN`   | `PA25`       |                   |                      | `TCC1` (channel 3)   |
+| `SDA_PIN`         | `PA22`       |                   | `I2C0` (SDA)         | `TCC0` (channel 0)   |
+| `SCL_PIN`         | `PA23`       |                   | `I2C0` (SCL)         | `TCC0` (channel 1)   |
+| `SPI0_SCK_PIN`    | `PB11`       |                   |                      | `TCC0` (channel 1)   |
+| `SPI0_SDO_PIN`    | `PB10`       |                   |                      | `TCC0` (channel 0)   |
+| `SPI0_SDI_PIN`    | `PA12`       |                   |                      | `TCC2` (channel 0), `TCC0` (channel 2) |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/feather-m4-can.md
+++ b/content/docs/reference/microcontrollers/feather-m4-can.md
@@ -19,43 +19,43 @@ The [Adafruit Feather M4 CAN](https://www.adafruit.com/product/4759) is a tiny A
 
 ## Pins
 
-| Pin               | Hardware pin | Alternative names | PWM                  |
-| ----------------- | ------------ | ----------------- | -------------------- |
-| `D0`              | `PB17`       | `UART_RX_PIN`     | `TCC3` (channel 1), `TCC0` (channel 5) |
-| `D1`              | `PB16`       | `UART_TX_PIN`     | `TCC3` (channel 0), `TCC0` (channel 4) |
-| `D4`              | `PA14`       |                   | `TCC2` (channel 0), `TCC1` (channel 2) |
-| `D5`              | `PA16`       |                   | `TCC1` (channel 0), `TCC0` (channel 4) |
-| `D6`              | `PA18`       |                   | `TCC1` (channel 2), `TCC0` (channel 6) |
-| `D7`              | `PB03`       |                   | `TCC2` (channel 3)   |
-| `D8`              | `PB02`       | `NEOPIXELS`, `WS2812` | `TCC2` (channel 2)   |
-| `D9`              | `PA19`       |                   | `TCC1` (channel 3), `TCC0` (channel 7) |
-| `D10`             | `PA20`       |                   | `TCC1` (channel 4), `TCC0` (channel 0) |
-| `D11`             | `PA21`       |                   | `TCC1` (channel 5), `TCC0` (channel 1) |
-| `D12`             | `PA22`       | `CAN0_TX`         | `TCC1` (channel 6), `TCC0` (channel 2) |
-| `D13`             | `PA23`       | `LED`, `CAN0_RX`  | `TCC1` (channel 7), `TCC0` (channel 3) |
-| `D21`             | `PA13`       | `SCL_PIN`         | `TCC0` (channel 7), `TCC1` (channel 3) |
-| `D22`             | `PA12`       | `SDA_PIN`         | `TCC0` (channel 6), `TCC1` (channel 2) |
-| `D23`             | `PB22`       | `SPI0_SDI_PIN`    |                      |
-| `D24`             | `PB23`       | `SPI0_SDO_PIN`    |                      |
-| `D25`             | `PA17`       | `SPI0_SCK_PIN`    | `TCC1` (channel 1), `TCC0` (channel 5) |
-| `A0`              | `PA02`       |                   |                      |
-| `A1`              | `PA05`       |                   |                      |
-| `A2`              | `PB08`       |                   |                      |
-| `A3`              | `PB09`       |                   |                      |
-| `A4`              | `PA04`       | `UART2_TX_PIN`    |                      |
-| `A5`              | `PA06`       | `UART2_RX_PIN`    |                      |
-| `USBCDC_DM_PIN`   | `PA24`       |                   | `TCC2` (channel 2)   |
-| `USBCDC_DP_PIN`   | `PA25`       |                   | `TCC2` (channel 3)   |
-| `CAN1_STANDBY`    | `PB12`       | `CAN_STANDBY`, `CAN_S` | `TCC3` (channel 0), `TCC0` (channel 0) |
-| `CAN1_TX`         | `PB14`       | `CAN_TX`          | `TCC4` (channel 0), `TCC0` (channel 2) |
-| `CAN1_RX`         | `PB15`       | `CAN_RX`          | `TCC4` (channel 1), `TCC0` (channel 3) |
-| `BOOST_EN`        | `PB13`       |                   | `TCC3` (channel 1), `TCC0` (channel 1) |
-| `QSPI_SCK`        | `PB10`       |                   | `TCC0` (channel 4), `TCC1` (channel 0) |
-| `QSPI_CS`         | `PB11`       |                   | `TCC0` (channel 5), `TCC1` (channel 1) |
-| `QSPI_DATA0`      | `PA08`       |                   | `TCC0` (channel 0), `TCC1` (channel 4) |
-| `QSPI_DATA1`      | `PA09`       |                   | `TCC0` (channel 1), `TCC1` (channel 5) |
-| `QSPI_DATA2`      | `PA10`       |                   | `TCC0` (channel 2), `TCC1` (channel 6) |
-| `QSPI_DATA3`      | `PA11`       |                   | `TCC0` (channel 3), `TCC1` (channel 7) |
+| Pin               | Hardware pin | Alternative names | I2C                  | PWM                  |
+| ----------------- | ------------ | ----------------- | -------------------- | -------------------- |
+| `D0`              | `PB17`       | `UART_RX_PIN`     |                      | `TCC3` (channel 1), `TCC0` (channel 5) |
+| `D1`              | `PB16`       | `UART_TX_PIN`     |                      | `TCC3` (channel 0), `TCC0` (channel 4) |
+| `D4`              | `PA14`       |                   |                      | `TCC2` (channel 0), `TCC1` (channel 2) |
+| `D5`              | `PA16`       |                   |                      | `TCC1` (channel 0), `TCC0` (channel 4) |
+| `D6`              | `PA18`       |                   |                      | `TCC1` (channel 2), `TCC0` (channel 6) |
+| `D7`              | `PB03`       |                   |                      | `TCC2` (channel 3)   |
+| `D8`              | `PB02`       | `NEOPIXELS`, `WS2812` |                      | `TCC2` (channel 2)   |
+| `D9`              | `PA19`       |                   |                      | `TCC1` (channel 3), `TCC0` (channel 7) |
+| `D10`             | `PA20`       |                   |                      | `TCC1` (channel 4), `TCC0` (channel 0) |
+| `D11`             | `PA21`       |                   |                      | `TCC1` (channel 5), `TCC0` (channel 1) |
+| `D12`             | `PA22`       | `CAN0_TX`         |                      | `TCC1` (channel 6), `TCC0` (channel 2) |
+| `D13`             | `PA23`       | `LED`, `CAN0_RX`  |                      | `TCC1` (channel 7), `TCC0` (channel 3) |
+| `D21`             | `PA13`       | `SCL_PIN`         | `I2C0` (SCL)         | `TCC0` (channel 7), `TCC1` (channel 3) |
+| `D22`             | `PA12`       | `SDA_PIN`         | `I2C0` (SDA)         | `TCC0` (channel 6), `TCC1` (channel 2) |
+| `D23`             | `PB22`       | `SPI0_SDI_PIN`    |                      |                      |
+| `D24`             | `PB23`       | `SPI0_SDO_PIN`    |                      |                      |
+| `D25`             | `PA17`       | `SPI0_SCK_PIN`    |                      | `TCC1` (channel 1), `TCC0` (channel 5) |
+| `A0`              | `PA02`       |                   |                      |                      |
+| `A1`              | `PA05`       |                   |                      |                      |
+| `A2`              | `PB08`       |                   |                      |                      |
+| `A3`              | `PB09`       |                   |                      |                      |
+| `A4`              | `PA04`       | `UART2_TX_PIN`    |                      |                      |
+| `A5`              | `PA06`       | `UART2_RX_PIN`    |                      |                      |
+| `USBCDC_DM_PIN`   | `PA24`       |                   |                      | `TCC2` (channel 2)   |
+| `USBCDC_DP_PIN`   | `PA25`       |                   |                      | `TCC2` (channel 3)   |
+| `CAN1_STANDBY`    | `PB12`       | `CAN_STANDBY`, `CAN_S` |                      | `TCC3` (channel 0), `TCC0` (channel 0) |
+| `CAN1_TX`         | `PB14`       | `CAN_TX`          |                      | `TCC4` (channel 0), `TCC0` (channel 2) |
+| `CAN1_RX`         | `PB15`       | `CAN_RX`          |                      | `TCC4` (channel 1), `TCC0` (channel 3) |
+| `BOOST_EN`        | `PB13`       |                   |                      | `TCC3` (channel 1), `TCC0` (channel 1) |
+| `QSPI_SCK`        | `PB10`       |                   |                      | `TCC0` (channel 4), `TCC1` (channel 0) |
+| `QSPI_CS`         | `PB11`       |                   |                      | `TCC0` (channel 5), `TCC1` (channel 1) |
+| `QSPI_DATA0`      | `PA08`       |                   | `I2C0` (SDA)         | `TCC0` (channel 0), `TCC1` (channel 4) |
+| `QSPI_DATA1`      | `PA09`       |                   | `I2C0` (SCL)         | `TCC0` (channel 1), `TCC1` (channel 5) |
+| `QSPI_DATA2`      | `PA10`       |                   |                      | `TCC0` (channel 2), `TCC1` (channel 6) |
+| `QSPI_DATA3`      | `PA11`       |                   |                      | `TCC0` (channel 3), `TCC1` (channel 7) |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/feather-m4.md
+++ b/content/docs/reference/microcontrollers/feather-m4.md
@@ -19,38 +19,38 @@ The [Adafruit Feather M4](https://www.adafruit.com/product/3857) is a tiny ARM d
 
 ## Pins
 
-| Pin               | Hardware pin | Alternative names | PWM                  |
-| ----------------- | ------------ | ----------------- | -------------------- |
-| `D0`              | `PB17`       | `UART_RX_PIN`     | `TCC3` (channel 1), `TCC0` (channel 5) |
-| `D1`              | `PB16`       | `UART_TX_PIN`     | `TCC3` (channel 0), `TCC0` (channel 4) |
-| `D4`              | `PA14`       |                   | `TCC2` (channel 0), `TCC1` (channel 2) |
-| `D5`              | `PA16`       |                   | `TCC1` (channel 0), `TCC0` (channel 4) |
-| `D6`              | `PA18`       |                   | `TCC1` (channel 2), `TCC0` (channel 6) |
-| `D8`              | `PB03`       | `WS2812`          | `TCC2` (channel 3)   |
-| `D9`              | `PA19`       |                   | `TCC1` (channel 3), `TCC0` (channel 7) |
-| `D10`             | `PA20`       |                   | `TCC1` (channel 4), `TCC0` (channel 0) |
-| `D11`             | `PA21`       |                   | `TCC1` (channel 5), `TCC0` (channel 1) |
-| `D12`             | `PA22`       |                   | `TCC1` (channel 6), `TCC0` (channel 2) |
-| `D13`             | `PA23`       | `LED`             | `TCC1` (channel 7), `TCC0` (channel 3) |
-| `D21`             | `PA13`       | `SCL_PIN`         | `TCC0` (channel 7), `TCC1` (channel 3) |
-| `D22`             | `PA12`       | `SDA_PIN`         | `TCC0` (channel 6), `TCC1` (channel 2) |
-| `D23`             | `PB22`       | `SPI0_SDI_PIN`    |                      |
-| `D24`             | `PB23`       | `SPI0_SDO_PIN`    |                      |
-| `D25`             | `PA17`       | `SPI0_SCK_PIN`    | `TCC1` (channel 1), `TCC0` (channel 5) |
-| `A0`              | `PA02`       |                   |                      |
-| `A1`              | `PA05`       |                   |                      |
-| `A2`              | `PB08`       |                   |                      |
-| `A3`              | `PB09`       |                   |                      |
-| `A4`              | `PA04`       | `UART2_TX_PIN`    |                      |
-| `A5`              | `PA06`       | `UART2_RX_PIN`    |                      |
-| `USBCDC_DM_PIN`   | `PA24`       |                   | `TCC2` (channel 2)   |
-| `USBCDC_DP_PIN`   | `PA25`       |                   | `TCC2` (channel 3)   |
-| `QSPI_SCK`        | `PB10`       |                   | `TCC0` (channel 4), `TCC1` (channel 0) |
-| `QSPI_CS`         | `PB11`       |                   | `TCC0` (channel 5), `TCC1` (channel 1) |
-| `QSPI_DATA0`      | `PA08`       |                   | `TCC0` (channel 0), `TCC1` (channel 4) |
-| `QSPI_DATA1`      | `PA09`       |                   | `TCC0` (channel 1), `TCC1` (channel 5) |
-| `QSPI_DATA2`      | `PA10`       |                   | `TCC0` (channel 2), `TCC1` (channel 6) |
-| `QSPI_DATA3`      | `PA11`       |                   | `TCC0` (channel 3), `TCC1` (channel 7) |
+| Pin               | Hardware pin | Alternative names | I2C                  | PWM                  |
+| ----------------- | ------------ | ----------------- | -------------------- | -------------------- |
+| `D0`              | `PB17`       | `UART_RX_PIN`     |                      | `TCC3` (channel 1), `TCC0` (channel 5) |
+| `D1`              | `PB16`       | `UART_TX_PIN`     |                      | `TCC3` (channel 0), `TCC0` (channel 4) |
+| `D4`              | `PA14`       |                   |                      | `TCC2` (channel 0), `TCC1` (channel 2) |
+| `D5`              | `PA16`       |                   |                      | `TCC1` (channel 0), `TCC0` (channel 4) |
+| `D6`              | `PA18`       |                   |                      | `TCC1` (channel 2), `TCC0` (channel 6) |
+| `D8`              | `PB03`       | `WS2812`          |                      | `TCC2` (channel 3)   |
+| `D9`              | `PA19`       |                   |                      | `TCC1` (channel 3), `TCC0` (channel 7) |
+| `D10`             | `PA20`       |                   |                      | `TCC1` (channel 4), `TCC0` (channel 0) |
+| `D11`             | `PA21`       |                   |                      | `TCC1` (channel 5), `TCC0` (channel 1) |
+| `D12`             | `PA22`       |                   |                      | `TCC1` (channel 6), `TCC0` (channel 2) |
+| `D13`             | `PA23`       | `LED`             |                      | `TCC1` (channel 7), `TCC0` (channel 3) |
+| `D21`             | `PA13`       | `SCL_PIN`         | `I2C0` (SCL)         | `TCC0` (channel 7), `TCC1` (channel 3) |
+| `D22`             | `PA12`       | `SDA_PIN`         | `I2C0` (SDA)         | `TCC0` (channel 6), `TCC1` (channel 2) |
+| `D23`             | `PB22`       | `SPI0_SDI_PIN`    |                      |                      |
+| `D24`             | `PB23`       | `SPI0_SDO_PIN`    |                      |                      |
+| `D25`             | `PA17`       | `SPI0_SCK_PIN`    |                      | `TCC1` (channel 1), `TCC0` (channel 5) |
+| `A0`              | `PA02`       |                   |                      |                      |
+| `A1`              | `PA05`       |                   |                      |                      |
+| `A2`              | `PB08`       |                   |                      |                      |
+| `A3`              | `PB09`       |                   |                      |                      |
+| `A4`              | `PA04`       | `UART2_TX_PIN`    |                      |                      |
+| `A5`              | `PA06`       | `UART2_RX_PIN`    |                      |                      |
+| `USBCDC_DM_PIN`   | `PA24`       |                   |                      | `TCC2` (channel 2)   |
+| `USBCDC_DP_PIN`   | `PA25`       |                   |                      | `TCC2` (channel 3)   |
+| `QSPI_SCK`        | `PB10`       |                   |                      | `TCC0` (channel 4), `TCC1` (channel 0) |
+| `QSPI_CS`         | `PB11`       |                   |                      | `TCC0` (channel 5), `TCC1` (channel 1) |
+| `QSPI_DATA0`      | `PA08`       |                   | `I2C0` (SDA)         | `TCC0` (channel 0), `TCC1` (channel 4) |
+| `QSPI_DATA1`      | `PA09`       |                   | `I2C0` (SCL)         | `TCC0` (channel 1), `TCC1` (channel 5) |
+| `QSPI_DATA2`      | `PA10`       |                   |                      | `TCC0` (channel 2), `TCC1` (channel 6) |
+| `QSPI_DATA3`      | `PA11`       |                   |                      | `TCC0` (channel 3), `TCC1` (channel 7) |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/feather-rp2040.md
+++ b/content/docs/reference/microcontrollers/feather-rp2040.md
@@ -19,29 +19,29 @@ The [Adafruit Feather RP2040](https://www.adafruit.com/product/4884) is a tiny d
 
 ## Pins
 
-| Pin               | Hardware pin | Alternative names | PWM                  |
-| ----------------- | ------------ | ----------------- | -------------------- |
-| `D4`              | `GPIO6`      |                   | `PWM3` (channel A)   |
-| `D5`              | `GPIO7`      |                   | `PWM3` (channel B)   |
-| `D6`              | `GPIO8`      | `UART1_TX_PIN`    | `PWM4` (channel A)   |
-| `D9`              | `GPIO9`      | `UART1_RX_PIN`    | `PWM4` (channel B)   |
-| `D10`             | `GPIO10`     | `SPI1_SCK_PIN`    | `PWM5` (channel A)   |
-| `D11`             | `GPIO11`     | `SPI1_SDO_PIN`    | `PWM5` (channel B)   |
-| `D12`             | `GPIO12`     | `SPI1_SDI_PIN`    | `PWM6` (channel A)   |
-| `D13`             | `GPIO13`     | `LED`             | `PWM6` (channel B)   |
-| `D24`             | `GPIO24`     | `I2C0_SDA_PIN`    | `PWM4` (channel A)   |
-| `D25`             | `GPIO25`     | `I2C0_SCL_PIN`    | `PWM4` (channel B)   |
-| `A0`              | `GPIO26`     | `ADC0`            | `PWM5` (channel A)   |
-| `A1`              | `GPIO27`     | `ADC1`            | `PWM5` (channel B)   |
-| `A2`              | `GPIO28`     | `ADC2`            | `PWM6` (channel A)   |
-| `A3`              | `GPIO29`     | `ADC3`            | `PWM6` (channel B)   |
-| `I2C1_SDA_PIN`    | `GPIO2`      | `SDA_PIN`         | `PWM1` (channel A)   |
-| `I2C1_SCL_PIN`    | `GPIO3`      | `SCL_PIN`         | `PWM1` (channel B)   |
-| `SPI0_SCK_PIN`    | `GPIO18`     |                   | `PWM1` (channel A)   |
-| `SPI0_SDO_PIN`    | `GPIO19`     |                   | `PWM1` (channel B)   |
-| `SPI0_SDI_PIN`    | `GPIO20`     |                   | `PWM2` (channel A)   |
-| `UART0_TX_PIN`    | `GPIO0`      | `UART_TX_PIN`     | `PWM0` (channel A)   |
-| `UART0_RX_PIN`    | `GPIO1`      | `UART_RX_PIN`     | `PWM0` (channel B)   |
+| Pin               | Hardware pin | Alternative names | I2C                  | PWM                  |
+| ----------------- | ------------ | ----------------- | -------------------- | -------------------- |
+| `D4`              | `GPIO6`      |                   | `I2C1` (SDA)         | `PWM3` (channel A)   |
+| `D5`              | `GPIO7`      |                   | `I2C1` (SCL)         | `PWM3` (channel B)   |
+| `D6`              | `GPIO8`      | `UART1_TX_PIN`    | `I2C0` (SDA)         | `PWM4` (channel A)   |
+| `D9`              | `GPIO9`      | `UART1_RX_PIN`    | `I2C0` (SCL)         | `PWM4` (channel B)   |
+| `D10`             | `GPIO10`     | `SPI1_SCK_PIN`    | `I2C1` (SDA)         | `PWM5` (channel A)   |
+| `D11`             | `GPIO11`     | `SPI1_SDO_PIN`    | `I2C1` (SCL)         | `PWM5` (channel B)   |
+| `D12`             | `GPIO12`     | `SPI1_SDI_PIN`    | `I2C0` (SDA)         | `PWM6` (channel A)   |
+| `D13`             | `GPIO13`     | `LED`             | `I2C0` (SCL)         | `PWM6` (channel B)   |
+| `D24`             | `GPIO24`     | `I2C0_SDA_PIN`    |                      | `PWM4` (channel A)   |
+| `D25`             | `GPIO25`     | `I2C0_SCL_PIN`    |                      | `PWM4` (channel B)   |
+| `A0`              | `GPIO26`     | `ADC0`            | `I2C1` (SDA)         | `PWM5` (channel A)   |
+| `A1`              | `GPIO27`     | `ADC1`            | `I2C1` (SCL)         | `PWM5` (channel B)   |
+| `A2`              | `GPIO28`     | `ADC2`            |                      | `PWM6` (channel A)   |
+| `A3`              | `GPIO29`     | `ADC3`            |                      | `PWM6` (channel B)   |
+| `I2C1_SDA_PIN`    | `GPIO2`      | `SDA_PIN`         | `I2C1` (SDA)         | `PWM1` (channel A)   |
+| `I2C1_SCL_PIN`    | `GPIO3`      | `SCL_PIN`         | `I2C1` (SCL)         | `PWM1` (channel B)   |
+| `SPI0_SCK_PIN`    | `GPIO18`     |                   | `I2C1` (SDA)         | `PWM1` (channel A)   |
+| `SPI0_SDO_PIN`    | `GPIO19`     |                   | `I2C1` (SCL)         | `PWM1` (channel B)   |
+| `SPI0_SDI_PIN`    | `GPIO20`     |                   | `I2C0` (SDA)         | `PWM2` (channel A)   |
+| `UART0_TX_PIN`    | `GPIO0`      | `UART_TX_PIN`     | `I2C0` (SDA)         | `PWM0` (channel A)   |
+| `UART0_RX_PIN`    | `GPIO1`      | `UART_RX_PIN`     | `I2C0` (SCL)         | `PWM0` (channel B)   |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/grandcentral-m4.md
+++ b/content/docs/reference/microcontrollers/grandcentral-m4.md
@@ -19,97 +19,97 @@ The [Adafruit Grand Central M4](https://www.adafruit.com/product/4064) is a tiny
 
 ## Pins
 
-| Pin               | Hardware pin | Alternative names | PWM                  |
-| ----------------- | ------------ | ----------------- | -------------------- |
-| `D0`              | `PB25`       | `UART1_RX_PIN`, `UART_RX_PIN` |                      |
-| `D1`              | `PB24`       | `UART1_TX_PIN`, `UART_TX_PIN` |                      |
-| `D2`              | `PC18`       |                   | `TCC0` (channel 2)   |
-| `D3`              | `PC19`       |                   | `TCC0` (channel 3)   |
-| `D4`              | `PC20`       |                   | `TCC0` (channel 4)   |
-| `D5`              | `PC21`       |                   | `TCC0` (channel 5)   |
-| `D6`              | `PD20`       |                   | `TCC1` (channel 0)   |
-| `D7`              | `PD21`       |                   | `TCC1` (channel 1)   |
-| `D8`              | `PB18`       |                   | `TCC1` (channel 0)   |
-| `D9`              | `PB02`       |                   | `TCC2` (channel 2)   |
-| `D10`             | `PB22`       |                   |                      |
-| `D11`             | `PB23`       |                   |                      |
-| `D12`             | `PB00`       |                   |                      |
-| `D13`             | `PB01`       | `D87`, `LED_PIN`, `LED` |                      |
-| `D14`             | `PB16`       | `UART4_TX_PIN`, `I2S0_SCK_PIN`, `I2S_SCK_PIN` | `TCC3` (channel 0), `TCC0` (channel 4) |
-| `D15`             | `PB17`       | `UART4_RX_PIN`, `I2S0_MCK_PIN` | `TCC3` (channel 1), `TCC0` (channel 5) |
-| `D16`             | `PC22`       | `UART3_TX_PIN`    | `TCC0` (channel 6)   |
-| `D17`             | `PC23`       | `UART3_RX_PIN`    | `TCC0` (channel 7)   |
-| `D18`             | `PB12`       | `UART2_TX_PIN`    | `TCC3` (channel 0), `TCC0` (channel 0) |
-| `D19`             | `PB13`       | `UART2_RX_PIN`    | `TCC3` (channel 1), `TCC0` (channel 1) |
-| `D20`             | `PB20`       | `D62`, `I2C0_SDA_PIN`, `I2C_SDA_PIN`, `SDA_PIN` | `TCC1` (channel 2)   |
-| `D21`             | `PB21`       | `D63`, `I2C0_SCL_PIN`, `I2C_SCL_PIN`, `SCL_PIN` | `TCC1` (channel 3)   |
-| `D22`             | `PD12`       |                   | `TCC0` (channel 5)   |
-| `D23`             | `PA15`       |                   | `TCC2` (channel 1), `TCC1` (channel 3) |
-| `D24`             | `PC17`       | `I2C1_SCL_PIN`    | `TCC0` (channel 1)   |
-| `D25`             | `PC16`       | `I2C1_SDA_PIN`    | `TCC0` (channel 0)   |
-| `D26`             | `PA12`       |                   | `TCC0` (channel 6), `TCC1` (channel 2) |
-| `D27`             | `PA13`       |                   | `TCC0` (channel 7), `TCC1` (channel 3) |
-| `D28`             | `PA14`       |                   | `TCC2` (channel 0), `TCC1` (channel 2) |
-| `D29`             | `PB19`       |                   | `TCC1` (channel 1)   |
-| `D30`             | `PA23`       |                   | `TCC1` (channel 7), `TCC0` (channel 3) |
-| `D31`             | `PA22`       | `I2S0_SDI_PIN`    | `TCC1` (channel 6), `TCC0` (channel 2) |
-| `D32`             | `PA21`       | `I2S0_SDO_PIN`, `I2S_SDO_PIN` | `TCC1` (channel 5), `TCC0` (channel 1) |
-| `D33`             | `PA20`       | `I2S0_FS_PIN`, `I2S_WS_PIN` | `TCC1` (channel 4), `TCC0` (channel 0) |
-| `D34`             | `PA19`       |                   | `TCC1` (channel 3), `TCC0` (channel 7) |
-| `D35`             | `PA18`       |                   | `TCC1` (channel 2), `TCC0` (channel 6) |
-| `D36`             | `PA17`       |                   | `TCC1` (channel 1), `TCC0` (channel 5) |
-| `D37`             | `PA16`       |                   | `TCC1` (channel 0), `TCC0` (channel 4) |
-| `D38`             | `PB15`       |                   | `TCC4` (channel 1), `TCC0` (channel 3) |
-| `D39`             | `PB14`       |                   | `TCC4` (channel 0), `TCC0` (channel 2) |
-| `D40`             | `PC13`       |                   | `TCC0` (channel 3), `TCC1` (channel 7) |
-| `D41`             | `PC12`       |                   | `TCC0` (channel 2), `TCC1` (channel 6) |
-| `D42`             | `PC15`       |                   | `TCC0` (channel 5), `TCC1` (channel 1) |
-| `D43`             | `PC14`       |                   | `TCC0` (channel 4), `TCC1` (channel 0) |
-| `D44`             | `PC11`       |                   | `TCC0` (channel 1), `TCC1` (channel 5) |
-| `D45`             | `PC10`       |                   | `TCC0` (channel 0), `TCC1` (channel 4) |
-| `D46`             | `PC06`       |                   |                      |
-| `D47`             | `PC07`       |                   |                      |
-| `D48`             | `PC04`       |                   | `TCC0` (channel 0)   |
-| `D49`             | `PC05`       |                   | `TCC0` (channel 1)   |
-| `D50`             | `PD11`       | `D64`, `SPI0_SDI_PIN`, `SPI_SDI_PIN` | `TCC0` (channel 4)   |
-| `D51`             | `PD08`       | `D65`, `SPI0_SDO_PIN`, `SPI_SDO_PIN` | `TCC0` (channel 1)   |
-| `D52`             | `PD09`       | `D66`, `SPI0_SCK_PIN`, `SPI_SCK_PIN` | `TCC0` (channel 2)   |
-| `D53`             | `PD10`       | `SPI0_CS_PIN`, `SPI_CS_PIN` | `TCC0` (channel 3)   |
-| `D54`             | `PB05`       | `A8`              |                      |
-| `D55`             | `PB06`       | `A9`              |                      |
-| `D56`             | `PB07`       | `A10`             |                      |
-| `D57`             | `PB08`       | `A11`             |                      |
-| `D58`             | `PB09`       | `A12`             |                      |
-| `D59`             | `PA04`       | `A13`             |                      |
-| `D60`             | `PA06`       | `A14`             |                      |
-| `D61`             | `PA07`       | `A15`             |                      |
-| `D67`             | `PA02`       | `D85`, `A0`       |                      |
-| `D68`             | `PA05`       | `D86`, `A1`       |                      |
-| `D69`             | `PB03`       | `A2`              | `TCC2` (channel 3)   |
-| `D70`             | `PC00`       | `A3`              |                      |
-| `D71`             | `PC01`       | `A4`              |                      |
-| `D72`             | `PC02`       | `A5`              |                      |
-| `D73`             | `PC03`       | `A6`              |                      |
-| `D74`             | `PB04`       | `A7`              |                      |
-| `D75`             | `PC31`       | `UART_RX_LED_PIN`, `LED_RX` |                      |
-| `D76`             | `PC30`       | `UART_TX_LED_PIN`, `LED_TX` |                      |
-| `D77`             | `PA27`       | `USBCDC_HOSTEN_PIN` |                      |
-| `D78`             | `PA24`       | `USBCDC_DM_PIN`   | `TCC2` (channel 2)   |
-| `D79`             | `PA25`       | `USBCDC_DP_PIN`   | `TCC2` (channel 3)   |
-| `D80`             | `PB29`       | `SPI1_SDI_PIN`, `SD0_SDI_PIN`, `SDCARD_SDI_PIN` | `TCC1` (channel 5)   |
-| `D81`             | `PB27`       | `SPI1_SCK_PIN`, `SD0_SCK_PIN`, `SDCARD_SCK_PIN` | `TCC1` (channel 3)   |
-| `D82`             | `PB26`       | `SPI1_SDO_PIN`, `SD0_SDO_PIN`, `SDCARD_SDO_PIN` | `TCC1` (channel 2)   |
-| `D83`             | `PB28`       | `SD0_CS_PIN`, `SDCARD_CS_PIN` | `TCC1` (channel 4)   |
-| `D84`             | `PA03`       | `AREF`            |                      |
-| `D88`             | `PC24`       | `NEOPIXEL_PIN`, `NEOPIXEL`, `WS2812` |                      |
-| `D89`             | `PB10`       | `QSPI_SCK`        | `TCC0` (channel 4), `TCC1` (channel 0) |
-| `D90`             | `PB11`       | `QSPI_CS`         | `TCC0` (channel 5), `TCC1` (channel 1) |
-| `D91`             | `PA08`       | `QSPI_DATA0`      | `TCC0` (channel 0), `TCC1` (channel 4) |
-| `D92`             | `PA09`       | `QSPI_DATA1`      | `TCC0` (channel 1), `TCC1` (channel 5) |
-| `D93`             | `PA10`       | `QSPI_DATA2`      | `TCC0` (channel 2), `TCC1` (channel 6) |
-| `D94`             | `PA11`       | `QSPI_DATA3`      | `TCC0` (channel 3), `TCC1` (channel 7) |
-| `D95`             | `PB31`       | `SD0_DET_PIN`, `SDCARD_DET_PIN` | `TCC4` (channel 1), `TCC0` (channel 7) |
-| `D96`             | `PB30`       |                   | `TCC4` (channel 0), `TCC0` (channel 6) |
+| Pin               | Hardware pin | Alternative names | I2C                  | PWM                  |
+| ----------------- | ------------ | ----------------- | -------------------- | -------------------- |
+| `D0`              | `PB25`       | `UART1_RX_PIN`, `UART_RX_PIN` |                      |                      |
+| `D1`              | `PB24`       | `UART1_TX_PIN`, `UART_TX_PIN` |                      |                      |
+| `D2`              | `PC18`       |                   |                      | `TCC0` (channel 2)   |
+| `D3`              | `PC19`       |                   |                      | `TCC0` (channel 3)   |
+| `D4`              | `PC20`       |                   |                      | `TCC0` (channel 4)   |
+| `D5`              | `PC21`       |                   |                      | `TCC0` (channel 5)   |
+| `D6`              | `PD20`       |                   |                      | `TCC1` (channel 0)   |
+| `D7`              | `PD21`       |                   |                      | `TCC1` (channel 1)   |
+| `D8`              | `PB18`       |                   |                      | `TCC1` (channel 0)   |
+| `D9`              | `PB02`       |                   |                      | `TCC2` (channel 2)   |
+| `D10`             | `PB22`       |                   |                      |                      |
+| `D11`             | `PB23`       |                   |                      |                      |
+| `D12`             | `PB00`       |                   |                      |                      |
+| `D13`             | `PB01`       | `D87`, `LED_PIN`, `LED` |                      |                      |
+| `D14`             | `PB16`       | `UART4_TX_PIN`, `I2S0_SCK_PIN`, `I2S_SCK_PIN` |                      | `TCC3` (channel 0), `TCC0` (channel 4) |
+| `D15`             | `PB17`       | `UART4_RX_PIN`, `I2S0_MCK_PIN` |                      | `TCC3` (channel 1), `TCC0` (channel 5) |
+| `D16`             | `PC22`       | `UART3_TX_PIN`    |                      | `TCC0` (channel 6)   |
+| `D17`             | `PC23`       | `UART3_RX_PIN`    |                      | `TCC0` (channel 7)   |
+| `D18`             | `PB12`       | `UART2_TX_PIN`    |                      | `TCC3` (channel 0), `TCC0` (channel 0) |
+| `D19`             | `PB13`       | `UART2_RX_PIN`    |                      | `TCC3` (channel 1), `TCC0` (channel 1) |
+| `D20`             | `PB20`       | `D62`, `I2C0_SDA_PIN`, `I2C_SDA_PIN`, `SDA_PIN` |                      | `TCC1` (channel 2)   |
+| `D21`             | `PB21`       | `D63`, `I2C0_SCL_PIN`, `I2C_SCL_PIN`, `SCL_PIN` |                      | `TCC1` (channel 3)   |
+| `D22`             | `PD12`       |                   |                      | `TCC0` (channel 5)   |
+| `D23`             | `PA15`       |                   |                      | `TCC2` (channel 1), `TCC1` (channel 3) |
+| `D24`             | `PC17`       | `I2C1_SCL_PIN`    |                      | `TCC0` (channel 1)   |
+| `D25`             | `PC16`       | `I2C1_SDA_PIN`    |                      | `TCC0` (channel 0)   |
+| `D26`             | `PA12`       |                   |                      | `TCC0` (channel 6), `TCC1` (channel 2) |
+| `D27`             | `PA13`       |                   |                      | `TCC0` (channel 7), `TCC1` (channel 3) |
+| `D28`             | `PA14`       |                   |                      | `TCC2` (channel 0), `TCC1` (channel 2) |
+| `D29`             | `PB19`       |                   |                      | `TCC1` (channel 1)   |
+| `D30`             | `PA23`       |                   | `I2C0` (SCL)         | `TCC1` (channel 7), `TCC0` (channel 3) |
+| `D31`             | `PA22`       | `I2S0_SDI_PIN`    | `I2C0` (SDA)         | `TCC1` (channel 6), `TCC0` (channel 2) |
+| `D32`             | `PA21`       | `I2S0_SDO_PIN`, `I2S_SDO_PIN` |                      | `TCC1` (channel 5), `TCC0` (channel 1) |
+| `D33`             | `PA20`       | `I2S0_FS_PIN`, `I2S_WS_PIN` |                      | `TCC1` (channel 4), `TCC0` (channel 0) |
+| `D34`             | `PA19`       |                   |                      | `TCC1` (channel 3), `TCC0` (channel 7) |
+| `D35`             | `PA18`       |                   |                      | `TCC1` (channel 2), `TCC0` (channel 6) |
+| `D36`             | `PA17`       |                   | `I2C0` (SCL)         | `TCC1` (channel 1), `TCC0` (channel 5) |
+| `D37`             | `PA16`       |                   | `I2C0` (SDA)         | `TCC1` (channel 0), `TCC0` (channel 4) |
+| `D38`             | `PB15`       |                   |                      | `TCC4` (channel 1), `TCC0` (channel 3) |
+| `D39`             | `PB14`       |                   |                      | `TCC4` (channel 0), `TCC0` (channel 2) |
+| `D40`             | `PC13`       |                   |                      | `TCC0` (channel 3), `TCC1` (channel 7) |
+| `D41`             | `PC12`       |                   |                      | `TCC0` (channel 2), `TCC1` (channel 6) |
+| `D42`             | `PC15`       |                   |                      | `TCC0` (channel 5), `TCC1` (channel 1) |
+| `D43`             | `PC14`       |                   |                      | `TCC0` (channel 4), `TCC1` (channel 0) |
+| `D44`             | `PC11`       |                   |                      | `TCC0` (channel 1), `TCC1` (channel 5) |
+| `D45`             | `PC10`       |                   |                      | `TCC0` (channel 0), `TCC1` (channel 4) |
+| `D46`             | `PC06`       |                   |                      |                      |
+| `D47`             | `PC07`       |                   |                      |                      |
+| `D48`             | `PC04`       |                   |                      | `TCC0` (channel 0)   |
+| `D49`             | `PC05`       |                   |                      | `TCC0` (channel 1)   |
+| `D50`             | `PD11`       | `D64`, `SPI0_SDI_PIN`, `SPI_SDI_PIN` |                      | `TCC0` (channel 4)   |
+| `D51`             | `PD08`       | `D65`, `SPI0_SDO_PIN`, `SPI_SDO_PIN` | `I2C1` (SDA)         | `TCC0` (channel 1)   |
+| `D52`             | `PD09`       | `D66`, `SPI0_SCK_PIN`, `SPI_SCK_PIN` | `I2C1` (SCL)         | `TCC0` (channel 2)   |
+| `D53`             | `PD10`       | `SPI0_CS_PIN`, `SPI_CS_PIN` |                      | `TCC0` (channel 3)   |
+| `D54`             | `PB05`       | `A8`              |                      |                      |
+| `D55`             | `PB06`       | `A9`              |                      |                      |
+| `D56`             | `PB07`       | `A10`             |                      |                      |
+| `D57`             | `PB08`       | `A11`             |                      |                      |
+| `D58`             | `PB09`       | `A12`             |                      |                      |
+| `D59`             | `PA04`       | `A13`             |                      |                      |
+| `D60`             | `PA06`       | `A14`             |                      |                      |
+| `D61`             | `PA07`       | `A15`             |                      |                      |
+| `D67`             | `PA02`       | `D85`, `A0`       |                      |                      |
+| `D68`             | `PA05`       | `D86`, `A1`       |                      |                      |
+| `D69`             | `PB03`       | `A2`              |                      | `TCC2` (channel 3)   |
+| `D70`             | `PC00`       | `A3`              |                      |                      |
+| `D71`             | `PC01`       | `A4`              |                      |                      |
+| `D72`             | `PC02`       | `A5`              |                      |                      |
+| `D73`             | `PC03`       | `A6`              |                      |                      |
+| `D74`             | `PB04`       | `A7`              |                      |                      |
+| `D75`             | `PC31`       | `UART_RX_LED_PIN`, `LED_RX` |                      |                      |
+| `D76`             | `PC30`       | `UART_TX_LED_PIN`, `LED_TX` |                      |                      |
+| `D77`             | `PA27`       | `USBCDC_HOSTEN_PIN` |                      |                      |
+| `D78`             | `PA24`       | `USBCDC_DM_PIN`   |                      | `TCC2` (channel 2)   |
+| `D79`             | `PA25`       | `USBCDC_DP_PIN`   |                      | `TCC2` (channel 3)   |
+| `D80`             | `PB29`       | `SPI1_SDI_PIN`, `SD0_SDI_PIN`, `SDCARD_SDI_PIN` |                      | `TCC1` (channel 5)   |
+| `D81`             | `PB27`       | `SPI1_SCK_PIN`, `SD0_SCK_PIN`, `SDCARD_SCK_PIN` |                      | `TCC1` (channel 3)   |
+| `D82`             | `PB26`       | `SPI1_SDO_PIN`, `SD0_SDO_PIN`, `SDCARD_SDO_PIN` |                      | `TCC1` (channel 2)   |
+| `D83`             | `PB28`       | `SD0_CS_PIN`, `SDCARD_CS_PIN` |                      | `TCC1` (channel 4)   |
+| `D84`             | `PA03`       | `AREF`            |                      |                      |
+| `D88`             | `PC24`       | `NEOPIXEL_PIN`, `NEOPIXEL`, `WS2812` |                      |                      |
+| `D89`             | `PB10`       | `QSPI_SCK`        |                      | `TCC0` (channel 4), `TCC1` (channel 0) |
+| `D90`             | `PB11`       | `QSPI_CS`         |                      | `TCC0` (channel 5), `TCC1` (channel 1) |
+| `D91`             | `PA08`       | `QSPI_DATA0`      |                      | `TCC0` (channel 0), `TCC1` (channel 4) |
+| `D92`             | `PA09`       | `QSPI_DATA1`      |                      | `TCC0` (channel 1), `TCC1` (channel 5) |
+| `D93`             | `PA10`       | `QSPI_DATA2`      |                      | `TCC0` (channel 2), `TCC1` (channel 6) |
+| `D94`             | `PA11`       | `QSPI_DATA3`      |                      | `TCC0` (channel 3), `TCC1` (channel 7) |
+| `D95`             | `PB31`       | `SD0_DET_PIN`, `SDCARD_DET_PIN` |                      | `TCC4` (channel 1), `TCC0` (channel 7) |
+| `D96`             | `PB30`       |                   |                      | `TCC4` (channel 0), `TCC0` (channel 6) |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/hifive1b.md
+++ b/content/docs/reference/microcontrollers/hifive1b.md
@@ -19,25 +19,25 @@ The [HiFive1 Rev B](https://www.sifive.com/boards/hifive1-rev-b) is low-cost, Ar
 
 ## Pins
 
-| Pin               | Hardware pin | Alternative names |
-| ----------------- | ------------ | ----------------- |
-| `D0`              | `P16`        | `D7`, `UART_RX_PIN` |
-| `D1`              | `P17`        | `UART_TX_PIN`     |
-| `D2`              | `P18`        |                   |
-| `D3`              | `P19`        | `LED2`, `LED_GREEN` |
-| `D4`              | `P20`        |                   |
-| `D5`              | `P21`        | `LED3`, `LED_BLUE` |
-| `D6`              | `P22`        | `LED`, `LED1`, `LED_RED` |
-| `D9`              | `P01`        |                   |
-| `D10`             | `P02`        |                   |
-| `D11`             | `P03`        | `SPI1_SDO_PIN`    |
-| `D12`             | `P04`        | `SPI1_SDI_PIN`    |
-| `D13`             | `P05`        | `SPI1_SCK_PIN`    |
-| `D15`             | `P09`        |                   |
-| `D16`             | `P10`        |                   |
-| `D17`             | `P11`        |                   |
-| `D18`             | `P12`        | `I2C0_SDA_PIN`    |
-| `D19`             | `P13`        | `I2C0_SCL_PIN`    |
+| Pin               | Hardware pin | Alternative names | I2C                  |
+| ----------------- | ------------ | ----------------- | -------------------- |
+| `D0`              | `P16`        | `D7`, `UART_RX_PIN` |                      |
+| `D1`              | `P17`        | `UART_TX_PIN`     |                      |
+| `D2`              | `P18`        |                   |                      |
+| `D3`              | `P19`        | `LED2`, `LED_GREEN` |                      |
+| `D4`              | `P20`        |                   |                      |
+| `D5`              | `P21`        | `LED3`, `LED_BLUE` |                      |
+| `D6`              | `P22`        | `LED`, `LED1`, `LED_RED` |                      |
+| `D9`              | `P01`        |                   |                      |
+| `D10`             | `P02`        |                   |                      |
+| `D11`             | `P03`        | `SPI1_SDO_PIN`    |                      |
+| `D12`             | `P04`        | `SPI1_SDI_PIN`    |                      |
+| `D13`             | `P05`        | `SPI1_SCK_PIN`    |                      |
+| `D15`             | `P09`        |                   |                      |
+| `D16`             | `P10`        |                   |                      |
+| `D17`             | `P11`        |                   |                      |
+| `D18`             | `P12`        | `I2C0_SDA_PIN`    | `I2C0` (SDA)         |
+| `D19`             | `P13`        | `I2C0_SCL_PIN`    | `I2C0` (SCL)         |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/itsybitsy-m0.md
+++ b/content/docs/reference/microcontrollers/itsybitsy-m0.md
@@ -19,39 +19,39 @@ The [Adafruit ItsyBitsy M0](https://www.adafruit.com/product/3727) is very compa
 
 ## Pins
 
-| Pin               | Hardware pin | Alternative names | PWM                  |
-| ----------------- | ------------ | ----------------- | -------------------- |
-| `D0`              | `PA11`       |                   | `TCC1` (channel 1), `TCC0` (channel 3) |
-| `D1`              | `PA10`       | `I2S_SCK_PIN`     | `TCC1` (channel 0), `TCC0` (channel 2) |
-| `D2`              | `PA14`       |                   | `TCC0` (channel 0)   |
-| `D3`              | `PA09`       |                   | `TCC0` (channel 1), `TCC1` (channel 3) |
-| `D4`              | `PA08`       | `I2S_SDO_PIN`     | `TCC0` (channel 0), `TCC1` (channel 2) |
-| `D5`              | `PA15`       |                   | `TCC0` (channel 1)   |
-| `D6`              | `PA20`       |                   | `TCC0` (channel 2)   |
-| `D7`              | `PA21`       |                   | `TCC0` (channel 3)   |
-| `D8`              | `PA06`       |                   | `TCC1` (channel 0)   |
-| `D9`              | `PA07`       |                   | `TCC1` (channel 1)   |
-| `D10`             | `PA18`       | `UART_TX_PIN`     | `TCC0` (channel 2)   |
-| `D11`             | `PA16`       | `UART_RX_PIN`     | `TCC2` (channel 0), `TCC0` (channel 2) |
-| `D12`             | `PA19`       |                   | `TCC0` (channel 3)   |
-| `D13`             | `PA17`       | `LED`             | `TCC2` (channel 1), `TCC0` (channel 3) |
-| `A0`              | `PA02`       |                   |                      |
-| `A1`              | `PB08`       |                   |                      |
-| `A2`              | `PB09`       |                   |                      |
-| `A3`              | `PA04`       |                   | `TCC0` (channel 0)   |
-| `A4`              | `PA05`       |                   | `TCC0` (channel 1)   |
-| `A5`              | `PB02`       |                   |                      |
-| `USBCDC_DM_PIN`   | `PA24`       |                   | `TCC1` (channel 2)   |
-| `USBCDC_DP_PIN`   | `PA25`       |                   | `TCC1` (channel 3)   |
-| `SDA_PIN`         | `PA22`       |                   | `TCC0` (channel 0)   |
-| `SCL_PIN`         | `PA23`       |                   | `TCC0` (channel 1)   |
-| `SPI0_SCK_PIN`    | `PB11`       |                   | `TCC0` (channel 1)   |
-| `SPI0_SDO_PIN`    | `PB10`       |                   | `TCC0` (channel 0)   |
-| `SPI0_SDI_PIN`    | `PA12`       |                   | `TCC2` (channel 0), `TCC0` (channel 2) |
-| `SPI1_CS_PIN`     | `PA27`       |                   |                      |
-| `SPI1_SCK_PIN`    | `PB23`       |                   |                      |
-| `SPI1_SDO_PIN`    | `PB22`       |                   |                      |
-| `SPI1_SDI_PIN`    | `PB03`       |                   |                      |
+| Pin               | Hardware pin | Alternative names | I2C                  | PWM                  |
+| ----------------- | ------------ | ----------------- | -------------------- | -------------------- |
+| `D0`              | `PA11`       |                   |                      | `TCC1` (channel 1), `TCC0` (channel 3) |
+| `D1`              | `PA10`       | `I2S_SCK_PIN`     |                      | `TCC1` (channel 0), `TCC0` (channel 2) |
+| `D2`              | `PA14`       |                   |                      | `TCC0` (channel 0)   |
+| `D3`              | `PA09`       |                   |                      | `TCC0` (channel 1), `TCC1` (channel 3) |
+| `D4`              | `PA08`       | `I2S_SDO_PIN`     |                      | `TCC0` (channel 0), `TCC1` (channel 2) |
+| `D5`              | `PA15`       |                   |                      | `TCC0` (channel 1)   |
+| `D6`              | `PA20`       |                   |                      | `TCC0` (channel 2)   |
+| `D7`              | `PA21`       |                   |                      | `TCC0` (channel 3)   |
+| `D8`              | `PA06`       |                   |                      | `TCC1` (channel 0)   |
+| `D9`              | `PA07`       |                   |                      | `TCC1` (channel 1)   |
+| `D10`             | `PA18`       | `UART_TX_PIN`     |                      | `TCC0` (channel 2)   |
+| `D11`             | `PA16`       | `UART_RX_PIN`     | `I2C0` (SDA)         | `TCC2` (channel 0), `TCC0` (channel 2) |
+| `D12`             | `PA19`       |                   |                      | `TCC0` (channel 3)   |
+| `D13`             | `PA17`       | `LED`             | `I2C0` (SCL)         | `TCC2` (channel 1), `TCC0` (channel 3) |
+| `A0`              | `PA02`       |                   |                      |                      |
+| `A1`              | `PB08`       |                   |                      |                      |
+| `A2`              | `PB09`       |                   |                      |                      |
+| `A3`              | `PA04`       |                   |                      | `TCC0` (channel 0)   |
+| `A4`              | `PA05`       |                   |                      | `TCC0` (channel 1)   |
+| `A5`              | `PB02`       |                   |                      |                      |
+| `USBCDC_DM_PIN`   | `PA24`       |                   |                      | `TCC1` (channel 2)   |
+| `USBCDC_DP_PIN`   | `PA25`       |                   |                      | `TCC1` (channel 3)   |
+| `SDA_PIN`         | `PA22`       |                   | `I2C0` (SDA)         | `TCC0` (channel 0)   |
+| `SCL_PIN`         | `PA23`       |                   | `I2C0` (SCL)         | `TCC0` (channel 1)   |
+| `SPI0_SCK_PIN`    | `PB11`       |                   |                      | `TCC0` (channel 1)   |
+| `SPI0_SDO_PIN`    | `PB10`       |                   |                      | `TCC0` (channel 0)   |
+| `SPI0_SDI_PIN`    | `PA12`       |                   |                      | `TCC2` (channel 0), `TCC0` (channel 2) |
+| `SPI1_CS_PIN`     | `PA27`       |                   |                      |                      |
+| `SPI1_SCK_PIN`    | `PB23`       |                   |                      |                      |
+| `SPI1_SDO_PIN`    | `PB22`       |                   |                      |                      |
+| `SPI1_SDI_PIN`    | `PB03`       |                   |                      |                      |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/itsybitsy-m4.md
+++ b/content/docs/reference/microcontrollers/itsybitsy-m4.md
@@ -19,41 +19,41 @@ The [Adafruit ItsyBitsy M4](https://www.adafruit.com/product/3800) is very compa
 
 ## Pins
 
-| Pin               | Hardware pin | Alternative names | PWM                  |
-| ----------------- | ------------ | ----------------- | -------------------- |
-| `D0`              | `PA16`       | `UART_RX_PIN`     | `TCC1` (channel 0), `TCC0` (channel 4) |
-| `D1`              | `PA17`       | `UART_TX_PIN`     | `TCC1` (channel 1), `TCC0` (channel 5) |
-| `D2`              | `PA07`       | `UART2_RX_PIN`    |                      |
-| `D3`              | `PB22`       |                   |                      |
-| `D4`              | `PA14`       |                   | `TCC2` (channel 0), `TCC1` (channel 2) |
-| `D5`              | `PA15`       |                   | `TCC2` (channel 1), `TCC1` (channel 3) |
-| `D6`              | `PB02`       |                   | `TCC2` (channel 2)   |
-| `D7`              | `PA18`       |                   | `TCC1` (channel 2), `TCC0` (channel 6) |
-| `D8`              | `PB03`       |                   | `TCC2` (channel 3)   |
-| `D9`              | `PA19`       |                   | `TCC1` (channel 3), `TCC0` (channel 7) |
-| `D10`             | `PA20`       |                   | `TCC1` (channel 4), `TCC0` (channel 0) |
-| `D11`             | `PA21`       |                   | `TCC1` (channel 5), `TCC0` (channel 1) |
-| `D12`             | `PA23`       |                   | `TCC1` (channel 7), `TCC0` (channel 3) |
-| `D13`             | `PA22`       | `LED`             | `TCC1` (channel 6), `TCC0` (channel 2) |
-| `A0`              | `PA02`       |                   |                      |
-| `A1`              | `PA05`       |                   |                      |
-| `A2`              | `PB08`       |                   |                      |
-| `A3`              | `PB09`       |                   |                      |
-| `A4`              | `PA04`       | `UART2_TX_PIN`    |                      |
-| `A5`              | `PA06`       |                   |                      |
-| `USBCDC_DM_PIN`   | `PA24`       |                   | `TCC2` (channel 2)   |
-| `USBCDC_DP_PIN`   | `PA25`       |                   | `TCC2` (channel 3)   |
-| `SDA_PIN`         | `PA12`       |                   | `TCC0` (channel 6), `TCC1` (channel 2) |
-| `SCL_PIN`         | `PA13`       |                   | `TCC0` (channel 7), `TCC1` (channel 3) |
-| `SPI0_SCK_PIN`    | `PA01`       |                   |                      |
-| `SPI0_SDO_PIN`    | `PA00`       |                   |                      |
-| `SPI0_SDI_PIN`    | `PB23`       |                   |                      |
-| `QSPI_SCK`        | `PB10`       |                   | `TCC0` (channel 4), `TCC1` (channel 0) |
-| `QSPI_CS`         | `PB11`       |                   | `TCC0` (channel 5), `TCC1` (channel 1) |
-| `QSPI_DATA0`      | `PA08`       |                   | `TCC0` (channel 0), `TCC1` (channel 4) |
-| `QSPI_DATA1`      | `PA09`       |                   | `TCC0` (channel 1), `TCC1` (channel 5) |
-| `QSPI_DATA2`      | `PA10`       |                   | `TCC0` (channel 2), `TCC1` (channel 6) |
-| `QSPI_DATA3`      | `PA11`       |                   | `TCC0` (channel 3), `TCC1` (channel 7) |
+| Pin               | Hardware pin | Alternative names | I2C                  | PWM                  |
+| ----------------- | ------------ | ----------------- | -------------------- | -------------------- |
+| `D0`              | `PA16`       | `UART_RX_PIN`     |                      | `TCC1` (channel 0), `TCC0` (channel 4) |
+| `D1`              | `PA17`       | `UART_TX_PIN`     |                      | `TCC1` (channel 1), `TCC0` (channel 5) |
+| `D2`              | `PA07`       | `UART2_RX_PIN`    |                      |                      |
+| `D3`              | `PB22`       |                   |                      |                      |
+| `D4`              | `PA14`       |                   |                      | `TCC2` (channel 0), `TCC1` (channel 2) |
+| `D5`              | `PA15`       |                   |                      | `TCC2` (channel 1), `TCC1` (channel 3) |
+| `D6`              | `PB02`       |                   |                      | `TCC2` (channel 2)   |
+| `D7`              | `PA18`       |                   |                      | `TCC1` (channel 2), `TCC0` (channel 6) |
+| `D8`              | `PB03`       |                   |                      | `TCC2` (channel 3)   |
+| `D9`              | `PA19`       |                   |                      | `TCC1` (channel 3), `TCC0` (channel 7) |
+| `D10`             | `PA20`       |                   |                      | `TCC1` (channel 4), `TCC0` (channel 0) |
+| `D11`             | `PA21`       |                   |                      | `TCC1` (channel 5), `TCC0` (channel 1) |
+| `D12`             | `PA23`       |                   |                      | `TCC1` (channel 7), `TCC0` (channel 3) |
+| `D13`             | `PA22`       | `LED`             |                      | `TCC1` (channel 6), `TCC0` (channel 2) |
+| `A0`              | `PA02`       |                   |                      |                      |
+| `A1`              | `PA05`       |                   |                      |                      |
+| `A2`              | `PB08`       |                   |                      |                      |
+| `A3`              | `PB09`       |                   |                      |                      |
+| `A4`              | `PA04`       | `UART2_TX_PIN`    |                      |                      |
+| `A5`              | `PA06`       |                   |                      |                      |
+| `USBCDC_DM_PIN`   | `PA24`       |                   |                      | `TCC2` (channel 2)   |
+| `USBCDC_DP_PIN`   | `PA25`       |                   |                      | `TCC2` (channel 3)   |
+| `SDA_PIN`         | `PA12`       |                   | `I2C0` (SDA)         | `TCC0` (channel 6), `TCC1` (channel 2) |
+| `SCL_PIN`         | `PA13`       |                   | `I2C0` (SCL)         | `TCC0` (channel 7), `TCC1` (channel 3) |
+| `SPI0_SCK_PIN`    | `PA01`       |                   |                      |                      |
+| `SPI0_SDO_PIN`    | `PA00`       |                   |                      |                      |
+| `SPI0_SDI_PIN`    | `PB23`       |                   |                      |                      |
+| `QSPI_SCK`        | `PB10`       |                   |                      | `TCC0` (channel 4), `TCC1` (channel 0) |
+| `QSPI_CS`         | `PB11`       |                   |                      | `TCC0` (channel 5), `TCC1` (channel 1) |
+| `QSPI_DATA0`      | `PA08`       |                   | `I2C0` (SDA)         | `TCC0` (channel 0), `TCC1` (channel 4) |
+| `QSPI_DATA1`      | `PA09`       |                   | `I2C0` (SCL)         | `TCC0` (channel 1), `TCC1` (channel 5) |
+| `QSPI_DATA2`      | `PA10`       |                   |                      | `TCC0` (channel 2), `TCC1` (channel 6) |
+| `QSPI_DATA3`      | `PA11`       |                   |                      | `TCC0` (channel 3), `TCC1` (channel 7) |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/machine/hifive1b.md
+++ b/content/docs/reference/microcontrollers/machine/hifive1b.md
@@ -20,8 +20,8 @@ const (
 	P09	Pin	= 9
 	P10	Pin	= 10
 	P11	Pin	= 11
-	P12	Pin	= 12
-	P13	Pin	= 13
+	P12	Pin	= 12	// peripherals: I2C0 SDA
+	P13	Pin	= 13	// peripherals: I2C0 SCL
 	P14	Pin	= 14
 	P15	Pin	= 15
 	P16	Pin	= 16

--- a/content/docs/reference/microcontrollers/macropad-rp2040.md
+++ b/content/docs/reference/microcontrollers/macropad-rp2040.md
@@ -19,36 +19,36 @@ The [Adafruit MacroPad RP2040](https://www.adafruit.com/product/5100) is a tiny 
 
 ## Pins
 
-| Pin               | Hardware pin | Alternative names | PWM                  |
-| ----------------- | ------------ | ----------------- | -------------------- |
-| `SWITCH`          | `GPIO0`      | `BUTTON`, `UART0_TX_PIN`, `UART_TX_PIN` | `PWM0` (channel A)   |
-| `KEY1`            | `GPIO1`      | `UART0_RX_PIN`, `UART_RX_PIN` | `PWM0` (channel B)   |
-| `KEY2`            | `GPIO2`      |                   | `PWM1` (channel A)   |
-| `KEY3`            | `GPIO3`      |                   | `PWM1` (channel B)   |
-| `KEY4`            | `GPIO4`      |                   | `PWM2` (channel A)   |
-| `KEY5`            | `GPIO5`      |                   | `PWM2` (channel B)   |
-| `KEY6`            | `GPIO6`      |                   | `PWM3` (channel A)   |
-| `KEY7`            | `GPIO7`      |                   | `PWM3` (channel B)   |
-| `KEY8`            | `GPIO8`      |                   | `PWM4` (channel A)   |
-| `KEY9`            | `GPIO9`      |                   | `PWM4` (channel B)   |
-| `KEY10`           | `GPIO10`     |                   | `PWM5` (channel A)   |
-| `KEY11`           | `GPIO11`     |                   | `PWM5` (channel B)   |
-| `KEY12`           | `GPIO12`     |                   | `PWM6` (channel A)   |
-| `LED`             | `GPIO13`     |                   | `PWM6` (channel B)   |
-| `SPEAKER_ENABLE`  | `GPIO14`     |                   | `PWM7` (channel A)   |
-| `SPEAKER`         | `GPIO16`     |                   | `PWM0` (channel A)   |
-| `ROT_A`           | `GPIO18`     |                   | `PWM1` (channel A)   |
-| `ROT_B`           | `GPIO17`     |                   | `PWM0` (channel B)   |
-| `OLED_CS`         | `GPIO22`     |                   | `PWM3` (channel A)   |
-| `OLED_RST`        | `GPIO23`     |                   | `PWM3` (channel B)   |
-| `OLED_DC`         | `GPIO24`     |                   | `PWM4` (channel A)   |
-| `NEOPIXEL`        | `GPIO19`     | `WS2812`          | `PWM1` (channel B)   |
-| `I2C0_SDA_PIN`    | `GPIO20`     |                   | `PWM2` (channel A)   |
-| `I2C0_SCL_PIN`    | `GPIO21`     |                   | `PWM2` (channel B)   |
-| `SPI1_SCK_PIN`    | `GPIO26`     | `ADC0`            | `PWM5` (channel A)   |
-| `SPI1_SDO_PIN`    | `GPIO27`     | `ADC1`            | `PWM5` (channel B)   |
-| `SPI1_SDI_PIN`    | `GPIO28`     | `ADC2`            | `PWM6` (channel A)   |
-| `ADC3`            | `GPIO29`     |                   | `PWM6` (channel B)   |
+| Pin               | Hardware pin | Alternative names | I2C                  | PWM                  |
+| ----------------- | ------------ | ----------------- | -------------------- | -------------------- |
+| `SWITCH`          | `GPIO0`      | `BUTTON`, `UART0_TX_PIN`, `UART_TX_PIN` | `I2C0` (SDA)         | `PWM0` (channel A)   |
+| `KEY1`            | `GPIO1`      | `UART0_RX_PIN`, `UART_RX_PIN` | `I2C0` (SCL)         | `PWM0` (channel B)   |
+| `KEY2`            | `GPIO2`      |                   | `I2C1` (SDA)         | `PWM1` (channel A)   |
+| `KEY3`            | `GPIO3`      |                   | `I2C1` (SCL)         | `PWM1` (channel B)   |
+| `KEY4`            | `GPIO4`      |                   | `I2C0` (SDA)         | `PWM2` (channel A)   |
+| `KEY5`            | `GPIO5`      |                   | `I2C0` (SCL)         | `PWM2` (channel B)   |
+| `KEY6`            | `GPIO6`      |                   | `I2C1` (SDA)         | `PWM3` (channel A)   |
+| `KEY7`            | `GPIO7`      |                   | `I2C1` (SCL)         | `PWM3` (channel B)   |
+| `KEY8`            | `GPIO8`      |                   | `I2C0` (SDA)         | `PWM4` (channel A)   |
+| `KEY9`            | `GPIO9`      |                   | `I2C0` (SCL)         | `PWM4` (channel B)   |
+| `KEY10`           | `GPIO10`     |                   | `I2C1` (SDA)         | `PWM5` (channel A)   |
+| `KEY11`           | `GPIO11`     |                   | `I2C1` (SCL)         | `PWM5` (channel B)   |
+| `KEY12`           | `GPIO12`     |                   | `I2C0` (SDA)         | `PWM6` (channel A)   |
+| `LED`             | `GPIO13`     |                   | `I2C0` (SCL)         | `PWM6` (channel B)   |
+| `SPEAKER_ENABLE`  | `GPIO14`     |                   | `I2C1` (SDA)         | `PWM7` (channel A)   |
+| `SPEAKER`         | `GPIO16`     |                   | `I2C0` (SDA)         | `PWM0` (channel A)   |
+| `ROT_A`           | `GPIO18`     |                   | `I2C1` (SDA)         | `PWM1` (channel A)   |
+| `ROT_B`           | `GPIO17`     |                   | `I2C0` (SCL)         | `PWM0` (channel B)   |
+| `OLED_CS`         | `GPIO22`     |                   |                      | `PWM3` (channel A)   |
+| `OLED_RST`        | `GPIO23`     |                   |                      | `PWM3` (channel B)   |
+| `OLED_DC`         | `GPIO24`     |                   |                      | `PWM4` (channel A)   |
+| `NEOPIXEL`        | `GPIO19`     | `WS2812`          | `I2C1` (SCL)         | `PWM1` (channel B)   |
+| `I2C0_SDA_PIN`    | `GPIO20`     |                   | `I2C0` (SDA)         | `PWM2` (channel A)   |
+| `I2C0_SCL_PIN`    | `GPIO21`     |                   | `I2C0` (SCL)         | `PWM2` (channel B)   |
+| `SPI1_SCK_PIN`    | `GPIO26`     | `ADC0`            | `I2C1` (SDA)         | `PWM5` (channel A)   |
+| `SPI1_SDO_PIN`    | `GPIO27`     | `ADC1`            | `I2C1` (SCL)         | `PWM5` (channel B)   |
+| `SPI1_SDI_PIN`    | `GPIO28`     | `ADC2`            |                      | `PWM6` (channel A)   |
+| `ADC3`            | `GPIO29`     |                   |                      | `PWM6` (channel B)   |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/matrixportal-m4.md
+++ b/content/docs/reference/microcontrollers/matrixportal-m4.md
@@ -19,55 +19,55 @@ The [Adafruit Matrix Portal M4](https://www.adafruit.com/product/4745) is an ARM
 
 ## Pins
 
-| Pin               | Hardware pin | Alternative names | PWM                  |
-| ----------------- | ------------ | ----------------- | -------------------- |
-| `D0`              | `PA01`       | `UART1_RX_PIN`, `UART_RX_PIN` |                      |
-| `D1`              | `PA00`       | `UART1_TX_PIN`, `UART_TX_PIN` |                      |
-| `D2`              | `PB22`       | `BUTTON_UP`       |                      |
-| `D3`              | `PB23`       | `BUTTON_DOWN`     |                      |
-| `D4`              | `PA23`       | `NEOPIXEL`, `WS2812` | `TCC1` (channel 7), `TCC0` (channel 3) |
-| `D5`              | `PB31`       | `I2C0_SDA_PIN`, `I2C_SDA_PIN`, `SDA_PIN` | `TCC4` (channel 1), `TCC0` (channel 7) |
-| `D6`              | `PB30`       | `I2C0_SCL_PIN`, `I2C_SCL_PIN`, `SCL_PIN` | `TCC4` (channel 0), `TCC0` (channel 6) |
-| `D7`              | `PB00`       | `HUB75_R1`        |                      |
-| `D8`              | `PB01`       | `HUB75_G1`        |                      |
-| `D9`              | `PB02`       | `HUB75_B1`        | `TCC2` (channel 2)   |
-| `D10`             | `PB03`       | `HUB75_R2`        | `TCC2` (channel 3)   |
-| `D11`             | `PB04`       | `HUB75_G2`        |                      |
-| `D12`             | `PB05`       | `HUB75_B2`        |                      |
-| `D13`             | `PA14`       | `LED`             | `TCC2` (channel 0), `TCC1` (channel 2) |
-| `D14`             | `PB06`       | `HUB75_CLK`       |                      |
-| `D15`             | `PB14`       | `HUB75_LAT`       | `TCC4` (channel 0), `TCC0` (channel 2) |
-| `D16`             | `PB12`       | `HUB75_OE`        | `TCC3` (channel 0), `TCC0` (channel 0) |
-| `D17`             | `PB07`       | `HUB75_ADDR_A`    |                      |
-| `D18`             | `PB08`       | `HUB75_ADDR_B`    |                      |
-| `D19`             | `PB09`       | `HUB75_ADDR_C`    |                      |
-| `D20`             | `PB15`       | `HUB75_ADDR_D`    | `TCC4` (channel 1), `TCC0` (channel 3) |
-| `D21`             | `PB13`       | `HUB75_ADDR_E`    | `TCC3` (channel 1), `TCC0` (channel 1) |
-| `D22`             | `PA02`       | `A0`              |                      |
-| `D23`             | `PA05`       | `D48`, `A1`, `SPI1_SCK_PIN` |                      |
-| `D24`             | `PA04`       | `D49`, `A2`, `SPI1_SDO_PIN` |                      |
-| `D25`             | `PA06`       | `A3`              |                      |
-| `D26`             | `PA07`       | `D50`, `A4`, `SPI1_SDI_PIN` |                      |
-| `D27`             | `PA12`       | `UART2_RX_PIN`, `NINA_RX` | `TCC0` (channel 6), `TCC1` (channel 2) |
-| `D28`             | `PA13`       | `UART2_TX_PIN`, `NINA_TX` | `TCC0` (channel 7), `TCC1` (channel 3) |
-| `D29`             | `PA20`       | `NINA_GPIO0`      | `TCC1` (channel 4), `TCC0` (channel 0) |
-| `D30`             | `PA21`       | `NINA_RESETN`     | `TCC1` (channel 5), `TCC0` (channel 1) |
-| `D31`             | `PA22`       | `NINA_ACK`        | `TCC1` (channel 6), `TCC0` (channel 2) |
-| `D32`             | `PA18`       | `NINA_RTS`        | `TCC1` (channel 2), `TCC0` (channel 6) |
-| `D33`             | `PB17`       | `NINA_CS`         | `TCC3` (channel 1), `TCC0` (channel 5) |
-| `D34`             | `PA16`       | `SPI0_SCK_PIN`, `SPI_SCK_PIN`, `NINA_SCK` | `TCC1` (channel 0), `TCC0` (channel 4) |
-| `D35`             | `PA17`       | `SPI0_SDI_PIN`, `SPI_SDI_PIN`, `NINA_SDI` | `TCC1` (channel 1), `TCC0` (channel 5) |
-| `D36`             | `PA19`       | `SPI0_SDO_PIN`, `SPI_SDO_PIN`, `NINA_SDO` | `TCC1` (channel 3), `TCC0` (channel 7) |
-| `D38`             | `PA24`       | `USBCDC_DM_PIN`, `UART0_RX_PIN` | `TCC2` (channel 2)   |
-| `D39`             | `PA25`       | `USBCDC_DP_PIN`, `UART0_TX_PIN` | `TCC2` (channel 3)   |
-| `D40`             | `PA03`       |                   |                      |
-| `D41`             | `PB10`       | `QSPI_SCK`        | `TCC0` (channel 4), `TCC1` (channel 0) |
-| `D42`             | `PB11`       | `QSPI_CS`         | `TCC0` (channel 5), `TCC1` (channel 1) |
-| `D43`             | `PA08`       | `QSPI_DATA0`      | `TCC0` (channel 0), `TCC1` (channel 4) |
-| `D44`             | `PA09`       | `QSPI_DATA1`      | `TCC0` (channel 1), `TCC1` (channel 5) |
-| `D45`             | `PA10`       | `QSPI_DATA2`      | `TCC0` (channel 2), `TCC1` (channel 6) |
-| `D46`             | `PA11`       | `QSPI_DATA3`      | `TCC0` (channel 3), `TCC1` (channel 7) |
-| `D47`             | `PA27`       |                   |                      |
+| Pin               | Hardware pin | Alternative names | I2C                  | PWM                  |
+| ----------------- | ------------ | ----------------- | -------------------- | -------------------- |
+| `D0`              | `PA01`       | `UART1_RX_PIN`, `UART_RX_PIN` |                      |                      |
+| `D1`              | `PA00`       | `UART1_TX_PIN`, `UART_TX_PIN` |                      |                      |
+| `D2`              | `PB22`       | `BUTTON_UP`       |                      |                      |
+| `D3`              | `PB23`       | `BUTTON_DOWN`     |                      |                      |
+| `D4`              | `PA23`       | `NEOPIXEL`, `WS2812` | `I2C0` (SCL)         | `TCC1` (channel 7), `TCC0` (channel 3) |
+| `D5`              | `PB31`       | `I2C0_SDA_PIN`, `I2C_SDA_PIN`, `SDA_PIN` |                      | `TCC4` (channel 1), `TCC0` (channel 7) |
+| `D6`              | `PB30`       | `I2C0_SCL_PIN`, `I2C_SCL_PIN`, `SCL_PIN` |                      | `TCC4` (channel 0), `TCC0` (channel 6) |
+| `D7`              | `PB00`       | `HUB75_R1`        |                      |                      |
+| `D8`              | `PB01`       | `HUB75_G1`        |                      |                      |
+| `D9`              | `PB02`       | `HUB75_B1`        |                      | `TCC2` (channel 2)   |
+| `D10`             | `PB03`       | `HUB75_R2`        |                      | `TCC2` (channel 3)   |
+| `D11`             | `PB04`       | `HUB75_G2`        |                      |                      |
+| `D12`             | `PB05`       | `HUB75_B2`        |                      |                      |
+| `D13`             | `PA14`       | `LED`             |                      | `TCC2` (channel 0), `TCC1` (channel 2) |
+| `D14`             | `PB06`       | `HUB75_CLK`       |                      |                      |
+| `D15`             | `PB14`       | `HUB75_LAT`       |                      | `TCC4` (channel 0), `TCC0` (channel 2) |
+| `D16`             | `PB12`       | `HUB75_OE`        |                      | `TCC3` (channel 0), `TCC0` (channel 0) |
+| `D17`             | `PB07`       | `HUB75_ADDR_A`    |                      |                      |
+| `D18`             | `PB08`       | `HUB75_ADDR_B`    |                      |                      |
+| `D19`             | `PB09`       | `HUB75_ADDR_C`    |                      |                      |
+| `D20`             | `PB15`       | `HUB75_ADDR_D`    |                      | `TCC4` (channel 1), `TCC0` (channel 3) |
+| `D21`             | `PB13`       | `HUB75_ADDR_E`    |                      | `TCC3` (channel 1), `TCC0` (channel 1) |
+| `D22`             | `PA02`       | `A0`              |                      |                      |
+| `D23`             | `PA05`       | `D48`, `A1`, `SPI1_SCK_PIN` |                      |                      |
+| `D24`             | `PA04`       | `D49`, `A2`, `SPI1_SDO_PIN` |                      |                      |
+| `D25`             | `PA06`       | `A3`              |                      |                      |
+| `D26`             | `PA07`       | `D50`, `A4`, `SPI1_SDI_PIN` |                      |                      |
+| `D27`             | `PA12`       | `UART2_RX_PIN`, `NINA_RX` |                      | `TCC0` (channel 6), `TCC1` (channel 2) |
+| `D28`             | `PA13`       | `UART2_TX_PIN`, `NINA_TX` |                      | `TCC0` (channel 7), `TCC1` (channel 3) |
+| `D29`             | `PA20`       | `NINA_GPIO0`      |                      | `TCC1` (channel 4), `TCC0` (channel 0) |
+| `D30`             | `PA21`       | `NINA_RESETN`     |                      | `TCC1` (channel 5), `TCC0` (channel 1) |
+| `D31`             | `PA22`       | `NINA_ACK`        | `I2C0` (SDA)         | `TCC1` (channel 6), `TCC0` (channel 2) |
+| `D32`             | `PA18`       | `NINA_RTS`        |                      | `TCC1` (channel 2), `TCC0` (channel 6) |
+| `D33`             | `PB17`       | `NINA_CS`         |                      | `TCC3` (channel 1), `TCC0` (channel 5) |
+| `D34`             | `PA16`       | `SPI0_SCK_PIN`, `SPI_SCK_PIN`, `NINA_SCK` |                      | `TCC1` (channel 0), `TCC0` (channel 4) |
+| `D35`             | `PA17`       | `SPI0_SDI_PIN`, `SPI_SDI_PIN`, `NINA_SDI` |                      | `TCC1` (channel 1), `TCC0` (channel 5) |
+| `D36`             | `PA19`       | `SPI0_SDO_PIN`, `SPI_SDO_PIN`, `NINA_SDO` |                      | `TCC1` (channel 3), `TCC0` (channel 7) |
+| `D38`             | `PA24`       | `USBCDC_DM_PIN`, `UART0_RX_PIN` |                      | `TCC2` (channel 2)   |
+| `D39`             | `PA25`       | `USBCDC_DP_PIN`, `UART0_TX_PIN` |                      | `TCC2` (channel 3)   |
+| `D40`             | `PA03`       |                   |                      |                      |
+| `D41`             | `PB10`       | `QSPI_SCK`        |                      | `TCC0` (channel 4), `TCC1` (channel 0) |
+| `D42`             | `PB11`       | `QSPI_CS`         |                      | `TCC0` (channel 5), `TCC1` (channel 1) |
+| `D43`             | `PA08`       | `QSPI_DATA0`      |                      | `TCC0` (channel 0), `TCC1` (channel 4) |
+| `D44`             | `PA09`       | `QSPI_DATA1`      |                      | `TCC0` (channel 1), `TCC1` (channel 5) |
+| `D45`             | `PA10`       | `QSPI_DATA2`      |                      | `TCC0` (channel 2), `TCC1` (channel 6) |
+| `D46`             | `PA11`       | `QSPI_DATA3`      |                      | `TCC0` (channel 3), `TCC1` (channel 7) |
+| `D47`             | `PA27`       |                   |                      |                      |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/metro-m4-airlift.md
+++ b/content/docs/reference/microcontrollers/metro-m4-airlift.md
@@ -19,48 +19,48 @@ The [Adafruit Metro M4 Express AirLift](https://www.adafruit.com/product/4000) i
 
 ## Pins
 
-| Pin               | Hardware pin | Alternative names | PWM                  |
-| ----------------- | ------------ | ----------------- | -------------------- |
-| `D0`              | `PA23`       | `UART_RX_PIN`     | `TCC1` (channel 7), `TCC0` (channel 3) |
-| `D1`              | `PA22`       | `UART_TX_PIN`     | `TCC1` (channel 6), `TCC0` (channel 2) |
-| `D2`              | `PB17`       |                   | `TCC3` (channel 1), `TCC0` (channel 5) |
-| `D3`              | `PB16`       |                   | `TCC3` (channel 0), `TCC0` (channel 4) |
-| `D4`              | `PB13`       |                   | `TCC3` (channel 1), `TCC0` (channel 1) |
-| `D5`              | `PB14`       |                   | `TCC4` (channel 0), `TCC0` (channel 2) |
-| `D6`              | `PB15`       |                   | `TCC4` (channel 1), `TCC0` (channel 3) |
-| `D7`              | `PB12`       |                   | `TCC3` (channel 0), `TCC0` (channel 0) |
-| `D8`              | `PA21`       |                   | `TCC1` (channel 5), `TCC0` (channel 1) |
-| `D9`              | `PA20`       |                   | `TCC1` (channel 4), `TCC0` (channel 0) |
-| `D10`             | `PA18`       |                   | `TCC1` (channel 2), `TCC0` (channel 6) |
-| `D11`             | `PA19`       | `SPI1_SDO_PIN`    | `TCC1` (channel 3), `TCC0` (channel 7) |
-| `D12`             | `PA17`       | `SPI1_SCK_PIN`    | `TCC1` (channel 1), `TCC0` (channel 5) |
-| `D13`             | `PA16`       | `LED`, `SPI1_SDI_PIN` | `TCC1` (channel 0), `TCC0` (channel 4) |
-| `D40`             | `PB22`       | `WS2812`          |                      |
-| `A0`              | `PA02`       |                   |                      |
-| `A1`              | `PA05`       |                   |                      |
-| `A2`              | `PB06`       |                   |                      |
-| `A3`              | `PB00`       |                   |                      |
-| `A4`              | `PB08`       |                   |                      |
-| `A5`              | `PB09`       |                   |                      |
-| `USBCDC_DM_PIN`   | `PA24`       |                   | `TCC2` (channel 2)   |
-| `USBCDC_DP_PIN`   | `PA25`       |                   | `TCC2` (channel 3)   |
-| `UART2_TX_PIN`    | `PA04`       | `NINA_TX`         |                      |
-| `UART2_RX_PIN`    | `PA07`       | `NINA_RX`         |                      |
-| `NINA_CS`         | `PA15`       |                   | `TCC2` (channel 1), `TCC1` (channel 3) |
-| `NINA_ACK`        | `PB04`       | `NINA_CTS`        |                      |
-| `NINA_GPIO0`      | `PB01`       | `NINA_RTS`        |                      |
-| `NINA_RESETN`     | `PB05`       |                   |                      |
-| `SDA_PIN`         | `PB02`       |                   | `TCC2` (channel 2)   |
-| `SCL_PIN`         | `PB03`       |                   | `TCC2` (channel 3)   |
-| `SPI0_SCK_PIN`    | `PA13`       | `NINA_SCK`        | `TCC0` (channel 7), `TCC1` (channel 3) |
-| `SPI0_SDO_PIN`    | `PA12`       | `NINA_SDO`        | `TCC0` (channel 6), `TCC1` (channel 2) |
-| `SPI0_SDI_PIN`    | `PA14`       | `NINA_SDI`        | `TCC2` (channel 0), `TCC1` (channel 2) |
-| `QSPI_SCK`        | `PB10`       |                   | `TCC0` (channel 4), `TCC1` (channel 0) |
-| `QSPI_CS`         | `PB11`       |                   | `TCC0` (channel 5), `TCC1` (channel 1) |
-| `QSPI_DATA0`      | `PA08`       |                   | `TCC0` (channel 0), `TCC1` (channel 4) |
-| `QSPI_DATA1`      | `PA09`       |                   | `TCC0` (channel 1), `TCC1` (channel 5) |
-| `QSPI_DATA2`      | `PA10`       |                   | `TCC0` (channel 2), `TCC1` (channel 6) |
-| `QSPI_DATA3`      | `PA11`       |                   | `TCC0` (channel 3), `TCC1` (channel 7) |
+| Pin               | Hardware pin | Alternative names | I2C                  | PWM                  |
+| ----------------- | ------------ | ----------------- | -------------------- | -------------------- |
+| `D0`              | `PA23`       | `UART_RX_PIN`     | `I2C0` (SCL)         | `TCC1` (channel 7), `TCC0` (channel 3) |
+| `D1`              | `PA22`       | `UART_TX_PIN`     | `I2C0` (SDA)         | `TCC1` (channel 6), `TCC0` (channel 2) |
+| `D2`              | `PB17`       |                   |                      | `TCC3` (channel 1), `TCC0` (channel 5) |
+| `D3`              | `PB16`       |                   |                      | `TCC3` (channel 0), `TCC0` (channel 4) |
+| `D4`              | `PB13`       |                   |                      | `TCC3` (channel 1), `TCC0` (channel 1) |
+| `D5`              | `PB14`       |                   |                      | `TCC4` (channel 0), `TCC0` (channel 2) |
+| `D6`              | `PB15`       |                   |                      | `TCC4` (channel 1), `TCC0` (channel 3) |
+| `D7`              | `PB12`       |                   |                      | `TCC3` (channel 0), `TCC0` (channel 0) |
+| `D8`              | `PA21`       |                   |                      | `TCC1` (channel 5), `TCC0` (channel 1) |
+| `D9`              | `PA20`       |                   |                      | `TCC1` (channel 4), `TCC0` (channel 0) |
+| `D10`             | `PA18`       |                   |                      | `TCC1` (channel 2), `TCC0` (channel 6) |
+| `D11`             | `PA19`       | `SPI1_SDO_PIN`    |                      | `TCC1` (channel 3), `TCC0` (channel 7) |
+| `D12`             | `PA17`       | `SPI1_SCK_PIN`    |                      | `TCC1` (channel 1), `TCC0` (channel 5) |
+| `D13`             | `PA16`       | `LED`, `SPI1_SDI_PIN` |                      | `TCC1` (channel 0), `TCC0` (channel 4) |
+| `D40`             | `PB22`       | `WS2812`          |                      |                      |
+| `A0`              | `PA02`       |                   |                      |                      |
+| `A1`              | `PA05`       |                   |                      |                      |
+| `A2`              | `PB06`       |                   |                      |                      |
+| `A3`              | `PB00`       |                   |                      |                      |
+| `A4`              | `PB08`       |                   |                      |                      |
+| `A5`              | `PB09`       |                   |                      |                      |
+| `USBCDC_DM_PIN`   | `PA24`       |                   |                      | `TCC2` (channel 2)   |
+| `USBCDC_DP_PIN`   | `PA25`       |                   |                      | `TCC2` (channel 3)   |
+| `UART2_TX_PIN`    | `PA04`       | `NINA_TX`         |                      |                      |
+| `UART2_RX_PIN`    | `PA07`       | `NINA_RX`         |                      |                      |
+| `NINA_CS`         | `PA15`       |                   |                      | `TCC2` (channel 1), `TCC1` (channel 3) |
+| `NINA_ACK`        | `PB04`       | `NINA_CTS`        |                      |                      |
+| `NINA_GPIO0`      | `PB01`       | `NINA_RTS`        |                      |                      |
+| `NINA_RESETN`     | `PB05`       |                   |                      |                      |
+| `SDA_PIN`         | `PB02`       |                   |                      | `TCC2` (channel 2)   |
+| `SCL_PIN`         | `PB03`       |                   |                      | `TCC2` (channel 3)   |
+| `SPI0_SCK_PIN`    | `PA13`       | `NINA_SCK`        |                      | `TCC0` (channel 7), `TCC1` (channel 3) |
+| `SPI0_SDO_PIN`    | `PA12`       | `NINA_SDO`        |                      | `TCC0` (channel 6), `TCC1` (channel 2) |
+| `SPI0_SDI_PIN`    | `PA14`       | `NINA_SDI`        |                      | `TCC2` (channel 0), `TCC1` (channel 2) |
+| `QSPI_SCK`        | `PB10`       |                   |                      | `TCC0` (channel 4), `TCC1` (channel 0) |
+| `QSPI_CS`         | `PB11`       |                   |                      | `TCC0` (channel 5), `TCC1` (channel 1) |
+| `QSPI_DATA0`      | `PA08`       |                   |                      | `TCC0` (channel 0), `TCC1` (channel 4) |
+| `QSPI_DATA1`      | `PA09`       |                   |                      | `TCC0` (channel 1), `TCC1` (channel 5) |
+| `QSPI_DATA2`      | `PA10`       |                   |                      | `TCC0` (channel 2), `TCC1` (channel 6) |
+| `QSPI_DATA3`      | `PA11`       |                   |                      | `TCC0` (channel 3), `TCC1` (channel 7) |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/nano-rp2040.md
+++ b/content/docs/reference/microcontrollers/nano-rp2040.md
@@ -24,36 +24,36 @@ Peripherals:
 
 ## Pins
 
-| Pin               | Hardware pin | Alternative names | PWM                  |
-| ----------------- | ------------ | ----------------- | -------------------- |
-| `D2`              | `GPIO25`     |                   | `PWM4` (channel B)   |
-| `D3`              | `GPIO15`     |                   | `PWM7` (channel B)   |
-| `D4`              | `GPIO16`     |                   | `PWM0` (channel A)   |
-| `D5`              | `GPIO17`     |                   | `PWM0` (channel B)   |
-| `D6`              | `GPIO18`     | `I2C1_SDA_PIN`    | `PWM1` (channel A)   |
-| `D7`              | `GPIO19`     | `I2C1_SCL_PIN`    | `PWM1` (channel B)   |
-| `D8`              | `GPIO20`     |                   | `PWM2` (channel A)   |
-| `D9`              | `GPIO21`     |                   | `PWM2` (channel B)   |
-| `D10`             | `GPIO5`      |                   | `PWM2` (channel B)   |
-| `D11`             | `GPIO7`      | `SPI0_SDO_PIN`    | `PWM3` (channel B)   |
-| `D12`             | `GPIO4`      | `SPI0_SDI_PIN`    | `PWM2` (channel A)   |
-| `D13`             | `GPIO6`      | `LED`, `SPI0_SCK_PIN` | `PWM3` (channel A)   |
-| `D14`             | `GPIO26`     | `A0`, `ADC0`      | `PWM5` (channel A)   |
-| `D15`             | `GPIO27`     | `A1`, `ADC1`      | `PWM5` (channel B)   |
-| `D16`             | `GPIO28`     | `A2`, `ADC2`      | `PWM6` (channel A)   |
-| `D17`             | `GPIO29`     | `A3`, `ADC3`      | `PWM6` (channel B)   |
-| `D18`             | `GPIO12`     | `I2C0_SDA_PIN`    | `PWM6` (channel A)   |
-| `D19`             | `GPIO13`     | `I2C0_SCL_PIN`    | `PWM6` (channel B)   |
-| `SPI1_SCK_PIN`    | `GPIO22`     | `SPI1_SDO_PIN`, `SPI1_SDI_PIN` | `PWM3` (channel A)   |
-| `NINA_SCK`        | `GPIO14`     |                   | `PWM7` (channel A)   |
-| `NINA_SDO`        | `GPIO11`     | `NINA_RTS`        | `PWM5` (channel B)   |
-| `NINA_SDI`        | `GPIO8`      | `NINA_TX`         | `PWM4` (channel A)   |
-| `NINA_CS`         | `GPIO9`      | `NINA_RX`         | `PWM4` (channel B)   |
-| `NINA_ACK`        | `GPIO10`     | `NINA_CTS`        | `PWM5` (channel A)   |
-| `NINA_GPIO0`      | `GPIO2`      |                   | `PWM1` (channel A)   |
-| `NINA_RESETN`     | `GPIO3`      |                   | `PWM1` (channel B)   |
-| `UART0_TX_PIN`    | `GPIO0`      | `UART_TX_PIN`     | `PWM0` (channel A)   |
-| `UART0_RX_PIN`    | `GPIO1`      | `UART_RX_PIN`     | `PWM0` (channel B)   |
+| Pin               | Hardware pin | Alternative names | I2C                  | PWM                  |
+| ----------------- | ------------ | ----------------- | -------------------- | -------------------- |
+| `D2`              | `GPIO25`     |                   |                      | `PWM4` (channel B)   |
+| `D3`              | `GPIO15`     |                   | `I2C1` (SCL)         | `PWM7` (channel B)   |
+| `D4`              | `GPIO16`     |                   | `I2C0` (SDA)         | `PWM0` (channel A)   |
+| `D5`              | `GPIO17`     |                   | `I2C0` (SCL)         | `PWM0` (channel B)   |
+| `D6`              | `GPIO18`     | `I2C1_SDA_PIN`    | `I2C1` (SDA)         | `PWM1` (channel A)   |
+| `D7`              | `GPIO19`     | `I2C1_SCL_PIN`    | `I2C1` (SCL)         | `PWM1` (channel B)   |
+| `D8`              | `GPIO20`     |                   | `I2C0` (SDA)         | `PWM2` (channel A)   |
+| `D9`              | `GPIO21`     |                   | `I2C0` (SCL)         | `PWM2` (channel B)   |
+| `D10`             | `GPIO5`      |                   | `I2C0` (SCL)         | `PWM2` (channel B)   |
+| `D11`             | `GPIO7`      | `SPI0_SDO_PIN`    | `I2C1` (SCL)         | `PWM3` (channel B)   |
+| `D12`             | `GPIO4`      | `SPI0_SDI_PIN`    | `I2C0` (SDA)         | `PWM2` (channel A)   |
+| `D13`             | `GPIO6`      | `LED`, `SPI0_SCK_PIN` | `I2C1` (SDA)         | `PWM3` (channel A)   |
+| `D14`             | `GPIO26`     | `A0`, `ADC0`      | `I2C1` (SDA)         | `PWM5` (channel A)   |
+| `D15`             | `GPIO27`     | `A1`, `ADC1`      | `I2C1` (SCL)         | `PWM5` (channel B)   |
+| `D16`             | `GPIO28`     | `A2`, `ADC2`      |                      | `PWM6` (channel A)   |
+| `D17`             | `GPIO29`     | `A3`, `ADC3`      |                      | `PWM6` (channel B)   |
+| `D18`             | `GPIO12`     | `I2C0_SDA_PIN`    | `I2C0` (SDA)         | `PWM6` (channel A)   |
+| `D19`             | `GPIO13`     | `I2C0_SCL_PIN`    | `I2C0` (SCL)         | `PWM6` (channel B)   |
+| `SPI1_SCK_PIN`    | `GPIO22`     | `SPI1_SDO_PIN`, `SPI1_SDI_PIN` |                      | `PWM3` (channel A)   |
+| `NINA_SCK`        | `GPIO14`     |                   | `I2C1` (SDA)         | `PWM7` (channel A)   |
+| `NINA_SDO`        | `GPIO11`     | `NINA_RTS`        | `I2C1` (SCL)         | `PWM5` (channel B)   |
+| `NINA_SDI`        | `GPIO8`      | `NINA_TX`         | `I2C0` (SDA)         | `PWM4` (channel A)   |
+| `NINA_CS`         | `GPIO9`      | `NINA_RX`         | `I2C0` (SCL)         | `PWM4` (channel B)   |
+| `NINA_ACK`        | `GPIO10`     | `NINA_CTS`        | `I2C1` (SDA)         | `PWM5` (channel A)   |
+| `NINA_GPIO0`      | `GPIO2`      |                   | `I2C1` (SDA)         | `PWM1` (channel A)   |
+| `NINA_RESETN`     | `GPIO3`      |                   | `I2C1` (SCL)         | `PWM1` (channel B)   |
+| `UART0_TX_PIN`    | `GPIO0`      | `UART_TX_PIN`     | `I2C0` (SDA)         | `PWM0` (channel A)   |
+| `UART0_RX_PIN`    | `GPIO1`      | `UART_RX_PIN`     | `I2C0` (SCL)         | `PWM0` (channel B)   |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/p1am-100.md
+++ b/content/docs/reference/microcontrollers/p1am-100.md
@@ -19,41 +19,41 @@ The [ProductivityOpen P1AM-100](https://facts-engineering.github.io/modules/P1AM
 
 ## Pins
 
-| Pin               | Hardware pin | Alternative names | PWM                  |
-| ----------------- | ------------ | ----------------- | -------------------- |
-| `D0`              | `PA22`       |                   | `TCC0` (channel 0)   |
-| `D1`              | `PA23`       |                   | `TCC0` (channel 1)   |
-| `D2`              | `PA10`       | `I2S_SCK_PIN`     | `TCC1` (channel 0), `TCC0` (channel 2) |
-| `D3`              | `PA11`       | `I2S_WS_PIN`      | `TCC1` (channel 1), `TCC0` (channel 3) |
-| `D4`              | `PB10`       |                   | `TCC0` (channel 0)   |
-| `D5`              | `PB11`       |                   | `TCC0` (channel 1)   |
-| `D6`              | `PA20`       |                   | `TCC0` (channel 2)   |
-| `D7`              | `PA21`       |                   | `TCC0` (channel 3)   |
-| `D8`              | `PA16`       | `SPI0_SDO_PIN`    | `TCC2` (channel 0), `TCC0` (channel 2) |
-| `D9`              | `PA17`       | `SPI0_SCK_PIN`    | `TCC2` (channel 1), `TCC0` (channel 3) |
-| `D10`             | `PA19`       | `SPI0_SDI_PIN`    | `TCC0` (channel 3)   |
-| `D11`             | `PA08`       | `SDA_PIN`         | `TCC0` (channel 0), `TCC1` (channel 2) |
-| `D12`             | `PA09`       | `SCL_PIN`         | `TCC0` (channel 1), `TCC1` (channel 3) |
-| `D13`             | `PB23`       | `UART_RX_PIN`     |                      |
-| `D14`             | `PB22`       | `UART_TX_PIN`     |                      |
-| `D15`             | `PA02`       | `A0`              |                      |
-| `D16`             | `PB02`       | `A1`              |                      |
-| `D17`             | `PB03`       | `A2`              |                      |
-| `D18`             | `PA04`       | `A3`, `BASE_SLAVE_SELECT_PIN` | `TCC0` (channel 0)   |
-| `D19`             | `PA05`       | `A4`, `BASE_SLAVE_ACK_PIN` | `TCC0` (channel 1)   |
-| `D20`             | `PA06`       | `A5`              | `TCC1` (channel 0)   |
-| `D21`             | `PA07`       | `A6`, `I2S_SDO_PIN` | `TCC1` (channel 1)   |
-| `SWITCH`          | `PA28`       |                   |                      |
-| `LED`             | `PB08`       |                   |                      |
-| `ADC_BATTERY`     | `PB09`       | `BASE_ENABLE_PIN` |                      |
-| `USBCDC_DM_PIN`   | `PA24`       |                   | `TCC1` (channel 2)   |
-| `USBCDC_DP_PIN`   | `PA25`       |                   | `TCC1` (channel 3)   |
-| `USBCDC_HOST_ENABLE_PIN` | `PA18`       |                   | `TCC0` (channel 2)   |
-| `SDCARD_SDI_PIN`  | `PA15`       |                   | `TCC0` (channel 1)   |
-| `SDCARD_SDO_PIN`  | `PA12`       |                   | `TCC2` (channel 0), `TCC0` (channel 2) |
-| `SDCARD_SCK_PIN`  | `PA13`       |                   | `TCC2` (channel 1), `TCC0` (channel 3) |
-| `SDCARD_SS_PIN`   | `PA14`       |                   | `TCC0` (channel 0)   |
-| `SDCARD_CD_PIN`   | `PA27`       |                   |                      |
+| Pin               | Hardware pin | Alternative names | I2C                  | PWM                  |
+| ----------------- | ------------ | ----------------- | -------------------- | -------------------- |
+| `D0`              | `PA22`       |                   |                      | `TCC0` (channel 0)   |
+| `D1`              | `PA23`       |                   |                      | `TCC0` (channel 1)   |
+| `D2`              | `PA10`       | `I2S_SCK_PIN`     |                      | `TCC1` (channel 0), `TCC0` (channel 2) |
+| `D3`              | `PA11`       | `I2S_WS_PIN`      |                      | `TCC1` (channel 1), `TCC0` (channel 3) |
+| `D4`              | `PB10`       |                   |                      | `TCC0` (channel 0)   |
+| `D5`              | `PB11`       |                   |                      | `TCC0` (channel 1)   |
+| `D6`              | `PA20`       |                   |                      | `TCC0` (channel 2)   |
+| `D7`              | `PA21`       |                   |                      | `TCC0` (channel 3)   |
+| `D8`              | `PA16`       | `SPI0_SDO_PIN`    |                      | `TCC2` (channel 0), `TCC0` (channel 2) |
+| `D9`              | `PA17`       | `SPI0_SCK_PIN`    |                      | `TCC2` (channel 1), `TCC0` (channel 3) |
+| `D10`             | `PA19`       | `SPI0_SDI_PIN`    |                      | `TCC0` (channel 3)   |
+| `D11`             | `PA08`       | `SDA_PIN`         | `I2C0` (SDA)         | `TCC0` (channel 0), `TCC1` (channel 2) |
+| `D12`             | `PA09`       | `SCL_PIN`         | `I2C0` (SCL)         | `TCC0` (channel 1), `TCC1` (channel 3) |
+| `D13`             | `PB23`       | `UART_RX_PIN`     |                      |                      |
+| `D14`             | `PB22`       | `UART_TX_PIN`     |                      |                      |
+| `D15`             | `PA02`       | `A0`              |                      |                      |
+| `D16`             | `PB02`       | `A1`              |                      |                      |
+| `D17`             | `PB03`       | `A2`              |                      |                      |
+| `D18`             | `PA04`       | `A3`, `BASE_SLAVE_SELECT_PIN` |                      | `TCC0` (channel 0)   |
+| `D19`             | `PA05`       | `A4`, `BASE_SLAVE_ACK_PIN` |                      | `TCC0` (channel 1)   |
+| `D20`             | `PA06`       | `A5`              |                      | `TCC1` (channel 0)   |
+| `D21`             | `PA07`       | `A6`, `I2S_SDO_PIN` |                      | `TCC1` (channel 1)   |
+| `SWITCH`          | `PA28`       |                   |                      |                      |
+| `LED`             | `PB08`       |                   |                      |                      |
+| `ADC_BATTERY`     | `PB09`       | `BASE_ENABLE_PIN` |                      |                      |
+| `USBCDC_DM_PIN`   | `PA24`       |                   |                      | `TCC1` (channel 2)   |
+| `USBCDC_DP_PIN`   | `PA25`       |                   |                      | `TCC1` (channel 3)   |
+| `USBCDC_HOST_ENABLE_PIN` | `PA18`       |                   |                      | `TCC0` (channel 2)   |
+| `SDCARD_SDI_PIN`  | `PA15`       |                   |                      | `TCC0` (channel 1)   |
+| `SDCARD_SDO_PIN`  | `PA12`       |                   |                      | `TCC2` (channel 0), `TCC0` (channel 2) |
+| `SDCARD_SCK_PIN`  | `PA13`       |                   |                      | `TCC2` (channel 1), `TCC0` (channel 3) |
+| `SDCARD_SS_PIN`   | `PA14`       |                   |                      | `TCC0` (channel 0)   |
+| `SDCARD_CD_PIN`   | `PA27`       |                   |                      |                      |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/pico-w.md
+++ b/content/docs/reference/microcontrollers/pico-w.md
@@ -19,36 +19,36 @@ The [Raspberry Pi Pico-W](https://www.raspberrypi.org/products/raspberry-pi-pico
 
 ## Pins
 
-| Pin               | Hardware pin | Alternative names | PWM                  |
-| ----------------- | ------------ | ----------------- | -------------------- |
-| `GP0`             | `GPIO0`      | `UART0_TX_PIN`, `UART_TX_PIN` | `PWM0` (channel A)   |
-| `GP1`             | `GPIO1`      | `UART0_RX_PIN`, `UART_RX_PIN` | `PWM0` (channel B)   |
-| `GP2`             | `GPIO2`      | `I2C1_SDA_PIN`    | `PWM1` (channel A)   |
-| `GP3`             | `GPIO3`      | `I2C1_SCL_PIN`    | `PWM1` (channel B)   |
-| `GP4`             | `GPIO4`      | `I2C0_SDA_PIN`    | `PWM2` (channel A)   |
-| `GP5`             | `GPIO5`      | `I2C0_SCL_PIN`    | `PWM2` (channel B)   |
-| `GP6`             | `GPIO6`      |                   | `PWM3` (channel A)   |
-| `GP7`             | `GPIO7`      |                   | `PWM3` (channel B)   |
-| `GP8`             | `GPIO8`      | `UART1_TX_PIN`    | `PWM4` (channel A)   |
-| `GP9`             | `GPIO9`      | `UART1_RX_PIN`    | `PWM4` (channel B)   |
-| `GP10`            | `GPIO10`     | `SPI1_SCK_PIN`    | `PWM5` (channel A)   |
-| `GP11`            | `GPIO11`     | `SPI1_SDO_PIN`    | `PWM5` (channel B)   |
-| `GP12`            | `GPIO12`     | `SPI1_SDI_PIN`    | `PWM6` (channel A)   |
-| `GP13`            | `GPIO13`     |                   | `PWM6` (channel B)   |
-| `GP14`            | `GPIO14`     |                   | `PWM7` (channel A)   |
-| `GP15`            | `GPIO15`     |                   | `PWM7` (channel B)   |
-| `GP16`            | `GPIO16`     | `SPI0_SDI_PIN`    | `PWM0` (channel A)   |
-| `GP17`            | `GPIO17`     |                   | `PWM0` (channel B)   |
-| `GP18`            | `GPIO18`     | `SPI0_SCK_PIN`    | `PWM1` (channel A)   |
-| `GP19`            | `GPIO19`     | `SPI0_SDO_PIN`    | `PWM1` (channel B)   |
-| `GP20`            | `GPIO20`     |                   | `PWM2` (channel A)   |
-| `GP21`            | `GPIO21`     |                   | `PWM2` (channel B)   |
-| `GP22`            | `GPIO22`     |                   | `PWM3` (channel A)   |
-| `GP26`            | `GPIO26`     | `ADC0`            | `PWM5` (channel A)   |
-| `GP27`            | `GPIO27`     | `ADC1`            | `PWM5` (channel B)   |
-| `GP28`            | `GPIO28`     | `ADC2`            | `PWM6` (channel A)   |
-| `LED`             | `GPIO25`     |                   | `PWM4` (channel B)   |
-| `ADC3`            | `GPIO29`     |                   | `PWM6` (channel B)   |
+| Pin               | Hardware pin | Alternative names | I2C                  | PWM                  |
+| ----------------- | ------------ | ----------------- | -------------------- | -------------------- |
+| `GP0`             | `GPIO0`      | `UART0_TX_PIN`, `UART_TX_PIN` | `I2C0` (SDA)         | `PWM0` (channel A)   |
+| `GP1`             | `GPIO1`      | `UART0_RX_PIN`, `UART_RX_PIN` | `I2C0` (SCL)         | `PWM0` (channel B)   |
+| `GP2`             | `GPIO2`      | `I2C1_SDA_PIN`    | `I2C1` (SDA)         | `PWM1` (channel A)   |
+| `GP3`             | `GPIO3`      | `I2C1_SCL_PIN`    | `I2C1` (SCL)         | `PWM1` (channel B)   |
+| `GP4`             | `GPIO4`      | `I2C0_SDA_PIN`    | `I2C0` (SDA)         | `PWM2` (channel A)   |
+| `GP5`             | `GPIO5`      | `I2C0_SCL_PIN`    | `I2C0` (SCL)         | `PWM2` (channel B)   |
+| `GP6`             | `GPIO6`      |                   | `I2C1` (SDA)         | `PWM3` (channel A)   |
+| `GP7`             | `GPIO7`      |                   | `I2C1` (SCL)         | `PWM3` (channel B)   |
+| `GP8`             | `GPIO8`      | `UART1_TX_PIN`    | `I2C0` (SDA)         | `PWM4` (channel A)   |
+| `GP9`             | `GPIO9`      | `UART1_RX_PIN`    | `I2C0` (SCL)         | `PWM4` (channel B)   |
+| `GP10`            | `GPIO10`     | `SPI1_SCK_PIN`    | `I2C1` (SDA)         | `PWM5` (channel A)   |
+| `GP11`            | `GPIO11`     | `SPI1_SDO_PIN`    | `I2C1` (SCL)         | `PWM5` (channel B)   |
+| `GP12`            | `GPIO12`     | `SPI1_SDI_PIN`    | `I2C0` (SDA)         | `PWM6` (channel A)   |
+| `GP13`            | `GPIO13`     |                   | `I2C0` (SCL)         | `PWM6` (channel B)   |
+| `GP14`            | `GPIO14`     |                   | `I2C1` (SDA)         | `PWM7` (channel A)   |
+| `GP15`            | `GPIO15`     |                   | `I2C1` (SCL)         | `PWM7` (channel B)   |
+| `GP16`            | `GPIO16`     | `SPI0_SDI_PIN`    | `I2C0` (SDA)         | `PWM0` (channel A)   |
+| `GP17`            | `GPIO17`     |                   | `I2C0` (SCL)         | `PWM0` (channel B)   |
+| `GP18`            | `GPIO18`     | `SPI0_SCK_PIN`    | `I2C1` (SDA)         | `PWM1` (channel A)   |
+| `GP19`            | `GPIO19`     | `SPI0_SDO_PIN`    | `I2C1` (SCL)         | `PWM1` (channel B)   |
+| `GP20`            | `GPIO20`     |                   | `I2C0` (SDA)         | `PWM2` (channel A)   |
+| `GP21`            | `GPIO21`     |                   | `I2C0` (SCL)         | `PWM2` (channel B)   |
+| `GP22`            | `GPIO22`     |                   |                      | `PWM3` (channel A)   |
+| `GP26`            | `GPIO26`     | `ADC0`            | `I2C1` (SDA)         | `PWM5` (channel A)   |
+| `GP27`            | `GPIO27`     | `ADC1`            | `I2C1` (SCL)         | `PWM5` (channel B)   |
+| `GP28`            | `GPIO28`     | `ADC2`            |                      | `PWM6` (channel A)   |
+| `LED`             | `GPIO25`     |                   |                      | `PWM4` (channel B)   |
+| `ADC3`            | `GPIO29`     |                   |                      | `PWM6` (channel B)   |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/pico.md
+++ b/content/docs/reference/microcontrollers/pico.md
@@ -19,36 +19,36 @@ The [Raspberry Pi Pico](https://www.raspberrypi.org/products/raspberry-pi-pico/)
 
 ## Pins
 
-| Pin               | Hardware pin | Alternative names | PWM                  |
-| ----------------- | ------------ | ----------------- | -------------------- |
-| `GP0`             | `GPIO0`      | `UART0_TX_PIN`, `UART_TX_PIN` | `PWM0` (channel A)   |
-| `GP1`             | `GPIO1`      | `UART0_RX_PIN`, `UART_RX_PIN` | `PWM0` (channel B)   |
-| `GP2`             | `GPIO2`      | `I2C1_SDA_PIN`    | `PWM1` (channel A)   |
-| `GP3`             | `GPIO3`      | `I2C1_SCL_PIN`    | `PWM1` (channel B)   |
-| `GP4`             | `GPIO4`      | `I2C0_SDA_PIN`    | `PWM2` (channel A)   |
-| `GP5`             | `GPIO5`      | `I2C0_SCL_PIN`    | `PWM2` (channel B)   |
-| `GP6`             | `GPIO6`      |                   | `PWM3` (channel A)   |
-| `GP7`             | `GPIO7`      |                   | `PWM3` (channel B)   |
-| `GP8`             | `GPIO8`      | `UART1_TX_PIN`    | `PWM4` (channel A)   |
-| `GP9`             | `GPIO9`      | `UART1_RX_PIN`    | `PWM4` (channel B)   |
-| `GP10`            | `GPIO10`     | `SPI1_SCK_PIN`    | `PWM5` (channel A)   |
-| `GP11`            | `GPIO11`     | `SPI1_SDO_PIN`    | `PWM5` (channel B)   |
-| `GP12`            | `GPIO12`     | `SPI1_SDI_PIN`    | `PWM6` (channel A)   |
-| `GP13`            | `GPIO13`     |                   | `PWM6` (channel B)   |
-| `GP14`            | `GPIO14`     |                   | `PWM7` (channel A)   |
-| `GP15`            | `GPIO15`     |                   | `PWM7` (channel B)   |
-| `GP16`            | `GPIO16`     | `SPI0_SDI_PIN`    | `PWM0` (channel A)   |
-| `GP17`            | `GPIO17`     |                   | `PWM0` (channel B)   |
-| `GP18`            | `GPIO18`     | `SPI0_SCK_PIN`    | `PWM1` (channel A)   |
-| `GP19`            | `GPIO19`     | `SPI0_SDO_PIN`    | `PWM1` (channel B)   |
-| `GP20`            | `GPIO20`     |                   | `PWM2` (channel A)   |
-| `GP21`            | `GPIO21`     |                   | `PWM2` (channel B)   |
-| `GP22`            | `GPIO22`     |                   | `PWM3` (channel A)   |
-| `GP26`            | `GPIO26`     | `ADC0`            | `PWM5` (channel A)   |
-| `GP27`            | `GPIO27`     | `ADC1`            | `PWM5` (channel B)   |
-| `GP28`            | `GPIO28`     | `ADC2`            | `PWM6` (channel A)   |
-| `LED`             | `GPIO25`     |                   | `PWM4` (channel B)   |
-| `ADC3`            | `GPIO29`     |                   | `PWM6` (channel B)   |
+| Pin               | Hardware pin | Alternative names | I2C                  | PWM                  |
+| ----------------- | ------------ | ----------------- | -------------------- | -------------------- |
+| `GP0`             | `GPIO0`      | `UART0_TX_PIN`, `UART_TX_PIN` | `I2C0` (SDA)         | `PWM0` (channel A)   |
+| `GP1`             | `GPIO1`      | `UART0_RX_PIN`, `UART_RX_PIN` | `I2C0` (SCL)         | `PWM0` (channel B)   |
+| `GP2`             | `GPIO2`      | `I2C1_SDA_PIN`    | `I2C1` (SDA)         | `PWM1` (channel A)   |
+| `GP3`             | `GPIO3`      | `I2C1_SCL_PIN`    | `I2C1` (SCL)         | `PWM1` (channel B)   |
+| `GP4`             | `GPIO4`      | `I2C0_SDA_PIN`    | `I2C0` (SDA)         | `PWM2` (channel A)   |
+| `GP5`             | `GPIO5`      | `I2C0_SCL_PIN`    | `I2C0` (SCL)         | `PWM2` (channel B)   |
+| `GP6`             | `GPIO6`      |                   | `I2C1` (SDA)         | `PWM3` (channel A)   |
+| `GP7`             | `GPIO7`      |                   | `I2C1` (SCL)         | `PWM3` (channel B)   |
+| `GP8`             | `GPIO8`      | `UART1_TX_PIN`    | `I2C0` (SDA)         | `PWM4` (channel A)   |
+| `GP9`             | `GPIO9`      | `UART1_RX_PIN`    | `I2C0` (SCL)         | `PWM4` (channel B)   |
+| `GP10`            | `GPIO10`     | `SPI1_SCK_PIN`    | `I2C1` (SDA)         | `PWM5` (channel A)   |
+| `GP11`            | `GPIO11`     | `SPI1_SDO_PIN`    | `I2C1` (SCL)         | `PWM5` (channel B)   |
+| `GP12`            | `GPIO12`     | `SPI1_SDI_PIN`    | `I2C0` (SDA)         | `PWM6` (channel A)   |
+| `GP13`            | `GPIO13`     |                   | `I2C0` (SCL)         | `PWM6` (channel B)   |
+| `GP14`            | `GPIO14`     |                   | `I2C1` (SDA)         | `PWM7` (channel A)   |
+| `GP15`            | `GPIO15`     |                   | `I2C1` (SCL)         | `PWM7` (channel B)   |
+| `GP16`            | `GPIO16`     | `SPI0_SDI_PIN`    | `I2C0` (SDA)         | `PWM0` (channel A)   |
+| `GP17`            | `GPIO17`     |                   | `I2C0` (SCL)         | `PWM0` (channel B)   |
+| `GP18`            | `GPIO18`     | `SPI0_SCK_PIN`    | `I2C1` (SDA)         | `PWM1` (channel A)   |
+| `GP19`            | `GPIO19`     | `SPI0_SDO_PIN`    | `I2C1` (SCL)         | `PWM1` (channel B)   |
+| `GP20`            | `GPIO20`     |                   | `I2C0` (SDA)         | `PWM2` (channel A)   |
+| `GP21`            | `GPIO21`     |                   | `I2C0` (SCL)         | `PWM2` (channel B)   |
+| `GP22`            | `GPIO22`     |                   |                      | `PWM3` (channel A)   |
+| `GP26`            | `GPIO26`     | `ADC0`            | `I2C1` (SDA)         | `PWM5` (channel A)   |
+| `GP27`            | `GPIO27`     | `ADC1`            | `I2C1` (SCL)         | `PWM5` (channel B)   |
+| `GP28`            | `GPIO28`     | `ADC2`            |                      | `PWM6` (channel A)   |
+| `LED`             | `GPIO25`     |                   |                      | `PWM4` (channel B)   |
+| `ADC3`            | `GPIO29`     |                   |                      | `PWM6` (channel B)   |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/pico2-w.md
+++ b/content/docs/reference/microcontrollers/pico2-w.md
@@ -19,36 +19,36 @@ The [Raspberry Pi Pico 2 - W](https://www.raspberrypi.com/products/raspberry-pi-
 
 ## Pins
 
-| Pin               | Hardware pin | Alternative names | PWM                  |
-| ----------------- | ------------ | ----------------- | -------------------- |
-| `GP0`             | `GPIO0`      | `UART0_TX_PIN`, `UART_TX_PIN` | `PWM0` (channel A)   |
-| `GP1`             | `GPIO1`      | `UART0_RX_PIN`, `UART_RX_PIN` | `PWM0` (channel B)   |
-| `GP2`             | `GPIO2`      | `I2C1_SDA_PIN`    | `PWM1` (channel A)   |
-| `GP3`             | `GPIO3`      | `I2C1_SCL_PIN`    | `PWM1` (channel B)   |
-| `GP4`             | `GPIO4`      | `I2C0_SDA_PIN`    | `PWM2` (channel A)   |
-| `GP5`             | `GPIO5`      | `I2C0_SCL_PIN`    | `PWM2` (channel B)   |
-| `GP6`             | `GPIO6`      |                   | `PWM3` (channel A)   |
-| `GP7`             | `GPIO7`      |                   | `PWM3` (channel B)   |
-| `GP8`             | `GPIO8`      | `UART1_TX_PIN`    | `PWM4` (channel A)   |
-| `GP9`             | `GPIO9`      | `UART1_RX_PIN`    | `PWM4` (channel B)   |
-| `GP10`            | `GPIO10`     | `SPI1_SCK_PIN`    | `PWM5` (channel A)   |
-| `GP11`            | `GPIO11`     | `SPI1_SDO_PIN`    | `PWM5` (channel B)   |
-| `GP12`            | `GPIO12`     | `SPI1_SDI_PIN`    | `PWM6` (channel A)   |
-| `GP13`            | `GPIO13`     |                   | `PWM6` (channel B)   |
-| `GP14`            | `GPIO14`     |                   | `PWM7` (channel A)   |
-| `GP15`            | `GPIO15`     |                   | `PWM7` (channel B)   |
-| `GP16`            | `GPIO16`     | `SPI0_SDI_PIN`    | `PWM0` (channel A)   |
-| `GP17`            | `GPIO17`     |                   | `PWM0` (channel B)   |
-| `GP18`            | `GPIO18`     | `SPI0_SCK_PIN`    | `PWM1` (channel A)   |
-| `GP19`            | `GPIO19`     | `SPI0_SDO_PIN`    | `PWM1` (channel B)   |
-| `GP20`            | `GPIO20`     |                   | `PWM2` (channel A)   |
-| `GP21`            | `GPIO21`     |                   | `PWM2` (channel B)   |
-| `GP22`            | `GPIO22`     |                   | `PWM3` (channel A)   |
-| `GP26`            | `GPIO26`     | `ADC0`            | `PWM5` (channel A)   |
-| `GP27`            | `GPIO27`     | `ADC1`            | `PWM5` (channel B)   |
-| `GP28`            | `GPIO28`     | `ADC2`            | `PWM6` (channel A)   |
-| `LED`             | `GPIO25`     |                   | `PWM4` (channel B)   |
-| `ADC3`            | `GPIO29`     |                   | `PWM6` (channel B)   |
+| Pin               | Hardware pin | Alternative names | I2C                  | PWM                  |
+| ----------------- | ------------ | ----------------- | -------------------- | -------------------- |
+| `GP0`             | `GPIO0`      | `UART0_TX_PIN`, `UART_TX_PIN` | `I2C0` (SDA)         | `PWM0` (channel A)   |
+| `GP1`             | `GPIO1`      | `UART0_RX_PIN`, `UART_RX_PIN` | `I2C0` (SCL)         | `PWM0` (channel B)   |
+| `GP2`             | `GPIO2`      | `I2C1_SDA_PIN`    | `I2C1` (SDA)         | `PWM1` (channel A)   |
+| `GP3`             | `GPIO3`      | `I2C1_SCL_PIN`    | `I2C1` (SCL)         | `PWM1` (channel B)   |
+| `GP4`             | `GPIO4`      | `I2C0_SDA_PIN`    | `I2C0` (SDA)         | `PWM2` (channel A)   |
+| `GP5`             | `GPIO5`      | `I2C0_SCL_PIN`    | `I2C0` (SCL)         | `PWM2` (channel B)   |
+| `GP6`             | `GPIO6`      |                   | `I2C1` (SDA)         | `PWM3` (channel A)   |
+| `GP7`             | `GPIO7`      |                   | `I2C1` (SCL)         | `PWM3` (channel B)   |
+| `GP8`             | `GPIO8`      | `UART1_TX_PIN`    | `I2C0` (SDA)         | `PWM4` (channel A)   |
+| `GP9`             | `GPIO9`      | `UART1_RX_PIN`    | `I2C0` (SCL)         | `PWM4` (channel B)   |
+| `GP10`            | `GPIO10`     | `SPI1_SCK_PIN`    | `I2C1` (SDA)         | `PWM5` (channel A)   |
+| `GP11`            | `GPIO11`     | `SPI1_SDO_PIN`    | `I2C1` (SCL)         | `PWM5` (channel B)   |
+| `GP12`            | `GPIO12`     | `SPI1_SDI_PIN`    | `I2C0` (SDA)         | `PWM6` (channel A)   |
+| `GP13`            | `GPIO13`     |                   | `I2C0` (SCL)         | `PWM6` (channel B)   |
+| `GP14`            | `GPIO14`     |                   | `I2C1` (SDA)         | `PWM7` (channel A)   |
+| `GP15`            | `GPIO15`     |                   | `I2C1` (SCL)         | `PWM7` (channel B)   |
+| `GP16`            | `GPIO16`     | `SPI0_SDI_PIN`    | `I2C0` (SDA)         | `PWM0` (channel A)   |
+| `GP17`            | `GPIO17`     |                   | `I2C0` (SCL)         | `PWM0` (channel B)   |
+| `GP18`            | `GPIO18`     | `SPI0_SCK_PIN`    | `I2C1` (SDA)         | `PWM1` (channel A)   |
+| `GP19`            | `GPIO19`     | `SPI0_SDO_PIN`    | `I2C1` (SCL)         | `PWM1` (channel B)   |
+| `GP20`            | `GPIO20`     |                   | `I2C0` (SDA)         | `PWM2` (channel A)   |
+| `GP21`            | `GPIO21`     |                   | `I2C0` (SCL)         | `PWM2` (channel B)   |
+| `GP22`            | `GPIO22`     |                   |                      | `PWM3` (channel A)   |
+| `GP26`            | `GPIO26`     | `ADC0`            | `I2C1` (SDA)         | `PWM5` (channel A)   |
+| `GP27`            | `GPIO27`     | `ADC1`            | `I2C1` (SCL)         | `PWM5` (channel B)   |
+| `GP28`            | `GPIO28`     | `ADC2`            |                      | `PWM6` (channel A)   |
+| `LED`             | `GPIO25`     |                   |                      | `PWM4` (channel B)   |
+| `ADC3`            | `GPIO29`     |                   |                      | `PWM6` (channel B)   |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/pico2.md
+++ b/content/docs/reference/microcontrollers/pico2.md
@@ -19,36 +19,36 @@ The [Raspberry Pi Pico 2](https://www.raspberrypi.com/products/raspberry-pi-pico
 
 ## Pins
 
-| Pin               | Hardware pin | Alternative names | PWM                  |
-| ----------------- | ------------ | ----------------- | -------------------- |
-| `GP0`             | `GPIO0`      | `UART0_TX_PIN`, `UART_TX_PIN` | `PWM0` (channel A)   |
-| `GP1`             | `GPIO1`      | `UART0_RX_PIN`, `UART_RX_PIN` | `PWM0` (channel B)   |
-| `GP2`             | `GPIO2`      | `I2C1_SDA_PIN`    | `PWM1` (channel A)   |
-| `GP3`             | `GPIO3`      | `I2C1_SCL_PIN`    | `PWM1` (channel B)   |
-| `GP4`             | `GPIO4`      | `I2C0_SDA_PIN`    | `PWM2` (channel A)   |
-| `GP5`             | `GPIO5`      | `I2C0_SCL_PIN`    | `PWM2` (channel B)   |
-| `GP6`             | `GPIO6`      |                   | `PWM3` (channel A)   |
-| `GP7`             | `GPIO7`      |                   | `PWM3` (channel B)   |
-| `GP8`             | `GPIO8`      | `UART1_TX_PIN`    | `PWM4` (channel A)   |
-| `GP9`             | `GPIO9`      | `UART1_RX_PIN`    | `PWM4` (channel B)   |
-| `GP10`            | `GPIO10`     | `SPI1_SCK_PIN`    | `PWM5` (channel A)   |
-| `GP11`            | `GPIO11`     | `SPI1_SDO_PIN`    | `PWM5` (channel B)   |
-| `GP12`            | `GPIO12`     | `SPI1_SDI_PIN`    | `PWM6` (channel A)   |
-| `GP13`            | `GPIO13`     |                   | `PWM6` (channel B)   |
-| `GP14`            | `GPIO14`     |                   | `PWM7` (channel A)   |
-| `GP15`            | `GPIO15`     |                   | `PWM7` (channel B)   |
-| `GP16`            | `GPIO16`     | `SPI0_SDI_PIN`    | `PWM0` (channel A)   |
-| `GP17`            | `GPIO17`     |                   | `PWM0` (channel B)   |
-| `GP18`            | `GPIO18`     | `SPI0_SCK_PIN`    | `PWM1` (channel A)   |
-| `GP19`            | `GPIO19`     | `SPI0_SDO_PIN`    | `PWM1` (channel B)   |
-| `GP20`            | `GPIO20`     |                   | `PWM2` (channel A)   |
-| `GP21`            | `GPIO21`     |                   | `PWM2` (channel B)   |
-| `GP22`            | `GPIO22`     |                   | `PWM3` (channel A)   |
-| `GP26`            | `GPIO26`     | `ADC0`            | `PWM5` (channel A)   |
-| `GP27`            | `GPIO27`     | `ADC1`            | `PWM5` (channel B)   |
-| `GP28`            | `GPIO28`     | `ADC2`            | `PWM6` (channel A)   |
-| `LED`             | `GPIO25`     |                   | `PWM4` (channel B)   |
-| `ADC3`            | `GPIO29`     |                   | `PWM6` (channel B)   |
+| Pin               | Hardware pin | Alternative names | I2C                  | PWM                  |
+| ----------------- | ------------ | ----------------- | -------------------- | -------------------- |
+| `GP0`             | `GPIO0`      | `UART0_TX_PIN`, `UART_TX_PIN` | `I2C0` (SDA)         | `PWM0` (channel A)   |
+| `GP1`             | `GPIO1`      | `UART0_RX_PIN`, `UART_RX_PIN` | `I2C0` (SCL)         | `PWM0` (channel B)   |
+| `GP2`             | `GPIO2`      | `I2C1_SDA_PIN`    | `I2C1` (SDA)         | `PWM1` (channel A)   |
+| `GP3`             | `GPIO3`      | `I2C1_SCL_PIN`    | `I2C1` (SCL)         | `PWM1` (channel B)   |
+| `GP4`             | `GPIO4`      | `I2C0_SDA_PIN`    | `I2C0` (SDA)         | `PWM2` (channel A)   |
+| `GP5`             | `GPIO5`      | `I2C0_SCL_PIN`    | `I2C0` (SCL)         | `PWM2` (channel B)   |
+| `GP6`             | `GPIO6`      |                   | `I2C1` (SDA)         | `PWM3` (channel A)   |
+| `GP7`             | `GPIO7`      |                   | `I2C1` (SCL)         | `PWM3` (channel B)   |
+| `GP8`             | `GPIO8`      | `UART1_TX_PIN`    | `I2C0` (SDA)         | `PWM4` (channel A)   |
+| `GP9`             | `GPIO9`      | `UART1_RX_PIN`    | `I2C0` (SCL)         | `PWM4` (channel B)   |
+| `GP10`            | `GPIO10`     | `SPI1_SCK_PIN`    | `I2C1` (SDA)         | `PWM5` (channel A)   |
+| `GP11`            | `GPIO11`     | `SPI1_SDO_PIN`    | `I2C1` (SCL)         | `PWM5` (channel B)   |
+| `GP12`            | `GPIO12`     | `SPI1_SDI_PIN`    | `I2C0` (SDA)         | `PWM6` (channel A)   |
+| `GP13`            | `GPIO13`     |                   | `I2C0` (SCL)         | `PWM6` (channel B)   |
+| `GP14`            | `GPIO14`     |                   | `I2C1` (SDA)         | `PWM7` (channel A)   |
+| `GP15`            | `GPIO15`     |                   | `I2C1` (SCL)         | `PWM7` (channel B)   |
+| `GP16`            | `GPIO16`     | `SPI0_SDI_PIN`    | `I2C0` (SDA)         | `PWM0` (channel A)   |
+| `GP17`            | `GPIO17`     |                   | `I2C0` (SCL)         | `PWM0` (channel B)   |
+| `GP18`            | `GPIO18`     | `SPI0_SCK_PIN`    | `I2C1` (SDA)         | `PWM1` (channel A)   |
+| `GP19`            | `GPIO19`     | `SPI0_SDO_PIN`    | `I2C1` (SCL)         | `PWM1` (channel B)   |
+| `GP20`            | `GPIO20`     |                   | `I2C0` (SDA)         | `PWM2` (channel A)   |
+| `GP21`            | `GPIO21`     |                   | `I2C0` (SCL)         | `PWM2` (channel B)   |
+| `GP22`            | `GPIO22`     |                   |                      | `PWM3` (channel A)   |
+| `GP26`            | `GPIO26`     | `ADC0`            | `I2C1` (SDA)         | `PWM5` (channel A)   |
+| `GP27`            | `GPIO27`     | `ADC1`            | `I2C1` (SCL)         | `PWM5` (channel B)   |
+| `GP28`            | `GPIO28`     | `ADC2`            |                      | `PWM6` (channel A)   |
+| `LED`             | `GPIO25`     |                   |                      | `PWM4` (channel B)   |
+| `ADC3`            | `GPIO29`     |                   |                      | `PWM6` (channel B)   |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/pybadge.md
+++ b/content/docs/reference/microcontrollers/pybadge.md
@@ -21,53 +21,53 @@ It has many built-in devices, such as a 1.8" 160x128 Color TFT Display, 8 x butt
 
 ## Pins
 
-| Pin               | Hardware pin | Alternative names | PWM                  |
-| ----------------- | ------------ | ----------------- | -------------------- |
-| `D0`              | `PB17`       | `UART_RX_PIN`, `NINA_RX` | `TCC3` (channel 1), `TCC0` (channel 5) |
-| `D1`              | `PB16`       | `UART_TX_PIN`, `NINA_TX` | `TCC3` (channel 0), `TCC0` (channel 4) |
-| `D2`              | `PB03`       | `A8`              | `TCC2` (channel 3)   |
-| `D3`              | `PB02`       | `A9`              | `TCC2` (channel 2)   |
-| `D4`              | `PA14`       |                   | `TCC2` (channel 0), `TCC1` (channel 2) |
-| `D5`              | `PA16`       |                   | `TCC1` (channel 0), `TCC0` (channel 4) |
-| `D6`              | `PA18`       |                   | `TCC1` (channel 2), `TCC0` (channel 6) |
-| `D7`              | `PB14`       |                   | `TCC4` (channel 0), `TCC0` (channel 2) |
-| `D8`              | `PA15`       | `NEOPIXELS`, `WS2812` | `TCC2` (channel 1), `TCC1` (channel 3) |
-| `D9`              | `PA19`       |                   | `TCC1` (channel 3), `TCC0` (channel 7) |
-| `D10`             | `PA20`       | `NINA_GPIO0`, `NINA_RTS` | `TCC1` (channel 4), `TCC0` (channel 0) |
-| `D11`             | `PA21`       | `NINA_ACK`, `NINA_CTS` | `TCC1` (channel 5), `TCC0` (channel 1) |
-| `D12`             | `PA22`       | `NINA_RESETN`     | `TCC1` (channel 6), `TCC0` (channel 2) |
-| `D13`             | `PA23`       | `LED`, `NINA_CS`  | `TCC1` (channel 7), `TCC0` (channel 3) |
-| `A0`              | `PA02`       |                   |                      |
-| `A1`              | `PA05`       |                   |                      |
-| `A2`              | `PB08`       |                   |                      |
-| `A3`              | `PB09`       |                   |                      |
-| `A4`              | `PA04`       | `UART2_TX_PIN`    |                      |
-| `A5`              | `PA06`       | `UART2_RX_PIN`    |                      |
-| `A6`              | `PB01`       |                   |                      |
-| `A7`              | `PB04`       | `LIGHTSENSOR`     |                      |
-| `BUTTON_LATCH`    | `PB00`       |                   |                      |
-| `BUTTON_OUT`      | `PB30`       |                   | `TCC4` (channel 0), `TCC0` (channel 6) |
-| `BUTTON_CLK`      | `PB31`       |                   | `TCC4` (channel 1), `TCC0` (channel 7) |
-| `TFT_DC`          | `PB05`       |                   |                      |
-| `TFT_CS`          | `PB07`       |                   |                      |
-| `TFT_RST`         | `PA00`       |                   |                      |
-| `TFT_LITE`        | `PA01`       |                   |                      |
-| `SPEAKER_ENABLE`  | `PA27`       |                   |                      |
-| `USBCDC_DM_PIN`   | `PA24`       |                   | `TCC2` (channel 2)   |
-| `USBCDC_DP_PIN`   | `PA25`       |                   | `TCC2` (channel 3)   |
-| `SDA_PIN`         | `PA12`       |                   | `TCC0` (channel 6), `TCC1` (channel 2) |
-| `SCL_PIN`         | `PA13`       |                   | `TCC0` (channel 7), `TCC1` (channel 3) |
-| `SPI0_SCK_PIN`    | `PA17`       | `NINA_SCK`        | `TCC1` (channel 1), `TCC0` (channel 5) |
-| `SPI0_SDO_PIN`    | `PB23`       | `NINA_SDO`        |                      |
-| `SPI0_SDI_PIN`    | `PB22`       | `NINA_SDI`        |                      |
-| `SPI1_SCK_PIN`    | `PB13`       |                   | `TCC3` (channel 1), `TCC0` (channel 1) |
-| `SPI1_SDO_PIN`    | `PB15`       |                   | `TCC4` (channel 1), `TCC0` (channel 3) |
-| `QSPI_SCK`        | `PB10`       |                   | `TCC0` (channel 4), `TCC1` (channel 0) |
-| `QSPI_CS`         | `PB11`       |                   | `TCC0` (channel 5), `TCC1` (channel 1) |
-| `QSPI_DATA0`      | `PA08`       |                   | `TCC0` (channel 0), `TCC1` (channel 4) |
-| `QSPI_DATA1`      | `PA09`       |                   | `TCC0` (channel 1), `TCC1` (channel 5) |
-| `QSPI_DATA2`      | `PA10`       |                   | `TCC0` (channel 2), `TCC1` (channel 6) |
-| `QSPI_DATA3`      | `PA11`       |                   | `TCC0` (channel 3), `TCC1` (channel 7) |
+| Pin               | Hardware pin | Alternative names | I2C                  | PWM                  |
+| ----------------- | ------------ | ----------------- | -------------------- | -------------------- |
+| `D0`              | `PB17`       | `UART_RX_PIN`, `NINA_RX` |                      | `TCC3` (channel 1), `TCC0` (channel 5) |
+| `D1`              | `PB16`       | `UART_TX_PIN`, `NINA_TX` |                      | `TCC3` (channel 0), `TCC0` (channel 4) |
+| `D2`              | `PB03`       | `A8`              |                      | `TCC2` (channel 3)   |
+| `D3`              | `PB02`       | `A9`              |                      | `TCC2` (channel 2)   |
+| `D4`              | `PA14`       |                   |                      | `TCC2` (channel 0), `TCC1` (channel 2) |
+| `D5`              | `PA16`       |                   |                      | `TCC1` (channel 0), `TCC0` (channel 4) |
+| `D6`              | `PA18`       |                   |                      | `TCC1` (channel 2), `TCC0` (channel 6) |
+| `D7`              | `PB14`       |                   |                      | `TCC4` (channel 0), `TCC0` (channel 2) |
+| `D8`              | `PA15`       | `NEOPIXELS`, `WS2812` |                      | `TCC2` (channel 1), `TCC1` (channel 3) |
+| `D9`              | `PA19`       |                   |                      | `TCC1` (channel 3), `TCC0` (channel 7) |
+| `D10`             | `PA20`       | `NINA_GPIO0`, `NINA_RTS` |                      | `TCC1` (channel 4), `TCC0` (channel 0) |
+| `D11`             | `PA21`       | `NINA_ACK`, `NINA_CTS` |                      | `TCC1` (channel 5), `TCC0` (channel 1) |
+| `D12`             | `PA22`       | `NINA_RESETN`     |                      | `TCC1` (channel 6), `TCC0` (channel 2) |
+| `D13`             | `PA23`       | `LED`, `NINA_CS`  |                      | `TCC1` (channel 7), `TCC0` (channel 3) |
+| `A0`              | `PA02`       |                   |                      |                      |
+| `A1`              | `PA05`       |                   |                      |                      |
+| `A2`              | `PB08`       |                   |                      |                      |
+| `A3`              | `PB09`       |                   |                      |                      |
+| `A4`              | `PA04`       | `UART2_TX_PIN`    |                      |                      |
+| `A5`              | `PA06`       | `UART2_RX_PIN`    |                      |                      |
+| `A6`              | `PB01`       |                   |                      |                      |
+| `A7`              | `PB04`       | `LIGHTSENSOR`     |                      |                      |
+| `BUTTON_LATCH`    | `PB00`       |                   |                      |                      |
+| `BUTTON_OUT`      | `PB30`       |                   |                      | `TCC4` (channel 0), `TCC0` (channel 6) |
+| `BUTTON_CLK`      | `PB31`       |                   |                      | `TCC4` (channel 1), `TCC0` (channel 7) |
+| `TFT_DC`          | `PB05`       |                   |                      |                      |
+| `TFT_CS`          | `PB07`       |                   |                      |                      |
+| `TFT_RST`         | `PA00`       |                   |                      |                      |
+| `TFT_LITE`        | `PA01`       |                   |                      |                      |
+| `SPEAKER_ENABLE`  | `PA27`       |                   |                      |                      |
+| `USBCDC_DM_PIN`   | `PA24`       |                   |                      | `TCC2` (channel 2)   |
+| `USBCDC_DP_PIN`   | `PA25`       |                   |                      | `TCC2` (channel 3)   |
+| `SDA_PIN`         | `PA12`       |                   | `I2C0` (SDA)         | `TCC0` (channel 6), `TCC1` (channel 2) |
+| `SCL_PIN`         | `PA13`       |                   | `I2C0` (SCL)         | `TCC0` (channel 7), `TCC1` (channel 3) |
+| `SPI0_SCK_PIN`    | `PA17`       | `NINA_SCK`        |                      | `TCC1` (channel 1), `TCC0` (channel 5) |
+| `SPI0_SDO_PIN`    | `PB23`       | `NINA_SDO`        |                      |                      |
+| `SPI0_SDI_PIN`    | `PB22`       | `NINA_SDI`        |                      |                      |
+| `SPI1_SCK_PIN`    | `PB13`       |                   |                      | `TCC3` (channel 1), `TCC0` (channel 1) |
+| `SPI1_SDO_PIN`    | `PB15`       |                   |                      | `TCC4` (channel 1), `TCC0` (channel 3) |
+| `QSPI_SCK`        | `PB10`       |                   |                      | `TCC0` (channel 4), `TCC1` (channel 0) |
+| `QSPI_CS`         | `PB11`       |                   |                      | `TCC0` (channel 5), `TCC1` (channel 1) |
+| `QSPI_DATA0`      | `PA08`       |                   | `I2C0` (SDA)         | `TCC0` (channel 0), `TCC1` (channel 4) |
+| `QSPI_DATA1`      | `PA09`       |                   | `I2C0` (SCL)         | `TCC0` (channel 1), `TCC1` (channel 5) |
+| `QSPI_DATA2`      | `PA10`       |                   |                      | `TCC0` (channel 2), `TCC1` (channel 6) |
+| `QSPI_DATA3`      | `PA11`       |                   |                      | `TCC0` (channel 3), `TCC1` (channel 7) |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/pygamer.md
+++ b/content/docs/reference/microcontrollers/pygamer.md
@@ -21,55 +21,55 @@ It has many built-in devices, such as a 1.8" 160x128 Color TFT Display, a dual-p
 
 ## Pins
 
-| Pin               | Hardware pin | Alternative names | PWM                  |
-| ----------------- | ------------ | ----------------- | -------------------- |
-| `D0`              | `PB17`       | `UART_RX_PIN`     | `TCC3` (channel 1), `TCC0` (channel 5) |
-| `D1`              | `PB16`       | `UART_TX_PIN`     | `TCC3` (channel 0), `TCC0` (channel 4) |
-| `D2`              | `PB03`       | `A8`              | `TCC2` (channel 3)   |
-| `D3`              | `PB02`       | `A9`              | `TCC2` (channel 2)   |
-| `D4`              | `PA14`       |                   | `TCC2` (channel 0), `TCC1` (channel 2) |
-| `D5`              | `PA16`       |                   | `TCC1` (channel 0), `TCC0` (channel 4) |
-| `D6`              | `PA18`       |                   | `TCC1` (channel 2), `TCC0` (channel 6) |
-| `D7`              | `PB14`       | `SD_CS`           | `TCC4` (channel 0), `TCC0` (channel 2) |
-| `D8`              | `PA15`       | `NEOPIXELS`, `WS2812` | `TCC2` (channel 1), `TCC1` (channel 3) |
-| `D9`              | `PA19`       |                   | `TCC1` (channel 3), `TCC0` (channel 7) |
-| `D10`             | `PA20`       |                   | `TCC1` (channel 4), `TCC0` (channel 0) |
-| `D11`             | `PA21`       |                   | `TCC1` (channel 5), `TCC0` (channel 1) |
-| `D12`             | `PA22`       |                   | `TCC1` (channel 6), `TCC0` (channel 2) |
-| `D13`             | `PA23`       | `LED`             | `TCC1` (channel 7), `TCC0` (channel 3) |
-| `A0`              | `PA02`       |                   |                      |
-| `A1`              | `PA05`       |                   |                      |
-| `A2`              | `PB08`       |                   |                      |
-| `A3`              | `PB09`       |                   |                      |
-| `A4`              | `PA04`       | `UART2_TX_PIN`    |                      |
-| `A5`              | `PA06`       | `UART2_RX_PIN`    |                      |
-| `A6`              | `PB01`       |                   |                      |
-| `A7`              | `PB04`       | `LIGHTSENSOR`     |                      |
-| `BUTTON_LATCH`    | `PB00`       |                   |                      |
-| `BUTTON_OUT`      | `PB30`       |                   | `TCC4` (channel 0), `TCC0` (channel 6) |
-| `BUTTON_CLK`      | `PB31`       |                   | `TCC4` (channel 1), `TCC0` (channel 7) |
-| `JOYY`            | `PB06`       |                   |                      |
-| `JOYX`            | `PB07`       |                   |                      |
-| `TFT_DC`          | `PB05`       |                   |                      |
-| `TFT_CS`          | `PB12`       |                   | `TCC3` (channel 0), `TCC0` (channel 0) |
-| `TFT_RST`         | `PA00`       |                   |                      |
-| `TFT_LITE`        | `PA01`       |                   |                      |
-| `SPEAKER_ENABLE`  | `PA27`       |                   |                      |
-| `USBCDC_DM_PIN`   | `PA24`       |                   | `TCC2` (channel 2)   |
-| `USBCDC_DP_PIN`   | `PA25`       |                   | `TCC2` (channel 3)   |
-| `SDA_PIN`         | `PA12`       |                   | `TCC0` (channel 6), `TCC1` (channel 2) |
-| `SCL_PIN`         | `PA13`       |                   | `TCC0` (channel 7), `TCC1` (channel 3) |
-| `SPI0_SCK_PIN`    | `PA17`       |                   | `TCC1` (channel 1), `TCC0` (channel 5) |
-| `SPI0_SDO_PIN`    | `PB23`       |                   |                      |
-| `SPI0_SDI_PIN`    | `PB22`       |                   |                      |
-| `SPI1_SCK_PIN`    | `PB13`       |                   | `TCC3` (channel 1), `TCC0` (channel 1) |
-| `SPI1_SDO_PIN`    | `PB15`       |                   | `TCC4` (channel 1), `TCC0` (channel 3) |
-| `QSPI_SCK`        | `PB10`       |                   | `TCC0` (channel 4), `TCC1` (channel 0) |
-| `QSPI_CS`         | `PB11`       |                   | `TCC0` (channel 5), `TCC1` (channel 1) |
-| `QSPI_DATA0`      | `PA08`       |                   | `TCC0` (channel 0), `TCC1` (channel 4) |
-| `QSPI_DATA1`      | `PA09`       |                   | `TCC0` (channel 1), `TCC1` (channel 5) |
-| `QSPI_DATA2`      | `PA10`       |                   | `TCC0` (channel 2), `TCC1` (channel 6) |
-| `QSPI_DATA3`      | `PA11`       |                   | `TCC0` (channel 3), `TCC1` (channel 7) |
+| Pin               | Hardware pin | Alternative names | I2C                  | PWM                  |
+| ----------------- | ------------ | ----------------- | -------------------- | -------------------- |
+| `D0`              | `PB17`       | `UART_RX_PIN`     |                      | `TCC3` (channel 1), `TCC0` (channel 5) |
+| `D1`              | `PB16`       | `UART_TX_PIN`     |                      | `TCC3` (channel 0), `TCC0` (channel 4) |
+| `D2`              | `PB03`       | `A8`              |                      | `TCC2` (channel 3)   |
+| `D3`              | `PB02`       | `A9`              |                      | `TCC2` (channel 2)   |
+| `D4`              | `PA14`       |                   |                      | `TCC2` (channel 0), `TCC1` (channel 2) |
+| `D5`              | `PA16`       |                   |                      | `TCC1` (channel 0), `TCC0` (channel 4) |
+| `D6`              | `PA18`       |                   |                      | `TCC1` (channel 2), `TCC0` (channel 6) |
+| `D7`              | `PB14`       | `SD_CS`           |                      | `TCC4` (channel 0), `TCC0` (channel 2) |
+| `D8`              | `PA15`       | `NEOPIXELS`, `WS2812` |                      | `TCC2` (channel 1), `TCC1` (channel 3) |
+| `D9`              | `PA19`       |                   |                      | `TCC1` (channel 3), `TCC0` (channel 7) |
+| `D10`             | `PA20`       |                   |                      | `TCC1` (channel 4), `TCC0` (channel 0) |
+| `D11`             | `PA21`       |                   |                      | `TCC1` (channel 5), `TCC0` (channel 1) |
+| `D12`             | `PA22`       |                   |                      | `TCC1` (channel 6), `TCC0` (channel 2) |
+| `D13`             | `PA23`       | `LED`             |                      | `TCC1` (channel 7), `TCC0` (channel 3) |
+| `A0`              | `PA02`       |                   |                      |                      |
+| `A1`              | `PA05`       |                   |                      |                      |
+| `A2`              | `PB08`       |                   |                      |                      |
+| `A3`              | `PB09`       |                   |                      |                      |
+| `A4`              | `PA04`       | `UART2_TX_PIN`    |                      |                      |
+| `A5`              | `PA06`       | `UART2_RX_PIN`    |                      |                      |
+| `A6`              | `PB01`       |                   |                      |                      |
+| `A7`              | `PB04`       | `LIGHTSENSOR`     |                      |                      |
+| `BUTTON_LATCH`    | `PB00`       |                   |                      |                      |
+| `BUTTON_OUT`      | `PB30`       |                   |                      | `TCC4` (channel 0), `TCC0` (channel 6) |
+| `BUTTON_CLK`      | `PB31`       |                   |                      | `TCC4` (channel 1), `TCC0` (channel 7) |
+| `JOYY`            | `PB06`       |                   |                      |                      |
+| `JOYX`            | `PB07`       |                   |                      |                      |
+| `TFT_DC`          | `PB05`       |                   |                      |                      |
+| `TFT_CS`          | `PB12`       |                   |                      | `TCC3` (channel 0), `TCC0` (channel 0) |
+| `TFT_RST`         | `PA00`       |                   |                      |                      |
+| `TFT_LITE`        | `PA01`       |                   |                      |                      |
+| `SPEAKER_ENABLE`  | `PA27`       |                   |                      |                      |
+| `USBCDC_DM_PIN`   | `PA24`       |                   |                      | `TCC2` (channel 2)   |
+| `USBCDC_DP_PIN`   | `PA25`       |                   |                      | `TCC2` (channel 3)   |
+| `SDA_PIN`         | `PA12`       |                   | `I2C0` (SDA)         | `TCC0` (channel 6), `TCC1` (channel 2) |
+| `SCL_PIN`         | `PA13`       |                   | `I2C0` (SCL)         | `TCC0` (channel 7), `TCC1` (channel 3) |
+| `SPI0_SCK_PIN`    | `PA17`       |                   |                      | `TCC1` (channel 1), `TCC0` (channel 5) |
+| `SPI0_SDO_PIN`    | `PB23`       |                   |                      |                      |
+| `SPI0_SDI_PIN`    | `PB22`       |                   |                      |                      |
+| `SPI1_SCK_PIN`    | `PB13`       |                   |                      | `TCC3` (channel 1), `TCC0` (channel 1) |
+| `SPI1_SDO_PIN`    | `PB15`       |                   |                      | `TCC4` (channel 1), `TCC0` (channel 3) |
+| `QSPI_SCK`        | `PB10`       |                   |                      | `TCC0` (channel 4), `TCC1` (channel 0) |
+| `QSPI_CS`         | `PB11`       |                   |                      | `TCC0` (channel 5), `TCC1` (channel 1) |
+| `QSPI_DATA0`      | `PA08`       |                   | `I2C0` (SDA)         | `TCC0` (channel 0), `TCC1` (channel 4) |
+| `QSPI_DATA1`      | `PA09`       |                   | `I2C0` (SCL)         | `TCC0` (channel 1), `TCC1` (channel 5) |
+| `QSPI_DATA2`      | `PA10`       |                   |                      | `TCC0` (channel 2), `TCC1` (channel 6) |
+| `QSPI_DATA3`      | `PA11`       |                   |                      | `TCC0` (channel 3), `TCC1` (channel 7) |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/pyportal.md
+++ b/content/docs/reference/microcontrollers/pyportal.md
@@ -21,55 +21,55 @@ The PyPortal also has an Espressif ESP32 Wi-Fi coprocessor with TLS/SSL support 
 
 ## Pins
 
-| Pin               | Hardware pin | Alternative names | PWM                  |
-| ----------------- | ------------ | ----------------- | -------------------- |
-| `D0`              | `PB13`       | `NINA_RX`, `UART_RX_PIN` | `TCC3` (channel 1), `TCC0` (channel 1) |
-| `D1`              | `PB12`       | `NINA_TX`, `UART_TX_PIN` | `TCC3` (channel 0), `TCC0` (channel 0) |
-| `D2`              | `PB22`       | `NEOPIXEL`, `WS2812` |                      |
-| `D3`              | `PA04`       | `A1`              |                      |
-| `D4`              | `PA05`       | `A3`              |                      |
-| `D5`              | `PB16`       | `NINA_ACK`, `NINA_CTS` | `TCC3` (channel 0), `TCC0` (channel 4) |
-| `D6`              | `PB15`       | `NINA_GPIO0`, `NINA_RTS` | `TCC4` (channel 1), `TCC0` (channel 3) |
-| `D7`              | `PB17`       | `NINA_RESETN`     | `TCC3` (channel 1), `TCC0` (channel 5) |
-| `D8`              | `PB14`       | `NINA_CS`         | `TCC4` (channel 0), `TCC0` (channel 2) |
-| `D9`              | `PB04`       | `TFT_RD`          |                      |
-| `D10`             | `PB05`       | `TFT_DC`          |                      |
-| `D11`             | `PB06`       | `TFT_CS`          |                      |
-| `D12`             | `PB07`       | `TFT_TE`          |                      |
-| `D13`             | `PB23`       | `LED`             |                      |
-| `D24`             | `PA00`       | `TFT_RESET`       |                      |
-| `D25`             | `PB31`       | `TFT_BACKLIGHT`   | `TCC4` (channel 1), `TCC0` (channel 7) |
-| `D26`             | `PB09`       | `TFT_WR`          |                      |
-| `D27`             | `PB02`       | `SDA_PIN`         | `TCC2` (channel 2)   |
-| `D28`             | `PB03`       | `SCL_PIN`         | `TCC2` (channel 3)   |
-| `D29`             | `PA12`       | `SPI0_SDO_PIN`, `NINA_SDO` | `TCC0` (channel 6), `TCC1` (channel 2) |
-| `D30`             | `PA13`       | `SPI0_SCK_PIN`, `NINA_SCK` | `TCC0` (channel 7), `TCC1` (channel 3) |
-| `D31`             | `PA14`       | `SPI0_SDI_PIN`, `NINA_SDI` | `TCC2` (channel 0), `TCC1` (channel 2) |
-| `D32`             | `PB30`       |                   | `TCC4` (channel 0), `TCC0` (channel 6) |
-| `D33`             | `PA01`       |                   |                      |
-| `D34`             | `PA16`       | `LCD_DATA0`       | `TCC1` (channel 0), `TCC0` (channel 4) |
-| `D35`             | `PA17`       |                   | `TCC1` (channel 1), `TCC0` (channel 5) |
-| `D36`             | `PA18`       |                   | `TCC1` (channel 2), `TCC0` (channel 6) |
-| `D37`             | `PA19`       |                   | `TCC1` (channel 3), `TCC0` (channel 7) |
-| `D38`             | `PA20`       |                   | `TCC1` (channel 4), `TCC0` (channel 0) |
-| `D39`             | `PA21`       |                   | `TCC1` (channel 5), `TCC0` (channel 1) |
-| `D40`             | `PA22`       |                   | `TCC1` (channel 6), `TCC0` (channel 2) |
-| `D41`             | `PA23`       |                   | `TCC1` (channel 7), `TCC0` (channel 3) |
-| `D42`             | `PB10`       | `QSPI_SCK`        | `TCC0` (channel 4), `TCC1` (channel 0) |
-| `D43`             | `PB11`       | `QSPI_CS`         | `TCC0` (channel 5), `TCC1` (channel 1) |
-| `D44`             | `PA08`       | `QSPI_DATA0`      | `TCC0` (channel 0), `TCC1` (channel 4) |
-| `D45`             | `PA09`       | `QSPI_DATA1`      | `TCC0` (channel 1), `TCC1` (channel 5) |
-| `D46`             | `PA10`       | `QSPI_DATA2`      | `TCC0` (channel 2), `TCC1` (channel 6) |
-| `D47`             | `PA11`       | `QSPI_DATA3`      | `TCC0` (channel 3), `TCC1` (channel 7) |
-| `D50`             | `PA02`       | `SPK_SD`, `A0`, `AUDIO_OUT` |                      |
-| `D51`             | `PA15`       |                   | `TCC2` (channel 1), `TCC1` (channel 3) |
-| `A2`              | `PA07`       | `LIGHT`           |                      |
-| `A4`              | `PB00`       | `TOUCH_YD`        |                      |
-| `A5`              | `PB01`       | `TOUCH_XL`        |                      |
-| `A6`              | `PA06`       | `TOUCH_YU`        |                      |
-| `A7`              | `PB08`       | `TOUCH_XR`        |                      |
-| `USBCDC_DM_PIN`   | `PA24`       |                   | `TCC2` (channel 2)   |
-| `USBCDC_DP_PIN`   | `PA25`       |                   | `TCC2` (channel 3)   |
+| Pin               | Hardware pin | Alternative names | I2C                  | PWM                  |
+| ----------------- | ------------ | ----------------- | -------------------- | -------------------- |
+| `D0`              | `PB13`       | `NINA_RX`, `UART_RX_PIN` |                      | `TCC3` (channel 1), `TCC0` (channel 1) |
+| `D1`              | `PB12`       | `NINA_TX`, `UART_TX_PIN` |                      | `TCC3` (channel 0), `TCC0` (channel 0) |
+| `D2`              | `PB22`       | `NEOPIXEL`, `WS2812` |                      |                      |
+| `D3`              | `PA04`       | `A1`              |                      |                      |
+| `D4`              | `PA05`       | `A3`              |                      |                      |
+| `D5`              | `PB16`       | `NINA_ACK`, `NINA_CTS` |                      | `TCC3` (channel 0), `TCC0` (channel 4) |
+| `D6`              | `PB15`       | `NINA_GPIO0`, `NINA_RTS` |                      | `TCC4` (channel 1), `TCC0` (channel 3) |
+| `D7`              | `PB17`       | `NINA_RESETN`     |                      | `TCC3` (channel 1), `TCC0` (channel 5) |
+| `D8`              | `PB14`       | `NINA_CS`         |                      | `TCC4` (channel 0), `TCC0` (channel 2) |
+| `D9`              | `PB04`       | `TFT_RD`          |                      |                      |
+| `D10`             | `PB05`       | `TFT_DC`          |                      |                      |
+| `D11`             | `PB06`       | `TFT_CS`          |                      |                      |
+| `D12`             | `PB07`       | `TFT_TE`          |                      |                      |
+| `D13`             | `PB23`       | `LED`             |                      |                      |
+| `D24`             | `PA00`       | `TFT_RESET`       |                      |                      |
+| `D25`             | `PB31`       | `TFT_BACKLIGHT`   |                      | `TCC4` (channel 1), `TCC0` (channel 7) |
+| `D26`             | `PB09`       | `TFT_WR`          |                      |                      |
+| `D27`             | `PB02`       | `SDA_PIN`         |                      | `TCC2` (channel 2)   |
+| `D28`             | `PB03`       | `SCL_PIN`         |                      | `TCC2` (channel 3)   |
+| `D29`             | `PA12`       | `SPI0_SDO_PIN`, `NINA_SDO` |                      | `TCC0` (channel 6), `TCC1` (channel 2) |
+| `D30`             | `PA13`       | `SPI0_SCK_PIN`, `NINA_SCK` |                      | `TCC0` (channel 7), `TCC1` (channel 3) |
+| `D31`             | `PA14`       | `SPI0_SDI_PIN`, `NINA_SDI` |                      | `TCC2` (channel 0), `TCC1` (channel 2) |
+| `D32`             | `PB30`       |                   |                      | `TCC4` (channel 0), `TCC0` (channel 6) |
+| `D33`             | `PA01`       |                   |                      |                      |
+| `D34`             | `PA16`       | `LCD_DATA0`       |                      | `TCC1` (channel 0), `TCC0` (channel 4) |
+| `D35`             | `PA17`       |                   |                      | `TCC1` (channel 1), `TCC0` (channel 5) |
+| `D36`             | `PA18`       |                   |                      | `TCC1` (channel 2), `TCC0` (channel 6) |
+| `D37`             | `PA19`       |                   |                      | `TCC1` (channel 3), `TCC0` (channel 7) |
+| `D38`             | `PA20`       |                   |                      | `TCC1` (channel 4), `TCC0` (channel 0) |
+| `D39`             | `PA21`       |                   |                      | `TCC1` (channel 5), `TCC0` (channel 1) |
+| `D40`             | `PA22`       |                   | `I2C0` (SDA)         | `TCC1` (channel 6), `TCC0` (channel 2) |
+| `D41`             | `PA23`       |                   | `I2C0` (SCL)         | `TCC1` (channel 7), `TCC0` (channel 3) |
+| `D42`             | `PB10`       | `QSPI_SCK`        |                      | `TCC0` (channel 4), `TCC1` (channel 0) |
+| `D43`             | `PB11`       | `QSPI_CS`         |                      | `TCC0` (channel 5), `TCC1` (channel 1) |
+| `D44`             | `PA08`       | `QSPI_DATA0`      |                      | `TCC0` (channel 0), `TCC1` (channel 4) |
+| `D45`             | `PA09`       | `QSPI_DATA1`      |                      | `TCC0` (channel 1), `TCC1` (channel 5) |
+| `D46`             | `PA10`       | `QSPI_DATA2`      |                      | `TCC0` (channel 2), `TCC1` (channel 6) |
+| `D47`             | `PA11`       | `QSPI_DATA3`      |                      | `TCC0` (channel 3), `TCC1` (channel 7) |
+| `D50`             | `PA02`       | `SPK_SD`, `A0`, `AUDIO_OUT` |                      |                      |
+| `D51`             | `PA15`       |                   |                      | `TCC2` (channel 1), `TCC1` (channel 3) |
+| `A2`              | `PA07`       | `LIGHT`           |                      |                      |
+| `A4`              | `PB00`       | `TOUCH_YD`        |                      |                      |
+| `A5`              | `PB01`       | `TOUCH_XL`        |                      |                      |
+| `A6`              | `PA06`       | `TOUCH_YU`        |                      |                      |
+| `A7`              | `PB08`       | `TOUCH_XR`        |                      |                      |
+| `USBCDC_DM_PIN`   | `PA24`       |                   |                      | `TCC2` (channel 2)   |
+| `USBCDC_DP_PIN`   | `PA25`       |                   |                      | `TCC2` (channel 3)   |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/qtpy-rp2040.md
+++ b/content/docs/reference/microcontrollers/qtpy-rp2040.md
@@ -19,23 +19,23 @@ The [Adafruit QT Py RP2040](https://www.adafruit.com/product/4900) is a tiny dev
 
 ## Pins
 
-| Pin               | Hardware pin | Alternative names | PWM                  |
-| ----------------- | ------------ | ----------------- | -------------------- |
-| `SDA`             | `GPIO24`     | `I2C0_SDA_PIN`, `SDA_PIN`, `SPI1_SDI_PIN` | `PWM4` (channel A)   |
-| `SCL`             | `GPIO25`     | `I2C0_SCL_PIN`, `SCL_PIN`, `SPI1_CS` | `PWM4` (channel B)   |
-| `TX`              | `GPIO20`     | `UART1_TX_PIN`    | `PWM2` (channel A)   |
-| `MO`              | `GPIO3`      | `MOSI`, `SPI0_SDO_PIN` | `PWM1` (channel B)   |
-| `MI`              | `GPIO4`      | `MISO`, `SPI0_SDI_PIN` | `PWM2` (channel A)   |
-| `SCK`             | `GPIO6`      | `SPI0_SCK_PIN`    | `PWM3` (channel A)   |
-| `RX`              | `GPIO5`      | `SPI0_CS`, `UART1_RX_PIN` | `PWM2` (channel B)   |
-| `QT_SCL1`         | `GPIO23`     | `I2C1_QT_SCL_PIN` | `PWM3` (channel B)   |
-| `QT_SDA1`         | `GPIO22`     | `I2C1_QT_SDA_PIN` | `PWM3` (channel A)   |
-| `A0`              | `GPIO29`     | `UART0_RX_PIN`, `UART_RX_PIN`, `ADC3` | `PWM6` (channel B)   |
-| `A1`              | `GPIO28`     | `UART0_TX_PIN`, `UART_TX_PIN`, `ADC2` | `PWM6` (channel A)   |
-| `A2`              | `GPIO27`     | `I2C1_SCL_PIN`, `SPI1_SDO_PIN`, `ADC1` | `PWM5` (channel B)   |
-| `A3`              | `GPIO26`     | `I2C1_SDA_PIN`, `SPI1_SCK_PIN`, `ADC0` | `PWM5` (channel A)   |
-| `NEOPIXEL`        | `GPIO12`     | `WS2812`          | `PWM6` (channel A)   |
-| `NEOPIXEL_POWER`  | `GPIO11`     |                   | `PWM5` (channel B)   |
+| Pin               | Hardware pin | Alternative names | I2C                  | PWM                  |
+| ----------------- | ------------ | ----------------- | -------------------- | -------------------- |
+| `SDA`             | `GPIO24`     | `I2C0_SDA_PIN`, `SDA_PIN`, `SPI1_SDI_PIN` |                      | `PWM4` (channel A)   |
+| `SCL`             | `GPIO25`     | `I2C0_SCL_PIN`, `SCL_PIN`, `SPI1_CS` |                      | `PWM4` (channel B)   |
+| `TX`              | `GPIO20`     | `UART1_TX_PIN`    | `I2C0` (SDA)         | `PWM2` (channel A)   |
+| `MO`              | `GPIO3`      | `MOSI`, `SPI0_SDO_PIN` | `I2C1` (SCL)         | `PWM1` (channel B)   |
+| `MI`              | `GPIO4`      | `MISO`, `SPI0_SDI_PIN` | `I2C0` (SDA)         | `PWM2` (channel A)   |
+| `SCK`             | `GPIO6`      | `SPI0_SCK_PIN`    | `I2C1` (SDA)         | `PWM3` (channel A)   |
+| `RX`              | `GPIO5`      | `SPI0_CS`, `UART1_RX_PIN` | `I2C0` (SCL)         | `PWM2` (channel B)   |
+| `QT_SCL1`         | `GPIO23`     | `I2C1_QT_SCL_PIN` |                      | `PWM3` (channel B)   |
+| `QT_SDA1`         | `GPIO22`     | `I2C1_QT_SDA_PIN` |                      | `PWM3` (channel A)   |
+| `A0`              | `GPIO29`     | `UART0_RX_PIN`, `UART_RX_PIN`, `ADC3` |                      | `PWM6` (channel B)   |
+| `A1`              | `GPIO28`     | `UART0_TX_PIN`, `UART_TX_PIN`, `ADC2` |                      | `PWM6` (channel A)   |
+| `A2`              | `GPIO27`     | `I2C1_SCL_PIN`, `SPI1_SDO_PIN`, `ADC1` | `I2C1` (SCL)         | `PWM5` (channel B)   |
+| `A3`              | `GPIO26`     | `I2C1_SDA_PIN`, `SPI1_SCK_PIN`, `ADC0` | `I2C1` (SDA)         | `PWM5` (channel A)   |
+| `NEOPIXEL`        | `GPIO12`     | `WS2812`          | `I2C0` (SDA)         | `PWM6` (channel A)   |
+| `NEOPIXEL_POWER`  | `GPIO11`     |                   | `I2C1` (SCL)         | `PWM5` (channel B)   |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/qtpy.md
+++ b/content/docs/reference/microcontrollers/qtpy.md
@@ -19,28 +19,28 @@ The [Adafruit QtPy](https://www.adafruit.com/product/4600) is a tiny ARM develop
 
 ## Pins
 
-| Pin               | Hardware pin | Alternative names | PWM                  |
-| ----------------- | ------------ | ----------------- | -------------------- |
-| `D0`              | `PA02`       | `A0`              |                      |
-| `D1`              | `PA03`       | `A1`              |                      |
-| `D2`              | `PA04`       | `A2`              | `TCC0` (channel 0)   |
-| `D3`              | `PA05`       | `A3`              | `TCC0` (channel 1)   |
-| `D4`              | `PA16`       | `A4`, `SDA_PIN`   | `TCC2` (channel 0), `TCC0` (channel 2) |
-| `D5`              | `PA17`       | `SCL_PIN`         | `TCC2` (channel 1), `TCC0` (channel 3) |
-| `D6`              | `PA06`       | `UART_TX_PIN`     | `TCC1` (channel 0)   |
-| `D7`              | `PA07`       | `UART_RX_PIN`     | `TCC1` (channel 1)   |
-| `D8`              | `PA11`       | `SPI0_SCK_PIN`    | `TCC1` (channel 1), `TCC0` (channel 3) |
-| `D9`              | `PA09`       | `SPI0_SDI_PIN`    | `TCC0` (channel 1), `TCC1` (channel 3) |
-| `D10`             | `PA10`       | `SPI0_SDO_PIN`, `I2S_SCK_PIN` | `TCC1` (channel 0), `TCC0` (channel 2) |
-| `D11`             | `PA18`       | `NEOPIXELS`, `WS2812` | `TCC0` (channel 2)   |
-| `D12`             | `PA15`       | `NEOPIXELS_POWER` | `TCC0` (channel 1)   |
-| `D13`             | `PA27`       |                   |                      |
-| `D14`             | `PA23`       |                   | `TCC0` (channel 1)   |
-| `D15`             | `PA19`       |                   | `TCC0` (channel 3)   |
-| `D16`             | `PA22`       |                   | `TCC0` (channel 0)   |
-| `D17`             | `PA08`       | `I2S_SDO_PIN`     | `TCC0` (channel 0), `TCC1` (channel 2) |
-| `USBCDC_DM_PIN`   | `PA24`       |                   | `TCC1` (channel 2)   |
-| `USBCDC_DP_PIN`   | `PA25`       |                   | `TCC1` (channel 3)   |
+| Pin               | Hardware pin | Alternative names | I2C                  | PWM                  |
+| ----------------- | ------------ | ----------------- | -------------------- | -------------------- |
+| `D0`              | `PA02`       | `A0`              |                      |                      |
+| `D1`              | `PA03`       | `A1`              |                      |                      |
+| `D2`              | `PA04`       | `A2`              |                      | `TCC0` (channel 0)   |
+| `D3`              | `PA05`       | `A3`              |                      | `TCC0` (channel 1)   |
+| `D4`              | `PA16`       | `A4`, `SDA_PIN`   | `I2C0` (SDA)         | `TCC2` (channel 0), `TCC0` (channel 2) |
+| `D5`              | `PA17`       | `SCL_PIN`         | `I2C0` (SCL)         | `TCC2` (channel 1), `TCC0` (channel 3) |
+| `D6`              | `PA06`       | `UART_TX_PIN`     |                      | `TCC1` (channel 0)   |
+| `D7`              | `PA07`       | `UART_RX_PIN`     |                      | `TCC1` (channel 1)   |
+| `D8`              | `PA11`       | `SPI0_SCK_PIN`    |                      | `TCC1` (channel 1), `TCC0` (channel 3) |
+| `D9`              | `PA09`       | `SPI0_SDI_PIN`    |                      | `TCC0` (channel 1), `TCC1` (channel 3) |
+| `D10`             | `PA10`       | `SPI0_SDO_PIN`, `I2S_SCK_PIN` |                      | `TCC1` (channel 0), `TCC0` (channel 2) |
+| `D11`             | `PA18`       | `NEOPIXELS`, `WS2812` |                      | `TCC0` (channel 2)   |
+| `D12`             | `PA15`       | `NEOPIXELS_POWER` |                      | `TCC0` (channel 1)   |
+| `D13`             | `PA27`       |                   |                      |                      |
+| `D14`             | `PA23`       |                   |                      | `TCC0` (channel 1)   |
+| `D15`             | `PA19`       |                   |                      | `TCC0` (channel 3)   |
+| `D16`             | `PA22`       |                   |                      | `TCC0` (channel 0)   |
+| `D17`             | `PA08`       | `I2S_SDO_PIN`     |                      | `TCC0` (channel 0), `TCC1` (channel 2) |
+| `USBCDC_DM_PIN`   | `PA24`       |                   |                      | `TCC1` (channel 2)   |
+| `USBCDC_DP_PIN`   | `PA25`       |                   |                      | `TCC1` (channel 3)   |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/thingplus-rp2040.md
+++ b/content/docs/reference/microcontrollers/thingplus-rp2040.md
@@ -23,35 +23,35 @@ Peripherals:
 
 ## Pins
 
-| Pin               | Hardware pin | Alternative names | PWM                  |
-| ----------------- | ------------ | ----------------- | -------------------- |
-| `GP0`             | `GPIO0`      | `UART0_TX_PIN`, `UART_TX_PIN` | `PWM0` (channel A)   |
-| `GP1`             | `GPIO1`      | `UART0_RX_PIN`, `UART_RX_PIN` | `PWM0` (channel B)   |
-| `GP2`             | `GPIO2`      | `SPI0_SCK_PIN`    | `PWM1` (channel A)   |
-| `GP3`             | `GPIO3`      | `SPI0_SDO_PIN`    | `PWM1` (channel B)   |
-| `GP4`             | `GPIO4`      | `SPI0_SDI_PIN`    | `PWM2` (channel A)   |
-| `GP6`             | `GPIO6`      | `I2C0_SCL_PIN`, `I2C1_SDA_PIN`, `SDA_PIN` | `PWM3` (channel A)   |
-| `GP7`             | `GPIO7`      | `I2C0_SDA_PIN`, `I2C1_SCL_PIN`, `SCL_PIN` | `PWM3` (channel B)   |
-| `GP8`             | `GPIO8`      | `WS2812`          | `PWM4` (channel A)   |
-| `GP9`             | `GPIO9`      |                   | `PWM4` (channel B)   |
-| `GP10`            | `GPIO10`     |                   | `PWM5` (channel A)   |
-| `GP11`            | `GPIO11`     |                   | `PWM5` (channel B)   |
-| `GP12`            | `GPIO12`     | `SPI1_SDI_PIN`    | `PWM6` (channel A)   |
-| `GP14`            | `GPIO14`     | `SPI1_SCK_PIN`    | `PWM7` (channel A)   |
-| `GP15`            | `GPIO15`     | `SPI1_SDO_PIN`    | `PWM7` (channel B)   |
-| `GP16`            | `GPIO16`     |                   | `PWM0` (channel A)   |
-| `GP17`            | `GPIO17`     |                   | `PWM0` (channel B)   |
-| `GP18`            | `GPIO18`     |                   | `PWM1` (channel A)   |
-| `GP19`            | `GPIO19`     |                   | `PWM1` (channel B)   |
-| `GP20`            | `GPIO20`     |                   | `PWM2` (channel A)   |
-| `GP21`            | `GPIO21`     |                   | `PWM2` (channel B)   |
-| `GP22`            | `GPIO22`     |                   | `PWM3` (channel A)   |
-| `GP23`            | `GPIO23`     |                   | `PWM3` (channel B)   |
-| `GP25`            | `GPIO25`     | `LED`             | `PWM4` (channel B)   |
-| `GP26`            | `GPIO26`     | `A0`, `ADC0`      | `PWM5` (channel A)   |
-| `GP27`            | `GPIO27`     | `A1`, `ADC1`      | `PWM5` (channel B)   |
-| `GP28`            | `GPIO28`     | `A2`, `ADC2`      | `PWM6` (channel A)   |
-| `GP29`            | `GPIO29`     | `A3`, `ADC3`      | `PWM6` (channel B)   |
+| Pin               | Hardware pin | Alternative names | I2C                  | PWM                  |
+| ----------------- | ------------ | ----------------- | -------------------- | -------------------- |
+| `GP0`             | `GPIO0`      | `UART0_TX_PIN`, `UART_TX_PIN` | `I2C0` (SDA)         | `PWM0` (channel A)   |
+| `GP1`             | `GPIO1`      | `UART0_RX_PIN`, `UART_RX_PIN` | `I2C0` (SCL)         | `PWM0` (channel B)   |
+| `GP2`             | `GPIO2`      | `SPI0_SCK_PIN`    | `I2C1` (SDA)         | `PWM1` (channel A)   |
+| `GP3`             | `GPIO3`      | `SPI0_SDO_PIN`    | `I2C1` (SCL)         | `PWM1` (channel B)   |
+| `GP4`             | `GPIO4`      | `SPI0_SDI_PIN`    | `I2C0` (SDA)         | `PWM2` (channel A)   |
+| `GP6`             | `GPIO6`      | `I2C0_SCL_PIN`, `I2C1_SDA_PIN`, `SDA_PIN` | `I2C1` (SDA)         | `PWM3` (channel A)   |
+| `GP7`             | `GPIO7`      | `I2C0_SDA_PIN`, `I2C1_SCL_PIN`, `SCL_PIN` | `I2C1` (SCL)         | `PWM3` (channel B)   |
+| `GP8`             | `GPIO8`      | `WS2812`          | `I2C0` (SDA)         | `PWM4` (channel A)   |
+| `GP9`             | `GPIO9`      |                   | `I2C0` (SCL)         | `PWM4` (channel B)   |
+| `GP10`            | `GPIO10`     |                   | `I2C1` (SDA)         | `PWM5` (channel A)   |
+| `GP11`            | `GPIO11`     |                   | `I2C1` (SCL)         | `PWM5` (channel B)   |
+| `GP12`            | `GPIO12`     | `SPI1_SDI_PIN`    | `I2C0` (SDA)         | `PWM6` (channel A)   |
+| `GP14`            | `GPIO14`     | `SPI1_SCK_PIN`    | `I2C1` (SDA)         | `PWM7` (channel A)   |
+| `GP15`            | `GPIO15`     | `SPI1_SDO_PIN`    | `I2C1` (SCL)         | `PWM7` (channel B)   |
+| `GP16`            | `GPIO16`     |                   | `I2C0` (SDA)         | `PWM0` (channel A)   |
+| `GP17`            | `GPIO17`     |                   | `I2C0` (SCL)         | `PWM0` (channel B)   |
+| `GP18`            | `GPIO18`     |                   | `I2C1` (SDA)         | `PWM1` (channel A)   |
+| `GP19`            | `GPIO19`     |                   | `I2C1` (SCL)         | `PWM1` (channel B)   |
+| `GP20`            | `GPIO20`     |                   | `I2C0` (SDA)         | `PWM2` (channel A)   |
+| `GP21`            | `GPIO21`     |                   | `I2C0` (SCL)         | `PWM2` (channel B)   |
+| `GP22`            | `GPIO22`     |                   |                      | `PWM3` (channel A)   |
+| `GP23`            | `GPIO23`     |                   |                      | `PWM3` (channel B)   |
+| `GP25`            | `GPIO25`     | `LED`             |                      | `PWM4` (channel B)   |
+| `GP26`            | `GPIO26`     | `A0`, `ADC0`      | `I2C1` (SDA)         | `PWM5` (channel A)   |
+| `GP27`            | `GPIO27`     | `A1`, `ADC1`      | `I2C1` (SCL)         | `PWM5` (channel B)   |
+| `GP28`            | `GPIO28`     | `A2`, `ADC2`      |                      | `PWM6` (channel A)   |
+| `GP29`            | `GPIO29`     | `A3`, `ADC3`      |                      | `PWM6` (channel B)   |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/trinket-m0.md
+++ b/content/docs/reference/microcontrollers/trinket-m0.md
@@ -19,16 +19,16 @@ The [Adafruit Trinket M0](https://www.adafruit.com/product/3500) is a tiny ARM d
 
 ## Pins
 
-| Pin               | Hardware pin | Alternative names | PWM                  |
-| ----------------- | ------------ | ----------------- | -------------------- |
-| `D0`              | `PA08`       | `A2`, `SDA_PIN`, `I2S_SDO_PIN` | `TCC0` (channel 0), `TCC1` (channel 2) |
-| `D1`              | `PA02`       | `A0`              |                      |
-| `D2`              | `PA09`       | `A1`, `SPI0_SDI_PIN`, `SCL_PIN` | `TCC0` (channel 1), `TCC1` (channel 3) |
-| `D3`              | `PA07`       | `A3`, `UART_RX_PIN`, `SPI0_SCK_PIN` | `TCC1` (channel 1)   |
-| `D4`              | `PA06`       | `A4`, `UART_TX_PIN`, `SPI0_SDO_PIN` | `TCC1` (channel 0)   |
-| `D13`             | `PA10`       | `LED`, `I2S_SCK_PIN` | `TCC1` (channel 0), `TCC0` (channel 2) |
-| `USBCDC_DM_PIN`   | `PA24`       |                   | `TCC1` (channel 2)   |
-| `USBCDC_DP_PIN`   | `PA25`       |                   | `TCC1` (channel 3)   |
+| Pin               | Hardware pin | Alternative names | I2C                  | PWM                  |
+| ----------------- | ------------ | ----------------- | -------------------- | -------------------- |
+| `D0`              | `PA08`       | `A2`, `SDA_PIN`, `I2S_SDO_PIN` | `I2C0` (SDA)         | `TCC0` (channel 0), `TCC1` (channel 2) |
+| `D1`              | `PA02`       | `A0`              |                      |                      |
+| `D2`              | `PA09`       | `A1`, `SPI0_SDI_PIN`, `SCL_PIN` | `I2C0` (SCL)         | `TCC0` (channel 1), `TCC1` (channel 3) |
+| `D3`              | `PA07`       | `A3`, `UART_RX_PIN`, `SPI0_SCK_PIN` |                      | `TCC1` (channel 1)   |
+| `D4`              | `PA06`       | `A4`, `UART_TX_PIN`, `SPI0_SDO_PIN` |                      | `TCC1` (channel 0)   |
+| `D13`             | `PA10`       | `LED`, `I2S_SCK_PIN` |                      | `TCC1` (channel 0), `TCC0` (channel 2) |
+| `USBCDC_DM_PIN`   | `PA24`       |                   |                      | `TCC1` (channel 2)   |
+| `USBCDC_DP_PIN`   | `PA25`       |                   |                      | `TCC1` (channel 3)   |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/trinkey-qt2040.md
+++ b/content/docs/reference/microcontrollers/trinkey-qt2040.md
@@ -19,14 +19,14 @@ The [Adafruit Trinkey QT2040](https://www.adafruit.com/product/5056) is a tiny d
 
 ## Pins
 
-| Pin               | Hardware pin | Alternative names | PWM                  |
-| ----------------- | ------------ | ----------------- | -------------------- |
-| `NEOPIXEL`        | `GPIO27`     | `WS2812`, `ADC1`  | `PWM5` (channel B)   |
-| `I2C0_SDA_PIN`    | `GPIO16`     |                   | `PWM0` (channel A)   |
-| `I2C0_SCL_PIN`    | `GPIO17`     |                   | `PWM0` (channel B)   |
-| `ADC0`            | `GPIO26`     |                   | `PWM5` (channel A)   |
-| `ADC2`            | `GPIO28`     |                   | `PWM6` (channel A)   |
-| `ADC3`            | `GPIO29`     |                   | `PWM6` (channel B)   |
+| Pin               | Hardware pin | Alternative names | I2C                  | PWM                  |
+| ----------------- | ------------ | ----------------- | -------------------- | -------------------- |
+| `NEOPIXEL`        | `GPIO27`     | `WS2812`, `ADC1`  | `I2C1` (SCL)         | `PWM5` (channel B)   |
+| `I2C0_SDA_PIN`    | `GPIO16`     |                   | `I2C0` (SDA)         | `PWM0` (channel A)   |
+| `I2C0_SCL_PIN`    | `GPIO17`     |                   | `I2C0` (SCL)         | `PWM0` (channel B)   |
+| `ADC0`            | `GPIO26`     |                   | `I2C1` (SDA)         | `PWM5` (channel A)   |
+| `ADC2`            | `GPIO28`     |                   |                      | `PWM6` (channel A)   |
+| `ADC3`            | `GPIO29`     |                   |                      | `PWM6` (channel B)   |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/tufty2040.md
+++ b/content/docs/reference/microcontrollers/tufty2040.md
@@ -19,37 +19,37 @@ The [Pimoroni Tufty2040](https://shop.pimoroni.com/products/tufty-2040) is a tin
 
 ## Pins
 
-| Pin               | Hardware pin | Alternative names | PWM                  |
-| ----------------- | ------------ | ----------------- | -------------------- |
-| `LED`             | `GPIO25`     | `USER_LED`        | `PWM4` (channel B)   |
-| `BUTTON_A`        | `GPIO7`      |                   | `PWM3` (channel B)   |
-| `BUTTON_B`        | `GPIO8`      |                   | `PWM4` (channel A)   |
-| `BUTTON_C`        | `GPIO9`      |                   | `PWM4` (channel B)   |
-| `BUTTON_UP`       | `GPIO22`     |                   | `PWM3` (channel A)   |
-| `BUTTON_DOWN`     | `GPIO6`      |                   | `PWM3` (channel A)   |
-| `BUTTON_USER`     | `GPIO23`     |                   | `PWM3` (channel B)   |
-| `LCD_BACKLIGHT`   | `GPIO2`      |                   | `PWM1` (channel A)   |
-| `LCD_CS`          | `GPIO10`     |                   | `PWM5` (channel A)   |
-| `LCD_DC`          | `GPIO11`     |                   | `PWM5` (channel B)   |
-| `LCD_WR`          | `GPIO12`     |                   | `PWM6` (channel A)   |
-| `LCD_RD`          | `GPIO13`     |                   | `PWM6` (channel B)   |
-| `LCD_DB0`         | `GPIO14`     |                   | `PWM7` (channel A)   |
-| `LCD_DB1`         | `GPIO15`     |                   | `PWM7` (channel B)   |
-| `LCD_DB2`         | `GPIO16`     |                   | `PWM0` (channel A)   |
-| `LCD_DB3`         | `GPIO17`     |                   | `PWM0` (channel B)   |
-| `LCD_DB4`         | `GPIO18`     |                   | `PWM1` (channel A)   |
-| `LCD_DB5`         | `GPIO19`     |                   | `PWM1` (channel B)   |
-| `LCD_DB6`         | `GPIO20`     |                   | `PWM2` (channel A)   |
-| `LCD_DB7`         | `GPIO21`     |                   | `PWM2` (channel B)   |
-| `VBUS_DETECT`     | `GPIO24`     |                   | `PWM4` (channel A)   |
-| `BATTERY`         | `GPIO29`     | `ADC3`            | `PWM6` (channel B)   |
-| `LIGHT_SENSE`     | `GPIO26`     | `ADC0`            | `PWM5` (channel A)   |
-| `SENSOR_POWER`    | `GPIO27`     | `ADC1`            | `PWM5` (channel B)   |
-| `I2C0_SDA_PIN`    | `GPIO4`      |                   | `PWM2` (channel A)   |
-| `I2C0_SCL_PIN`    | `GPIO5`      |                   | `PWM2` (channel B)   |
-| `UART0_TX_PIN`    | `GPIO0`      | `UART_TX_PIN`     | `PWM0` (channel A)   |
-| `UART0_RX_PIN`    | `GPIO1`      | `UART_RX_PIN`     | `PWM0` (channel B)   |
-| `ADC2`            | `GPIO28`     |                   | `PWM6` (channel A)   |
+| Pin               | Hardware pin | Alternative names | I2C                  | PWM                  |
+| ----------------- | ------------ | ----------------- | -------------------- | -------------------- |
+| `LED`             | `GPIO25`     | `USER_LED`        |                      | `PWM4` (channel B)   |
+| `BUTTON_A`        | `GPIO7`      |                   | `I2C1` (SCL)         | `PWM3` (channel B)   |
+| `BUTTON_B`        | `GPIO8`      |                   | `I2C0` (SDA)         | `PWM4` (channel A)   |
+| `BUTTON_C`        | `GPIO9`      |                   | `I2C0` (SCL)         | `PWM4` (channel B)   |
+| `BUTTON_UP`       | `GPIO22`     |                   |                      | `PWM3` (channel A)   |
+| `BUTTON_DOWN`     | `GPIO6`      |                   | `I2C1` (SDA)         | `PWM3` (channel A)   |
+| `BUTTON_USER`     | `GPIO23`     |                   |                      | `PWM3` (channel B)   |
+| `LCD_BACKLIGHT`   | `GPIO2`      |                   | `I2C1` (SDA)         | `PWM1` (channel A)   |
+| `LCD_CS`          | `GPIO10`     |                   | `I2C1` (SDA)         | `PWM5` (channel A)   |
+| `LCD_DC`          | `GPIO11`     |                   | `I2C1` (SCL)         | `PWM5` (channel B)   |
+| `LCD_WR`          | `GPIO12`     |                   | `I2C0` (SDA)         | `PWM6` (channel A)   |
+| `LCD_RD`          | `GPIO13`     |                   | `I2C0` (SCL)         | `PWM6` (channel B)   |
+| `LCD_DB0`         | `GPIO14`     |                   | `I2C1` (SDA)         | `PWM7` (channel A)   |
+| `LCD_DB1`         | `GPIO15`     |                   | `I2C1` (SCL)         | `PWM7` (channel B)   |
+| `LCD_DB2`         | `GPIO16`     |                   | `I2C0` (SDA)         | `PWM0` (channel A)   |
+| `LCD_DB3`         | `GPIO17`     |                   | `I2C0` (SCL)         | `PWM0` (channel B)   |
+| `LCD_DB4`         | `GPIO18`     |                   | `I2C1` (SDA)         | `PWM1` (channel A)   |
+| `LCD_DB5`         | `GPIO19`     |                   | `I2C1` (SCL)         | `PWM1` (channel B)   |
+| `LCD_DB6`         | `GPIO20`     |                   | `I2C0` (SDA)         | `PWM2` (channel A)   |
+| `LCD_DB7`         | `GPIO21`     |                   | `I2C0` (SCL)         | `PWM2` (channel B)   |
+| `VBUS_DETECT`     | `GPIO24`     |                   |                      | `PWM4` (channel A)   |
+| `BATTERY`         | `GPIO29`     | `ADC3`            |                      | `PWM6` (channel B)   |
+| `LIGHT_SENSE`     | `GPIO26`     | `ADC0`            | `I2C1` (SDA)         | `PWM5` (channel A)   |
+| `SENSOR_POWER`    | `GPIO27`     | `ADC1`            | `I2C1` (SCL)         | `PWM5` (channel B)   |
+| `I2C0_SDA_PIN`    | `GPIO4`      |                   | `I2C0` (SDA)         | `PWM2` (channel A)   |
+| `I2C0_SCL_PIN`    | `GPIO5`      |                   | `I2C0` (SCL)         | `PWM2` (channel B)   |
+| `UART0_TX_PIN`    | `GPIO0`      | `UART_TX_PIN`     | `I2C0` (SDA)         | `PWM0` (channel A)   |
+| `UART0_RX_PIN`    | `GPIO1`      | `UART_RX_PIN`     | `I2C0` (SCL)         | `PWM0` (channel B)   |
+| `ADC2`            | `GPIO28`     |                   |                      | `PWM6` (channel A)   |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/waveshare-rp2040-zero.md
+++ b/content/docs/reference/microcontrollers/waveshare-rp2040-zero.md
@@ -19,38 +19,38 @@ The [Waveshare RP2040-Zero](https://www.waveshare.com/wiki/RP2040-Zero) is a tin
 
 ## Pins
 
-| Pin               | Hardware pin | Alternative names | PWM                  |
-| ----------------- | ------------ | ----------------- | -------------------- |
-| `D0`              | `GPIO0`      | `I2C0_SDA_PIN`, `UART0_TX_PIN`, `UART_TX_PIN` | `PWM0` (channel A)   |
-| `D1`              | `GPIO1`      | `I2C0_SCL_PIN`, `UART0_RX_PIN`, `UART_RX_PIN` | `PWM0` (channel B)   |
-| `D2`              | `GPIO2`      | `I2C1_SDA_PIN`    | `PWM1` (channel A)   |
-| `D3`              | `GPIO3`      | `I2C1_SCL_PIN`, `SPI0_SDO_PIN` | `PWM1` (channel B)   |
-| `D4`              | `GPIO4`      | `SPI0_SDI_PIN`    | `PWM2` (channel A)   |
-| `D5`              | `GPIO5`      |                   | `PWM2` (channel B)   |
-| `D6`              | `GPIO6`      | `SPI0_SCK_PIN`    | `PWM3` (channel A)   |
-| `D7`              | `GPIO7`      |                   | `PWM3` (channel B)   |
-| `D8`              | `GPIO8`      | `UART1_TX_PIN`    | `PWM4` (channel A)   |
-| `D9`              | `GPIO9`      | `UART1_RX_PIN`    | `PWM4` (channel B)   |
-| `D10`             | `GPIO10`     | `SPI1_SCK_PIN`    | `PWM5` (channel A)   |
-| `D11`             | `GPIO11`     | `SPI1_SDO_PIN`    | `PWM5` (channel B)   |
-| `D12`             | `GPIO12`     | `SPI1_SDI_PIN`    | `PWM6` (channel A)   |
-| `D13`             | `GPIO13`     |                   | `PWM6` (channel B)   |
-| `D14`             | `GPIO14`     |                   | `PWM7` (channel A)   |
-| `D15`             | `GPIO15`     |                   | `PWM7` (channel B)   |
-| `D16`             | `GPIO16`     | `NEOPIXEL`, `WS2812` | `PWM0` (channel A)   |
-| `D17`             | `GPIO17`     |                   | `PWM0` (channel B)   |
-| `D18`             | `GPIO18`     |                   | `PWM1` (channel A)   |
-| `D19`             | `GPIO19`     |                   | `PWM1` (channel B)   |
-| `D20`             | `GPIO20`     |                   | `PWM2` (channel A)   |
-| `D21`             | `GPIO21`     |                   | `PWM2` (channel B)   |
-| `D22`             | `GPIO22`     |                   | `PWM3` (channel A)   |
-| `D23`             | `GPIO23`     |                   | `PWM3` (channel B)   |
-| `D24`             | `GPIO24`     |                   | `PWM4` (channel A)   |
-| `D25`             | `GPIO25`     |                   | `PWM4` (channel B)   |
-| `D26`             | `GPIO26`     | `A0`, `ADC0`      | `PWM5` (channel A)   |
-| `D27`             | `GPIO27`     | `A1`, `ADC1`      | `PWM5` (channel B)   |
-| `D28`             | `GPIO28`     | `A2`, `ADC2`      | `PWM6` (channel A)   |
-| `D29`             | `GPIO29`     | `A3`, `ADC3`      | `PWM6` (channel B)   |
+| Pin               | Hardware pin | Alternative names | I2C                  | PWM                  |
+| ----------------- | ------------ | ----------------- | -------------------- | -------------------- |
+| `D0`              | `GPIO0`      | `I2C0_SDA_PIN`, `UART0_TX_PIN`, `UART_TX_PIN` | `I2C0` (SDA)         | `PWM0` (channel A)   |
+| `D1`              | `GPIO1`      | `I2C0_SCL_PIN`, `UART0_RX_PIN`, `UART_RX_PIN` | `I2C0` (SCL)         | `PWM0` (channel B)   |
+| `D2`              | `GPIO2`      | `I2C1_SDA_PIN`    | `I2C1` (SDA)         | `PWM1` (channel A)   |
+| `D3`              | `GPIO3`      | `I2C1_SCL_PIN`, `SPI0_SDO_PIN` | `I2C1` (SCL)         | `PWM1` (channel B)   |
+| `D4`              | `GPIO4`      | `SPI0_SDI_PIN`    | `I2C0` (SDA)         | `PWM2` (channel A)   |
+| `D5`              | `GPIO5`      |                   | `I2C0` (SCL)         | `PWM2` (channel B)   |
+| `D6`              | `GPIO6`      | `SPI0_SCK_PIN`    | `I2C1` (SDA)         | `PWM3` (channel A)   |
+| `D7`              | `GPIO7`      |                   | `I2C1` (SCL)         | `PWM3` (channel B)   |
+| `D8`              | `GPIO8`      | `UART1_TX_PIN`    | `I2C0` (SDA)         | `PWM4` (channel A)   |
+| `D9`              | `GPIO9`      | `UART1_RX_PIN`    | `I2C0` (SCL)         | `PWM4` (channel B)   |
+| `D10`             | `GPIO10`     | `SPI1_SCK_PIN`    | `I2C1` (SDA)         | `PWM5` (channel A)   |
+| `D11`             | `GPIO11`     | `SPI1_SDO_PIN`    | `I2C1` (SCL)         | `PWM5` (channel B)   |
+| `D12`             | `GPIO12`     | `SPI1_SDI_PIN`    | `I2C0` (SDA)         | `PWM6` (channel A)   |
+| `D13`             | `GPIO13`     |                   | `I2C0` (SCL)         | `PWM6` (channel B)   |
+| `D14`             | `GPIO14`     |                   | `I2C1` (SDA)         | `PWM7` (channel A)   |
+| `D15`             | `GPIO15`     |                   | `I2C1` (SCL)         | `PWM7` (channel B)   |
+| `D16`             | `GPIO16`     | `NEOPIXEL`, `WS2812` | `I2C0` (SDA)         | `PWM0` (channel A)   |
+| `D17`             | `GPIO17`     |                   | `I2C0` (SCL)         | `PWM0` (channel B)   |
+| `D18`             | `GPIO18`     |                   | `I2C1` (SDA)         | `PWM1` (channel A)   |
+| `D19`             | `GPIO19`     |                   | `I2C1` (SCL)         | `PWM1` (channel B)   |
+| `D20`             | `GPIO20`     |                   | `I2C0` (SDA)         | `PWM2` (channel A)   |
+| `D21`             | `GPIO21`     |                   | `I2C0` (SCL)         | `PWM2` (channel B)   |
+| `D22`             | `GPIO22`     |                   |                      | `PWM3` (channel A)   |
+| `D23`             | `GPIO23`     |                   |                      | `PWM3` (channel B)   |
+| `D24`             | `GPIO24`     |                   |                      | `PWM4` (channel A)   |
+| `D25`             | `GPIO25`     |                   |                      | `PWM4` (channel B)   |
+| `D26`             | `GPIO26`     | `A0`, `ADC0`      | `I2C1` (SDA)         | `PWM5` (channel A)   |
+| `D27`             | `GPIO27`     | `A1`, `ADC1`      | `I2C1` (SCL)         | `PWM5` (channel B)   |
+| `D28`             | `GPIO28`     | `A2`, `ADC2`      |                      | `PWM6` (channel A)   |
+| `D29`             | `GPIO29`     | `A3`, `ADC3`      |                      | `PWM6` (channel B)   |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/wioterminal.md
+++ b/content/docs/reference/microcontrollers/wioterminal.md
@@ -19,99 +19,99 @@ The [Seeed Wio Terminal](https://www.seeedstudio.com/Wio-Terminal-p-4509.html) i
 
 ## Pins
 
-| Pin               | Hardware pin | Alternative names | PWM                  |
-| ----------------- | ------------ | ----------------- | -------------------- |
-| `ADC0`            | `PB08`       | `D0`, `A0`, `BCM27`, `RPI_A0` |                      |
-| `ADC1`            | `PB09`       | `D1`, `A1`, `BCM22`, `RPI_A1` |                      |
-| `ADC2`            | `PA07`       | `D2`, `A2`, `BCM23`, `RPI_A2` |                      |
-| `ADC3`            | `PB04`       | `D3`, `A3`, `BCM24`, `RPI_A3` |                      |
-| `ADC4`            | `PB05`       | `D4`, `A4`, `BCM25`, `RPI_A4` |                      |
-| `ADC5`            | `PB06`       | `D5`, `A5`, `BCM12`, `RPI_A5` |                      |
-| `ADC6`            | `PA04`       | `D6`, `A6`, `BCM13`, `RPI_A6` |                      |
-| `ADC7`            | `PB07`       | `D7`, `A7`, `BCM16`, `RPI_A7` |                      |
-| `ADC8`            | `PA06`       | `D8`, `A8`, `BCM26`, `RPI_A8` |                      |
-| `LED`             | `PA15`       | `PIN_LED_13`, `PIN_LED_RXL`, `PIN_LED_TXL`, `PIN_LED`, `PIN_LED2`, `PIN_LED3`, `LED_BUILTIN`, `PIN_NEOPIXEL` | `TCC2` (channel 1), `TCC1` (channel 3) |
-| `BUTTON`          | `PC26`       | `BUTTON_1`, `WIO_KEY_A` |                      |
-| `BCM0`            | `PA13`       | `PIN_WIRE1_SDA`, `SDA1`, `PIN_GYROSCOPE_WIRE_SDA`, `WIO_LIS3DH_SDA`, `SDA0_PIN` | `TCC0` (channel 7), `TCC1` (channel 3) |
-| `BCM1`            | `PA12`       | `PIN_WIRE1_SCL`, `SCL1`, `PIN_GYROSCOPE_WIRE_SCL`, `WIO_LIS3DH_SCL`, `SCL0_PIN` | `TCC0` (channel 6), `TCC1` (channel 2) |
-| `BCM2`            | `PA17`       | `PIN_WIRE_SDA`, `SDA`, `SDA1_PIN`, `SDA_PIN` | `TCC1` (channel 1), `TCC0` (channel 5) |
-| `BCM3`            | `PA16`       | `PIN_WIRE_SCL`, `SCL`, `SCL1_PIN`, `SCL_PIN` | `TCC1` (channel 0), `TCC0` (channel 4) |
-| `BCM4`            | `PB14`       | `GCLK0`           | `TCC4` (channel 0), `TCC0` (channel 2) |
-| `BCM5`            | `PB12`       | `GCLK1`           | `TCC3` (channel 0), `TCC0` (channel 0) |
-| `BCM6`            | `PB13`       | `GCLK2`           | `TCC3` (channel 1), `TCC0` (channel 1) |
-| `BCM7`            | `PA05`       | `PIN_DAC1`        |                      |
-| `BCM8`            | `PB01`       | `PIN_SPI_SS`, `SS` |                      |
-| `BCM9`            | `PB00`       | `PIN_SPI_SDI`, `SDI`, `SPI0_SDI_PIN` |                      |
-| `BCM10`           | `PB02`       | `PIN_SPI_SDO`, `SDO`, `SPI0_SDO_PIN` | `TCC2` (channel 2)   |
-| `BCM11`           | `PB03`       | `PIN_SPI_SCK`, `SCK`, `SPI0_SCK_PIN` | `TCC2` (channel 3)   |
-| `BCM14`           | `PB27`       | `PIN_SERIAL1_RX`, `UART_RX_PIN` | `TCC1` (channel 3)   |
-| `BCM15`           | `PB26`       | `PIN_SERIAL1_TX`, `UART_TX_PIN` | `TCC1` (channel 2)   |
-| `BCM17`           | `PA02`       | `PIN_DAC0`        |                      |
-| `BCM18`           | `PB28`       | `FPC1`, `I2S_SCK_PIN` | `TCC1` (channel 4)   |
-| `BCM19`           | `PA20`       | `PIN_I2S_FS`, `I2S_LRCLK`, `I2S_WS_PIN` | `TCC1` (channel 4), `TCC0` (channel 0) |
-| `BCM20`           | `PA21`       | `PIN_I2S_SDI`, `I2S_SDIN`, `I2S_SDI_PIN` | `TCC1` (channel 5), `TCC0` (channel 1) |
-| `BCM21`           | `PA22`       | `PIN_I2S_SDO`, `I2S_SDOUT`, `I2S_SDO_PIN` | `TCC1` (channel 6), `TCC0` (channel 2) |
-| `FPC2`            | `PB17`       |                   | `TCC3` (channel 1), `TCC0` (channel 5) |
-| `FPC3`            | `PB29`       |                   | `TCC1` (channel 5)   |
-| `FPC4`            | `PA14`       |                   | `TCC2` (channel 0), `TCC1` (channel 2) |
-| `FPC5`            | `PC01`       |                   |                      |
-| `FPC6`            | `PC02`       |                   |                      |
-| `FPC7`            | `PC03`       |                   |                      |
-| `FPC8`            | `PC04`       |                   | `TCC0` (channel 0)   |
-| `FPC9`            | `PC31`       |                   |                      |
-| `FPC10`           | `PD00`       |                   |                      |
-| `PIN_USB_DM`      | `PA24`       | `USBCDC_DM_PIN`   | `TCC2` (channel 2)   |
-| `PIN_USB_DP`      | `PA25`       | `USBCDC_DP_PIN`   | `TCC2` (channel 3)   |
-| `PIN_USB_HOST_ENABLE` | `PA27`       |                   |                      |
-| `BUTTON_2`        | `PC27`       | `WIO_KEY_B`       |                      |
-| `BUTTON_3`        | `PC28`       | `WIO_KEY_C`       |                      |
-| `SWITCH_X`        | `PD20`       | `WIO_5S_UP`       | `TCC1` (channel 0)   |
-| `SWITCH_Y`        | `PD12`       | `WIO_5S_LEFT`     | `TCC0` (channel 5)   |
-| `SWITCH_Z`        | `PD09`       | `WIO_5S_RIGHT`    | `TCC0` (channel 2)   |
-| `SWITCH_B`        | `PD08`       | `WIO_5S_DOWN`     | `TCC0` (channel 1)   |
-| `SWITCH_U`        | `PD10`       | `WIO_5S_PRESS`    | `TCC0` (channel 3)   |
-| `IRQ0`            | `PC20`       |                   | `TCC0` (channel 4)   |
-| `BUZZER_CTR`      | `PD11`       | `WIO_BUZZER`      | `TCC0` (channel 4)   |
-| `MIC_INPUT`       | `PC30`       | `WIO_MIC`         |                      |
-| `PIN_SERIAL2_RX`  | `PC23`       | `UART2_RX_PIN`    | `TCC0` (channel 7)   |
-| `PIN_SERIAL2_TX`  | `PC22`       | `UART2_TX_PIN`    | `TCC0` (channel 6)   |
-| `GYROSCOPE_INT1`  | `PC21`       | `WIO_LIS3DH_INT`  | `TCC0` (channel 5)   |
-| `PIN_SPI1_SDI`    | `PC24`       | `SDI1`, `RTL8720D_SDI_PIN`, `SPI1_SDI_PIN` |                      |
-| `PIN_SPI1_SDO`    | `PB24`       | `SDO1`, `RTL8720D_SDO_PIN`, `SPI1_SDO_PIN` |                      |
-| `PIN_SPI1_SCK`    | `PB25`       | `SCK1`, `RTL8720D_SCK_PIN`, `SPI1_SCK_PIN` |                      |
-| `PIN_SPI1_SS`     | `PC25`       | `SS1`, `RTL8720D_SS_PIN` |                      |
-| `PIN_SPI2_SDI`    | `PC18`       | `SDI2`, `SDCARD_SDI_PIN`, `SPI2_SDI_PIN` | `TCC0` (channel 2)   |
-| `PIN_SPI2_SDO`    | `PC16`       | `SDO2`, `SDCARD_SDO_PIN`, `SPI2_SDO_PIN` | `TCC0` (channel 0)   |
-| `PIN_SPI2_SCK`    | `PC17`       | `SCK2`, `SDCARD_SCK_PIN`, `SPI2_SCK_PIN` | `TCC0` (channel 1)   |
-| `PIN_SPI2_SS`     | `PC19`       | `SS2`, `SDCARD_SS_PIN` | `TCC0` (channel 3)   |
-| `PIN_SPI3_SDI`    | `PB18`       | `SDI3`, `LCD_SDI_PIN`, `SPI3_SDI_PIN` | `TCC1` (channel 0)   |
-| `PIN_SPI3_SDO`    | `PB19`       | `SDO3`, `LCD_SDO_PIN`, `SPI3_SDO_PIN` | `TCC1` (channel 1)   |
-| `PIN_SPI3_SCK`    | `PB20`       | `SCK3`, `LCD_SCK_PIN`, `SPI3_SCK_PIN` | `TCC1` (channel 2)   |
-| `PIN_SPI3_SS`     | `PB21`       | `SS3`, `LCD_SS_PIN` | `TCC1` (channel 3)   |
-| `SDCARD_DET_PIN`  | `PD21`       |                   | `TCC1` (channel 1)   |
-| `LCD_DC`          | `PC06`       |                   |                      |
-| `LCD_RESET`       | `PC07`       |                   |                      |
-| `LCD_BACKLIGHT`   | `PC05`       |                   | `TCC0` (channel 1)   |
-| `LCD_XL`          | `PC10`       |                   | `TCC0` (channel 0), `TCC1` (channel 4) |
-| `LCD_YU`          | `PC11`       |                   | `TCC0` (channel 1), `TCC1` (channel 5) |
-| `LCD_XR`          | `PC12`       |                   | `TCC0` (channel 2), `TCC1` (channel 6) |
-| `LCD_YD`          | `PC13`       |                   | `TCC0` (channel 3), `TCC1` (channel 7) |
-| `PIN_QSPI_IO0`    | `PA08`       | `QSPI_DATA0`      | `TCC0` (channel 0), `TCC1` (channel 4) |
-| `PIN_QSPI_IO1`    | `PA09`       | `QSPI_DATA1`      | `TCC0` (channel 1), `TCC1` (channel 5) |
-| `PIN_QSPI_IO2`    | `PA10`       | `QSPI_DATA2`      | `TCC0` (channel 2), `TCC1` (channel 6) |
-| `PIN_QSPI_IO3`    | `PA11`       | `QSPI_DATA3`      | `TCC0` (channel 3), `TCC1` (channel 7) |
-| `PIN_QSPI_SCK`    | `PB10`       | `QSPI_SCK`        | `TCC0` (channel 4), `TCC1` (channel 0) |
-| `PIN_QSPI_CS`     | `PB11`       | `QSPI_CS`         | `TCC0` (channel 5), `TCC1` (channel 1) |
-| `PIN_I2S_SCK`     | `PB16`       | `I2S_BLCK`        | `TCC3` (channel 0), `TCC0` (channel 4) |
-| `RTL8720D_CHIP_PU` | `PA18`       |                   | `TCC1` (channel 2), `TCC0` (channel 6) |
-| `RTL8720D_GPIO0`  | `PA19`       |                   | `TCC1` (channel 3), `TCC0` (channel 7) |
-| `SWDCLK`          | `PA30`       |                   | `TCC2` (channel 0)   |
-| `SWDIO`           | `PA31`       |                   | `TCC2` (channel 1)   |
-| `SWO`             | `PB30`       |                   | `TCC4` (channel 0), `TCC0` (channel 6) |
-| `WIO_LIGHT`       | `PD01`       |                   |                      |
-| `WIO_IR`          | `PB31`       |                   | `TCC4` (channel 1), `TCC0` (channel 7) |
-| `OUTPUT_CTR_5V`   | `PC14`       |                   | `TCC0` (channel 4), `TCC1` (channel 0) |
-| `OUTPUT_CTR_3V3`  | `PC15`       |                   | `TCC0` (channel 5), `TCC1` (channel 1) |
+| Pin               | Hardware pin | Alternative names | I2C                  | PWM                  |
+| ----------------- | ------------ | ----------------- | -------------------- | -------------------- |
+| `ADC0`            | `PB08`       | `D0`, `A0`, `BCM27`, `RPI_A0` |                      |                      |
+| `ADC1`            | `PB09`       | `D1`, `A1`, `BCM22`, `RPI_A1` |                      |                      |
+| `ADC2`            | `PA07`       | `D2`, `A2`, `BCM23`, `RPI_A2` |                      |                      |
+| `ADC3`            | `PB04`       | `D3`, `A3`, `BCM24`, `RPI_A3` |                      |                      |
+| `ADC4`            | `PB05`       | `D4`, `A4`, `BCM25`, `RPI_A4` |                      |                      |
+| `ADC5`            | `PB06`       | `D5`, `A5`, `BCM12`, `RPI_A5` |                      |                      |
+| `ADC6`            | `PA04`       | `D6`, `A6`, `BCM13`, `RPI_A6` |                      |                      |
+| `ADC7`            | `PB07`       | `D7`, `A7`, `BCM16`, `RPI_A7` |                      |                      |
+| `ADC8`            | `PA06`       | `D8`, `A8`, `BCM26`, `RPI_A8` |                      |                      |
+| `LED`             | `PA15`       | `PIN_LED_13`, `PIN_LED_RXL`, `PIN_LED_TXL`, `PIN_LED`, `PIN_LED2`, `PIN_LED3`, `LED_BUILTIN`, `PIN_NEOPIXEL` |                      | `TCC2` (channel 1), `TCC1` (channel 3) |
+| `BUTTON`          | `PC26`       | `BUTTON_1`, `WIO_KEY_A` |                      |                      |
+| `BCM0`            | `PA13`       | `PIN_WIRE1_SDA`, `SDA1`, `PIN_GYROSCOPE_WIRE_SDA`, `WIO_LIS3DH_SDA`, `SDA0_PIN` | `I2C0` (SCL)         | `TCC0` (channel 7), `TCC1` (channel 3) |
+| `BCM1`            | `PA12`       | `PIN_WIRE1_SCL`, `SCL1`, `PIN_GYROSCOPE_WIRE_SCL`, `WIO_LIS3DH_SCL`, `SCL0_PIN` | `I2C0` (SDA)         | `TCC0` (channel 6), `TCC1` (channel 2) |
+| `BCM2`            | `PA17`       | `PIN_WIRE_SDA`, `SDA`, `SDA1_PIN`, `SDA_PIN` | `I2C1` (SCL)         | `TCC1` (channel 1), `TCC0` (channel 5) |
+| `BCM3`            | `PA16`       | `PIN_WIRE_SCL`, `SCL`, `SCL1_PIN`, `SCL_PIN` | `I2C1` (SDA)         | `TCC1` (channel 0), `TCC0` (channel 4) |
+| `BCM4`            | `PB14`       | `GCLK0`           |                      | `TCC4` (channel 0), `TCC0` (channel 2) |
+| `BCM5`            | `PB12`       | `GCLK1`           |                      | `TCC3` (channel 0), `TCC0` (channel 0) |
+| `BCM6`            | `PB13`       | `GCLK2`           |                      | `TCC3` (channel 1), `TCC0` (channel 1) |
+| `BCM7`            | `PA05`       | `PIN_DAC1`        |                      |                      |
+| `BCM8`            | `PB01`       | `PIN_SPI_SS`, `SS` |                      |                      |
+| `BCM9`            | `PB00`       | `PIN_SPI_SDI`, `SDI`, `SPI0_SDI_PIN` |                      |                      |
+| `BCM10`           | `PB02`       | `PIN_SPI_SDO`, `SDO`, `SPI0_SDO_PIN` |                      | `TCC2` (channel 2)   |
+| `BCM11`           | `PB03`       | `PIN_SPI_SCK`, `SCK`, `SPI0_SCK_PIN` |                      | `TCC2` (channel 3)   |
+| `BCM14`           | `PB27`       | `PIN_SERIAL1_RX`, `UART_RX_PIN` |                      | `TCC1` (channel 3)   |
+| `BCM15`           | `PB26`       | `PIN_SERIAL1_TX`, `UART_TX_PIN` |                      | `TCC1` (channel 2)   |
+| `BCM17`           | `PA02`       | `PIN_DAC0`        |                      |                      |
+| `BCM18`           | `PB28`       | `FPC1`, `I2S_SCK_PIN` |                      | `TCC1` (channel 4)   |
+| `BCM19`           | `PA20`       | `PIN_I2S_FS`, `I2S_LRCLK`, `I2S_WS_PIN` |                      | `TCC1` (channel 4), `TCC0` (channel 0) |
+| `BCM20`           | `PA21`       | `PIN_I2S_SDI`, `I2S_SDIN`, `I2S_SDI_PIN` |                      | `TCC1` (channel 5), `TCC0` (channel 1) |
+| `BCM21`           | `PA22`       | `PIN_I2S_SDO`, `I2S_SDOUT`, `I2S_SDO_PIN` | `I2C1` (SDA)         | `TCC1` (channel 6), `TCC0` (channel 2) |
+| `FPC2`            | `PB17`       |                   |                      | `TCC3` (channel 1), `TCC0` (channel 5) |
+| `FPC3`            | `PB29`       |                   |                      | `TCC1` (channel 5)   |
+| `FPC4`            | `PA14`       |                   |                      | `TCC2` (channel 0), `TCC1` (channel 2) |
+| `FPC5`            | `PC01`       |                   |                      |                      |
+| `FPC6`            | `PC02`       |                   |                      |                      |
+| `FPC7`            | `PC03`       |                   |                      |                      |
+| `FPC8`            | `PC04`       |                   |                      | `TCC0` (channel 0)   |
+| `FPC9`            | `PC31`       |                   |                      |                      |
+| `FPC10`           | `PD00`       |                   |                      |                      |
+| `PIN_USB_DM`      | `PA24`       | `USBCDC_DM_PIN`   |                      | `TCC2` (channel 2)   |
+| `PIN_USB_DP`      | `PA25`       | `USBCDC_DP_PIN`   |                      | `TCC2` (channel 3)   |
+| `PIN_USB_HOST_ENABLE` | `PA27`       |                   |                      |                      |
+| `BUTTON_2`        | `PC27`       | `WIO_KEY_B`       |                      |                      |
+| `BUTTON_3`        | `PC28`       | `WIO_KEY_C`       |                      |                      |
+| `SWITCH_X`        | `PD20`       | `WIO_5S_UP`       |                      | `TCC1` (channel 0)   |
+| `SWITCH_Y`        | `PD12`       | `WIO_5S_LEFT`     |                      | `TCC0` (channel 5)   |
+| `SWITCH_Z`        | `PD09`       | `WIO_5S_RIGHT`    |                      | `TCC0` (channel 2)   |
+| `SWITCH_B`        | `PD08`       | `WIO_5S_DOWN`     |                      | `TCC0` (channel 1)   |
+| `SWITCH_U`        | `PD10`       | `WIO_5S_PRESS`    |                      | `TCC0` (channel 3)   |
+| `IRQ0`            | `PC20`       |                   |                      | `TCC0` (channel 4)   |
+| `BUZZER_CTR`      | `PD11`       | `WIO_BUZZER`      |                      | `TCC0` (channel 4)   |
+| `MIC_INPUT`       | `PC30`       | `WIO_MIC`         |                      |                      |
+| `PIN_SERIAL2_RX`  | `PC23`       | `UART2_RX_PIN`    |                      | `TCC0` (channel 7)   |
+| `PIN_SERIAL2_TX`  | `PC22`       | `UART2_TX_PIN`    |                      | `TCC0` (channel 6)   |
+| `GYROSCOPE_INT1`  | `PC21`       | `WIO_LIS3DH_INT`  |                      | `TCC0` (channel 5)   |
+| `PIN_SPI1_SDI`    | `PC24`       | `SDI1`, `RTL8720D_SDI_PIN`, `SPI1_SDI_PIN` |                      |                      |
+| `PIN_SPI1_SDO`    | `PB24`       | `SDO1`, `RTL8720D_SDO_PIN`, `SPI1_SDO_PIN` |                      |                      |
+| `PIN_SPI1_SCK`    | `PB25`       | `SCK1`, `RTL8720D_SCK_PIN`, `SPI1_SCK_PIN` |                      |                      |
+| `PIN_SPI1_SS`     | `PC25`       | `SS1`, `RTL8720D_SS_PIN` |                      |                      |
+| `PIN_SPI2_SDI`    | `PC18`       | `SDI2`, `SDCARD_SDI_PIN`, `SPI2_SDI_PIN` |                      | `TCC0` (channel 2)   |
+| `PIN_SPI2_SDO`    | `PC16`       | `SDO2`, `SDCARD_SDO_PIN`, `SPI2_SDO_PIN` |                      | `TCC0` (channel 0)   |
+| `PIN_SPI2_SCK`    | `PC17`       | `SCK2`, `SDCARD_SCK_PIN`, `SPI2_SCK_PIN` |                      | `TCC0` (channel 1)   |
+| `PIN_SPI2_SS`     | `PC19`       | `SS2`, `SDCARD_SS_PIN` |                      | `TCC0` (channel 3)   |
+| `PIN_SPI3_SDI`    | `PB18`       | `SDI3`, `LCD_SDI_PIN`, `SPI3_SDI_PIN` |                      | `TCC1` (channel 0)   |
+| `PIN_SPI3_SDO`    | `PB19`       | `SDO3`, `LCD_SDO_PIN`, `SPI3_SDO_PIN` |                      | `TCC1` (channel 1)   |
+| `PIN_SPI3_SCK`    | `PB20`       | `SCK3`, `LCD_SCK_PIN`, `SPI3_SCK_PIN` |                      | `TCC1` (channel 2)   |
+| `PIN_SPI3_SS`     | `PB21`       | `SS3`, `LCD_SS_PIN` |                      | `TCC1` (channel 3)   |
+| `SDCARD_DET_PIN`  | `PD21`       |                   |                      | `TCC1` (channel 1)   |
+| `LCD_DC`          | `PC06`       |                   |                      |                      |
+| `LCD_RESET`       | `PC07`       |                   |                      |                      |
+| `LCD_BACKLIGHT`   | `PC05`       |                   |                      | `TCC0` (channel 1)   |
+| `LCD_XL`          | `PC10`       |                   |                      | `TCC0` (channel 0), `TCC1` (channel 4) |
+| `LCD_YU`          | `PC11`       |                   |                      | `TCC0` (channel 1), `TCC1` (channel 5) |
+| `LCD_XR`          | `PC12`       |                   |                      | `TCC0` (channel 2), `TCC1` (channel 6) |
+| `LCD_YD`          | `PC13`       |                   |                      | `TCC0` (channel 3), `TCC1` (channel 7) |
+| `PIN_QSPI_IO0`    | `PA08`       | `QSPI_DATA0`      |                      | `TCC0` (channel 0), `TCC1` (channel 4) |
+| `PIN_QSPI_IO1`    | `PA09`       | `QSPI_DATA1`      |                      | `TCC0` (channel 1), `TCC1` (channel 5) |
+| `PIN_QSPI_IO2`    | `PA10`       | `QSPI_DATA2`      |                      | `TCC0` (channel 2), `TCC1` (channel 6) |
+| `PIN_QSPI_IO3`    | `PA11`       | `QSPI_DATA3`      |                      | `TCC0` (channel 3), `TCC1` (channel 7) |
+| `PIN_QSPI_SCK`    | `PB10`       | `QSPI_SCK`        |                      | `TCC0` (channel 4), `TCC1` (channel 0) |
+| `PIN_QSPI_CS`     | `PB11`       | `QSPI_CS`         |                      | `TCC0` (channel 5), `TCC1` (channel 1) |
+| `PIN_I2S_SCK`     | `PB16`       | `I2S_BLCK`        |                      | `TCC3` (channel 0), `TCC0` (channel 4) |
+| `RTL8720D_CHIP_PU` | `PA18`       |                   |                      | `TCC1` (channel 2), `TCC0` (channel 6) |
+| `RTL8720D_GPIO0`  | `PA19`       |                   |                      | `TCC1` (channel 3), `TCC0` (channel 7) |
+| `SWDCLK`          | `PA30`       |                   |                      | `TCC2` (channel 0)   |
+| `SWDIO`           | `PA31`       |                   |                      | `TCC2` (channel 1)   |
+| `SWO`             | `PB30`       |                   |                      | `TCC4` (channel 0), `TCC0` (channel 6) |
+| `WIO_LIGHT`       | `PD01`       |                   |                      |                      |
+| `WIO_IR`          | `PB31`       |                   |                      | `TCC4` (channel 1), `TCC0` (channel 7) |
+| `OUTPUT_CTR_5V`   | `PC14`       |                   |                      | `TCC0` (channel 4), `TCC1` (channel 0) |
+| `OUTPUT_CTR_3V3`  | `PC15`       |                   |                      | `TCC0` (channel 5), `TCC1` (channel 1) |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/xiao-rp2040.md
+++ b/content/docs/reference/microcontrollers/xiao-rp2040.md
@@ -19,24 +19,24 @@ The [Seeed XIAO RP2040](https://www.seeedstudio.com/XIAO-RP2040-v1-0-p-5026.html
 
 ## Pins
 
-| Pin               | Hardware pin | Alternative names | PWM                  |
-| ----------------- | ------------ | ----------------- | -------------------- |
-| `D0`              | `GPIO26`     | `A0`, `ADC0`      | `PWM5` (channel A)   |
-| `D1`              | `GPIO27`     | `A1`, `ADC1`      | `PWM5` (channel B)   |
-| `D2`              | `GPIO28`     | `A2`, `I2C0_SDA_PIN`, `ADC2` | `PWM6` (channel A)   |
-| `D3`              | `GPIO29`     | `A3`, `I2C0_SCL_PIN`, `ADC3` | `PWM6` (channel B)   |
-| `D4`              | `GPIO6`      | `I2C1_SDA_PIN`    | `PWM3` (channel A)   |
-| `D5`              | `GPIO7`      | `I2C1_SCL_PIN`    | `PWM3` (channel B)   |
-| `D6`              | `GPIO0`      | `UART0_TX_PIN`, `UART_TX_PIN` | `PWM0` (channel A)   |
-| `D7`              | `GPIO1`      | `UART0_RX_PIN`, `UART_RX_PIN` | `PWM0` (channel B)   |
-| `D8`              | `GPIO2`      | `SPI0_SCK_PIN`    | `PWM1` (channel A)   |
-| `D9`              | `GPIO4`      | `SPI0_SDI_PIN`    | `PWM2` (channel A)   |
-| `D10`             | `GPIO3`      | `SPI0_SDO_PIN`    | `PWM1` (channel B)   |
-| `NEOPIXEL`        | `GPIO12`     | `WS2812`          | `PWM6` (channel A)   |
-| `NEO_PWR`         | `GPIO11`     | `NEOPIXEL_POWER`  | `PWM5` (channel B)   |
-| `LED`             | `GPIO17`     | `LED_RED`         | `PWM0` (channel B)   |
-| `LED_GREEN`       | `GPIO16`     |                   | `PWM0` (channel A)   |
-| `LED_BLUE`        | `GPIO25`     |                   | `PWM4` (channel B)   |
+| Pin               | Hardware pin | Alternative names | I2C                  | PWM                  |
+| ----------------- | ------------ | ----------------- | -------------------- | -------------------- |
+| `D0`              | `GPIO26`     | `A0`, `ADC0`      | `I2C1` (SDA)         | `PWM5` (channel A)   |
+| `D1`              | `GPIO27`     | `A1`, `ADC1`      | `I2C1` (SCL)         | `PWM5` (channel B)   |
+| `D2`              | `GPIO28`     | `A2`, `I2C0_SDA_PIN`, `ADC2` |                      | `PWM6` (channel A)   |
+| `D3`              | `GPIO29`     | `A3`, `I2C0_SCL_PIN`, `ADC3` |                      | `PWM6` (channel B)   |
+| `D4`              | `GPIO6`      | `I2C1_SDA_PIN`    | `I2C1` (SDA)         | `PWM3` (channel A)   |
+| `D5`              | `GPIO7`      | `I2C1_SCL_PIN`    | `I2C1` (SCL)         | `PWM3` (channel B)   |
+| `D6`              | `GPIO0`      | `UART0_TX_PIN`, `UART_TX_PIN` | `I2C0` (SDA)         | `PWM0` (channel A)   |
+| `D7`              | `GPIO1`      | `UART0_RX_PIN`, `UART_RX_PIN` | `I2C0` (SCL)         | `PWM0` (channel B)   |
+| `D8`              | `GPIO2`      | `SPI0_SCK_PIN`    | `I2C1` (SDA)         | `PWM1` (channel A)   |
+| `D9`              | `GPIO4`      | `SPI0_SDI_PIN`    | `I2C0` (SDA)         | `PWM2` (channel A)   |
+| `D10`             | `GPIO3`      | `SPI0_SDO_PIN`    | `I2C1` (SCL)         | `PWM1` (channel B)   |
+| `NEOPIXEL`        | `GPIO12`     | `WS2812`          | `I2C0` (SDA)         | `PWM6` (channel A)   |
+| `NEO_PWR`         | `GPIO11`     | `NEOPIXEL_POWER`  | `I2C1` (SCL)         | `PWM5` (channel B)   |
+| `LED`             | `GPIO17`     | `LED_RED`         | `I2C0` (SCL)         | `PWM0` (channel B)   |
+| `LED_GREEN`       | `GPIO16`     |                   | `I2C0` (SDA)         | `PWM0` (channel A)   |
+| `LED_BLUE`        | `GPIO25`     |                   |                      | `PWM4` (channel B)   |
 
 ## Machine Package Docs
 

--- a/content/docs/reference/microcontrollers/xiao.md
+++ b/content/docs/reference/microcontrollers/xiao.md
@@ -19,24 +19,24 @@ The [Seeed Seeeduino XIAO, which has been renamed to Seeed Studio XIAO SAMD21](h
 
 ## Pins
 
-| Pin               | Hardware pin | Alternative names | PWM                  |
-| ----------------- | ------------ | ----------------- | -------------------- |
-| `D0`              | `PA02`       | `A0`              |                      |
-| `D1`              | `PA04`       | `A1`              | `TCC0` (channel 0)   |
-| `D2`              | `PA10`       | `A2`, `I2S_SCK_PIN` | `TCC1` (channel 0), `TCC0` (channel 2) |
-| `D3`              | `PA11`       | `A3`              | `TCC1` (channel 1), `TCC0` (channel 3) |
-| `D4`              | `PA08`       | `A4`, `SDA_PIN`, `I2S_SDO_PIN` | `TCC0` (channel 0), `TCC1` (channel 2) |
-| `D5`              | `PA09`       | `A5`, `SCL_PIN`   | `TCC0` (channel 1), `TCC1` (channel 3) |
-| `D6`              | `PB08`       | `A6`, `UART_TX_PIN` |                      |
-| `D7`              | `PB09`       | `A7`, `UART_RX_PIN` |                      |
-| `D8`              | `PA07`       | `A8`, `SPI0_SCK_PIN` | `TCC1` (channel 1)   |
-| `D9`              | `PA05`       | `A9`, `SPI0_SDI_PIN` | `TCC0` (channel 1)   |
-| `D10`             | `PA06`       | `A10`, `SPI0_SDO_PIN` | `TCC1` (channel 0)   |
-| `LED`             | `PA17`       |                   | `TCC2` (channel 1), `TCC0` (channel 3) |
-| `LED_RXL`         | `PA18`       | `LED2`            | `TCC0` (channel 2)   |
-| `LED_TXL`         | `PA19`       | `LED3`            | `TCC0` (channel 3)   |
-| `USBCDC_DM_PIN`   | `PA24`       |                   | `TCC1` (channel 2)   |
-| `USBCDC_DP_PIN`   | `PA25`       |                   | `TCC1` (channel 3)   |
+| Pin               | Hardware pin | Alternative names | I2C                  | PWM                  |
+| ----------------- | ------------ | ----------------- | -------------------- | -------------------- |
+| `D0`              | `PA02`       | `A0`              |                      |                      |
+| `D1`              | `PA04`       | `A1`              |                      | `TCC0` (channel 0)   |
+| `D2`              | `PA10`       | `A2`, `I2S_SCK_PIN` |                      | `TCC1` (channel 0), `TCC0` (channel 2) |
+| `D3`              | `PA11`       | `A3`              |                      | `TCC1` (channel 1), `TCC0` (channel 3) |
+| `D4`              | `PA08`       | `A4`, `SDA_PIN`, `I2S_SDO_PIN` | `I2C0` (SDA)         | `TCC0` (channel 0), `TCC1` (channel 2) |
+| `D5`              | `PA09`       | `A5`, `SCL_PIN`   | `I2C0` (SCL)         | `TCC0` (channel 1), `TCC1` (channel 3) |
+| `D6`              | `PB08`       | `A6`, `UART_TX_PIN` |                      |                      |
+| `D7`              | `PB09`       | `A7`, `UART_RX_PIN` |                      |                      |
+| `D8`              | `PA07`       | `A8`, `SPI0_SCK_PIN` |                      | `TCC1` (channel 1)   |
+| `D9`              | `PA05`       | `A9`, `SPI0_SDI_PIN` |                      | `TCC0` (channel 1)   |
+| `D10`             | `PA06`       | `A10`, `SPI0_SDO_PIN` |                      | `TCC1` (channel 0)   |
+| `LED`             | `PA17`       |                   |                      | `TCC2` (channel 1), `TCC0` (channel 3) |
+| `LED_RXL`         | `PA18`       | `LED2`            |                      | `TCC0` (channel 2)   |
+| `LED_TXL`         | `PA19`       | `LED3`            |                      | `TCC0` (channel 3)   |
+| `USBCDC_DM_PIN`   | `PA24`       |                   |                      | `TCC1` (channel 2)   |
+| `USBCDC_DP_PIN`   | `PA25`       |                   |                      | `TCC1` (channel 3)   |
 
 ## Machine Package Docs
 

--- a/doc-gen/main.go
+++ b/doc-gen/main.go
@@ -463,19 +463,32 @@ func detectSupportedFeatures(pkg *packages.Package, buildTags []string) map[stri
 }
 
 func getPinsSection(pkg *packages.Package) (string, error) {
-	supportedPeripherals := map[string]bool{
-		"PWM": true,
-	}
-
 	// Find board pin names
 	pinNames := make(map[string]uint64)
 	hardwarePins := make(map[string]struct{})
 	pinPeripherals := make(map[string][]string)
+	variableAssigns := make(map[string][]string)
 	var pinNamesSlice []string
 	for _, file := range pkg.Syntax {
 		for _, decl := range file.Decls {
 			switch decl := decl.(type) {
 			case *ast.GenDecl:
+				if decl.Tok == token.VAR {
+					for _, spec := range decl.Specs {
+						spec := spec.(*ast.ValueSpec)
+						if len(spec.Names) != 1 || len(spec.Values) != 1 {
+							continue
+						}
+						name := spec.Names[0]
+						value := spec.Values[0]
+						if !token.IsExported(name.Name) {
+							continue
+						}
+						if value, ok := value.(*ast.Ident); ok {
+							variableAssigns[value.Name] = append(variableAssigns[value.Name], name.Name)
+						}
+					}
+				}
 				if decl.Tok != token.CONST {
 					continue
 				}
@@ -530,11 +543,27 @@ func getPinsSection(pkg *packages.Package) (string, error) {
 			}
 			pin.HardwareName = name
 			for _, peripheral := range pinPeripherals[name] {
-				peripheralName := strings.SplitN(peripheral, " ", 2)[0]
-				peripheralType := classifyPeripheral(pkg, peripheralName)
-				if supportedPeripherals[peripheralType] {
-					pin.Peripherals[peripheralType] = append(pin.Peripherals[peripheralType], peripheral)
-					hasPeripheral[peripheralType] = true
+				parts := strings.SplitN(peripheral, " ", 2)
+				peripheralName := parts[0]
+				peripheralSuffix := parts[1]
+				var peripheralType string
+				peripherals := []string{peripheral}
+				if strings.HasPrefix(peripheralName, "I2C") {
+					peripheralType = "I2C"
+				} else if strings.HasPrefix(peripheralName, "sercomI2CM") {
+					peripheralType = "I2C"
+					peripherals = nil
+					for _, name := range variableAssigns[peripheralName] {
+						peripherals = append(peripherals, name+" "+peripheralSuffix)
+					}
+				} else {
+					peripheralType = classifyPeripheral(pkg, peripheralName)
+				}
+				if peripheralType == "I2C" || peripheralType == "PWM" {
+					for _, name := range peripherals {
+						pin.Peripherals[peripheralType] = append(pin.Peripherals[peripheralType], name)
+						hasPeripheral[peripheralType] = true
+					}
 				}
 			}
 		} else {
@@ -547,6 +576,9 @@ func getPinsSection(pkg *packages.Package) (string, error) {
 	}
 
 	pinsText := "## Pins\n\n| Pin               | Hardware pin | Alternative names |"
+	if hasPeripheral["I2C"] {
+		pinsText += " I2C                  |"
+	}
 	if hasPeripheral["PWM"] {
 		pinsText += " PWM                  |"
 	}
@@ -564,7 +596,7 @@ func getPinsSection(pkg *packages.Package) (string, error) {
 			alternativeNames = append(alternativeNames, "`"+name+"`")
 		}
 		pinsText += fmt.Sprintf("| %-17s | %-12s | %-17s |", "`"+pin.OtherNames[0]+"`", "`"+pin.HardwareName+"`", strings.Join(alternativeNames, ", "))
-		for _, peripheralType := range []string{"PWM"} {
+		for _, peripheralType := range []string{"I2C", "PWM"} {
 			if !hasPeripheral[peripheralType] {
 				continue
 			}


### PR DESCRIPTION
This makes it easier to find which pins support I2C and which peripheral is used. It uses the comments added in https://github.com/tinygo-org/tinygo/pull/4952 and https://github.com/tinygo-org/tinygo/pull/5053.

My plan is to refer to these pins in the documentation from the tour.