### PR TITLE
reference/microcontrollers: adding pages for xiao esp32c3, xiao esp32s3, and xiao-rp2350 boards

### DIFF
--- a/content/docs/reference/microcontrollers/xiao-ble.md
+++ b/content/docs/reference/microcontrollers/xiao-ble.md
@@ -1,9 +1,9 @@
 ---
-title: "Seeed XIAO BLE"
+title: "Seeed Studio XIAO BLE"
 weight: 3
 ---
 
-The [Seeed XIAO BLE](https://www.seeedstudio.com/Seeed-XIAO-BLE-nRF52840-p-5201.html) is a tiny ARM development board based on the Nordic Semiconductor [nrf52840](https://www.nordicsemi.com/eng/Products/nRF52840) processor.
+The [Seeed Studio XIAO BLE](https://www.seeedstudio.com/Seeed-XIAO-BLE-nRF52840-p-5201.html) is a tiny ARM development board based on the Nordic Semiconductor [nrf52840](https://www.nordicsemi.com/eng/Products/nRF52840) processor.
 
 ## Interfaces
 
@@ -47,7 +47,7 @@ The [Seeed XIAO BLE](https://www.seeedstudio.com/Seeed-XIAO-BLE-nRF52840-p-5201.
 
 ## Machine Package Docs
 
-[Documentation for the machine package for the Seeed XIAO BLE](../machine/xiao-ble)
+[Documentation for the machine package for the Seeed Studio XIAO BLE](../machine/xiao-ble)
 
 ## Flashing
 

--- a/content/docs/reference/microcontrollers/xiao-esp32c3.md
+++ b/content/docs/reference/microcontrollers/xiao-esp32c3.md
@@ -1,0 +1,60 @@
+---
+title: "Seeed Studio XIAO ESP32C3"
+weight: 3
+---
+
+The [Seeed Studio XIAO ESP32C3](https://wiki.seeedstudio.com/XIAO_ESP32C3_Getting_Started/) is a tiny development board based on the Espressif [ESP32C3](https://www.espressif.com/en/products/socs/esp32-c3) 32-bit RISC-V CPU microcontroller.
+
+## Interfaces
+
+| Interface | Hardware Supported | TinyGo Support |
+| --------- | ------------- | ----- |
+| GPIO      | YES | YES |
+| UART      | YES | YES |
+| SPI       | YES | YES |
+| I2C       | YES | YES |
+| ADC       | YES | YES |
+| PWM       | YES | YES |
+| USBDevice | YES | Not yet |
+| WiFi      | YES | Not Yet |
+| Bluetooth | YES | Not yet |
+
+## Pins
+
+| Pin               | Hardware pin | Alternative names |
+| ----------------- | ------------ | ----------------- |
+| `D0`              | `GPIO2`      | `A0`              |
+| `D1`              | `GPIO3`      | `A1`              |
+| `D2`              | `GPIO4`      | `A2`              |
+| `D3`              | `GPIO5`      | `A3`              |
+| `D4`              | `GPIO6`      | `SDA_PIN`         |
+| `D5`              | `GPIO7`      | `SCL_PIN`         |
+| `D6`              | `GPIO21`     | `UART_TX_PIN`     |
+| `D7`              | `GPIO20`     | `UART_RX_PIN`     |
+| `D8`              | `GPIO8`      | `SPI_SCK_PIN`     |
+| `D9`              | `GPIO9`      | `SPI_SDI_PIN`     |
+| `D10`             | `GPIO10`     | `SPI_SDO_PIN`     |
+
+## Machine Package Docs
+
+[Documentation for the machine package for the Seeed Studio XIAO ESP32C3](../machine/xiao-esp32c3)
+
+## Flashing
+
+### CLI Flashing
+
+- Flash your TinyGo program to the board using this command:
+
+    ```shell
+    tinygo flash -target=xiao-esp32c3 [PATH TO YOUR PROGRAM]
+    ```
+
+- The XIAO ESP32C3 board should restart and then begin running your program.
+
+### Troubleshooting
+
+Any troubleshooting tips go here.
+
+## Notes
+
+Any additional notes go here.

--- a/content/docs/reference/microcontrollers/xiao-esp32s3.md
+++ b/content/docs/reference/microcontrollers/xiao-esp32s3.md
@@ -1,0 +1,61 @@
+---
+title: "Seeed Studio XIAO ESP32S3"
+weight: 3
+---
+
+The [Seeed Studio XIAO ESP32S3](https://wiki.seeedstudio.com/xiao_esp32s3_getting_started/) is a tiny development board based on the Espressif [Xtensa LX7 dual-core, 32-bit processor ](https://www.espressif.com/en/products/socs/esp32-s3/) microcontroller.
+
+## Interfaces
+
+| Interface | Hardware Supported | TinyGo Support |
+| --------- | ------------- | ----- |
+| GPIO      | YES | YES |
+| UART      | YES | YES |
+| SPI       | YES | YES |
+| I2C       | YES | YES |
+| ADC       | YES | YES |
+| PWM       | YES | YES |
+| USBDevice | YES | Not yet |
+| WiFi      | YES | Not Yet |
+| Bluetooth | YES | Not yet |
+
+## Pins
+
+| Pin               | Hardware pin | Alternative names |
+| ----------------- | ------------ | ----------------- |
+| `D0`              | `GPIO1`      | `A0`              |
+| `D1`              | `GPIO2`      | `A1`              |
+| `D2`              | `GPIO3`      | `A2`              |
+| `D3`              | `GPIO4`      | `A3`              |
+| `D4`              | `GPIO5`      | `SDA_PIN`         |
+| `D5`              | `GPIO6`      | `SCL_PIN`         |
+| `D6`              | `GPIO43`     | `UART_TX_PIN`     |
+| `D7`              | `GPIO44`     | `UART_RX_PIN`     |
+| `D8`              | `GPIO7`      | `SPI1_SCK_PIN`    |
+| `D9`              | `GPIO8`      | `SPI1_MISO_PIN`   |
+| `D10`             | `GPIO9`      | `SPI1_MOSI_PIN`   |
+| `LED`             | `GPIO21`     |                   |
+
+## Machine Package Docs
+
+[Documentation for the machine package for the Seeed Studio XIAO ESP32S3](../machine/xiao-esp32s3)
+
+## Flashing
+
+### CLI Flashing
+
+- Flash your TinyGo program to the board using this command:
+
+    ```shell
+    tinygo flash -target=xiao-esp32s3 [PATH TO YOUR PROGRAM]
+    ```
+
+- The XIAO ESP32S3 board should restart and then begin running your program.
+
+### Troubleshooting
+
+Any troubleshooting tips go here.
+
+## Notes
+
+Any additional notes go here.

--- a/content/docs/reference/microcontrollers/xiao-rp2040.md
+++ b/content/docs/reference/microcontrollers/xiao-rp2040.md
@@ -1,9 +1,9 @@
 ---
-title: "Seeed XIAO RP2040"
+title: "Seeed Studio XIAO RP2040"
 weight: 3
 ---
 
-The [Seeed XIAO RP2040](https://www.seeedstudio.com/XIAO-RP2040-v1-0-p-5026.html) is a tiny development board based on the Raspberry Pi [RP2040](https://datasheets.raspberrypi.org/rp2040/rp2040-datasheet.pdf) microcontroller.
+The [Seeed Studio XIAO RP2040](https://www.seeedstudio.com/XIAO-RP2040-v1-0-p-5026.html) is a tiny development board based on the Raspberry Pi [RP2040](https://datasheets.raspberrypi.org/rp2040/rp2040-datasheet.pdf) microcontroller.
 
 ## Interfaces
 
@@ -40,7 +40,7 @@ The [Seeed XIAO RP2040](https://www.seeedstudio.com/XIAO-RP2040-v1-0-p-5026.html
 
 ## Machine Package Docs
 
-[Documentation for the machine package for the Seeed XIAO RP2040](../machine/xiao-rp2040)
+[Documentation for the machine package for the Seeed Studio XIAO RP2040](../machine/xiao-rp2040)
 
 ## Flashing
 
@@ -68,4 +68,4 @@ You can use the USB port to the XIAO RP2040 as a serial port.
 
 TinyGo has support for the RP2040's on-board Programmable Input/Output (PIO) block.
 
-For more informantion, see [https://github.com/tinygo-org/pio](https://github.com/tinygo-org/pio)
+For more information, see [https://github.com/tinygo-org/pio](https://github.com/tinygo-org/pio)

--- a/content/docs/reference/microcontrollers/xiao-rp2350.md
+++ b/content/docs/reference/microcontrollers/xiao-rp2350.md
@@ -1,0 +1,77 @@
+---
+title: "Seeed Studio XIAO RP23550"
+weight: 3
+---
+
+The [Seeed Studio XIAO RP2350]() is a tiny development board based on the Raspberry Pi [RP2350]() microcontroller.
+
+## Interfaces
+
+| Interface | Hardware Supported | TinyGo Support |
+| --------- | ------------- | ----- |
+| GPIO      | YES | YES |
+| UART      | YES | YES |
+| SPI       | YES | YES |
+| I2C       | YES | YES |
+| ADC       | YES | YES |
+| PWM       | YES | YES |
+| USBDevice | YES | YES |
+
+## Pins
+
+| Pin               | Hardware pin | Alternative names | I2C                  | PWM                  |
+| ----------------- | ------------ | ----------------- | -------------------- | -------------------- |
+| `D0`              | `GPIO26`     | `A0`, `ADC0`      | `I2C1` (SDA)         | `PWM5` (channel A)   |
+| `D1`              | `GPIO27`     | `A1`, `ADC1`      | `I2C1` (SCL)         | `PWM5` (channel B)   |
+| `D2`              | `GPIO28`     | `A2`, `ADC2`      |                      | `PWM6` (channel A)   |
+| `D3`              | `GPIO5`      |                   | `I2C0` (SCL)         | `PWM2` (channel B)   |
+| `D4`              | `GPIO6`      | `I2C1_SDA_PIN`    | `I2C1` (SDA)         | `PWM3` (channel A)   |
+| `D5`              | `GPIO7`      | `I2C1_SCL_PIN`    | `I2C1` (SCL)         | `PWM3` (channel B)   |
+| `D6`              | `GPIO0`      | `UART0_TX_PIN`, `UART_TX_PIN` | `I2C0` (SDA)         | `PWM0` (channel A)   |
+| `D7`              | `GPIO1`      | `UART0_RX_PIN`, `UART_RX_PIN` | `I2C0` (SCL)         | `PWM0` (channel B)   |
+| `D8`              | `GPIO2`      | `SPI0_SCK_PIN`    | `I2C1` (SDA)         | `PWM1` (channel A)   |
+| `D9`              | `GPIO4`      | `SPI0_SDI_PIN`    | `I2C0` (SDA)         | `PWM2` (channel A)   |
+| `D10`             | `GPIO3`      | `SPI0_SDO_PIN`    | `I2C1` (SCL)         | `PWM1` (channel B)   |
+| `D11`             | `GPIO21`     |                   | `I2C0` (SCL)         | `PWM2` (channel B)   |
+| `D12`             | `GPIO20`     |                   | `I2C0` (SDA)         | `PWM2` (channel A)   |
+| `D13`             | `GPIO17`     | `I2C0_SCL_PIN`    | `I2C0` (SCL)         | `PWM0` (channel B)   |
+| `D14`             | `GPIO16`     | `I2C0_SDA_PIN`    | `I2C0` (SDA)         | `PWM0` (channel A)   |
+| `D15`             | `GPIO11`     | `SPI1_SDO_PIN`    | `I2C1` (SCL)         | `PWM5` (channel B)   |
+| `D16`             | `GPIO12`     | `SPI1_SDI_PIN`    | `I2C0` (SDA)         | `PWM6` (channel A)   |
+| `D17`             | `GPIO10`     | `SPI1_SCK_PIN`    | `I2C1` (SDA)         | `PWM5` (channel A)   |
+| `NEOPIXEL`        | `GPIO22`     | `WS2812`          |                      | `PWM3` (channel A)   |
+| `NEO_PWR`         | `GPIO23`     | `NEOPIXEL_POWER`  |                      | `PWM3` (channel B)   |
+| `LED`             | `GPIO25`     |                   |                      | `PWM4` (channel B)   |
+| `ADC3`            | `GPIO29`     |                   |                      | `PWM6` (channel B)   |
+
+## Machine Package Docs
+
+[Documentation for the machine package for the Seeed Studio XIAO RP2350](../machine/xiao-rp2350)
+
+## Flashing
+
+### UF2
+
+The XIAO RP2350 comes with the [UF2 bootloader](https://github.com/Microsoft/uf2) already installed.
+
+### CLI Flashing
+
+- Flash your TinyGo program to the board using this command:
+
+    ```shell
+    tinygo flash -target=xiao-rp2350 [PATH TO YOUR PROGRAM]
+    ```
+
+- The XIAO RP2350 board should restart and then begin running your program.
+
+### Troubleshooting
+
+Any troubleshooting tips go here.
+
+## Notes
+
+You can use the USB port to the XIAO RP2350 as a serial port.
+
+TinyGo has support for the RP2350's on-board Programmable Input/Output (PIO) block.
+
+For more information, see [https://github.com/tinygo-org/pio](https://github.com/tinygo-org/pio)

--- a/content/docs/reference/microcontrollers/xiao.md
+++ b/content/docs/reference/microcontrollers/xiao.md
@@ -1,5 +1,5 @@
 ---
-title: "Seeed Studio XIAO SAMD21 aka Seeeduino XIAO"
+title: "Seeed Studio XIAO SAMD21"
 weight: 3
 ---
 


### PR DESCRIPTION
This PR updates the reference/microcontrollers section by adding pages for xiao esp32c3, xiao esp32s3, and xiao-rp2350 boards. Machine package and pins will be updated when we update all docs on the next release.