### PR TITLE
Updating debugging guide steps for Raspberry Pi Debug Probe

### DIFF
--- a/content/docs/guides/debugging.md
+++ b/content/docs/guides/debugging.md
@@ -54,6 +54,31 @@ You can install the most common dependencies through Homebrew:
     brew tap ARMmbed/homebrew-formulae
     brew install arm-none-eabi-gcc
 
+However this will not support the Raspberry Pi Pico targets or the Raspberry Pi Debug Probe. Instead, compile openocd from source using [Raspberry Pi's openocd fork](https://github.com/raspberrypi/openocd):
+
+    brew tap ARMmbed/homebrew-formulae
+    brew install libtool automake libusb aclocal texinfo pkg-config capstone gdb arm-none-eabi-gcc
+
+    git clone git@github.com:raspberrypi/openocd.git
+    cd openocd
+
+    git submodule init
+    git submodule update
+
+    ./bootstrap
+    ./configure --disable-werror --enable-internal-jimtcl --enable-cmsis-dap-v2 --enable-bcm2835gpio
+    make -j4
+
+You can then add openocd and the required scripts to your environment like so:
+
+    export PATH=$PWD/src:$PATH
+    export OPENOCD_SCRIPTS=$PWD/tcl
+
+Or add it to your `~/.zshrc` so that it persists for future sessions:
+
+    echo "export PATH=\"$PWD/src:\$PATH\"" >> ~/.zshrc
+    echo "export OPENOCD_SCRIPTS=\"$PWD/tcl\"" >> ~/.zshrc
+
 ## Connecting a debug probe
 
 Sometimes you need a separate debug probe. Whether this is necessary depends on the board, some have a debug probe built onto the board already:
@@ -122,4 +147,18 @@ For example:
 
 ```
 $ tinygo gdb -target=arduino-nano33 -programmer=cmsis-dap examples/blinky1
+```
+
+If you have issues connecting to your probe the following flags may be helpful:
+
+| Flag                        | Explanation                                              |
+| --------------------------- | -------------------------------------------------------- |
+| `-ocd-output`               | Echoes the output of openocd to the terminal             |
+| `-ocd-commands "<command>"` | Sets custom openocd commands                             |
+| `-x`                        | Prints the commands tinygo is sending to openocd and gdb |
+
+For example, this custom openocd command is necessary when using a Rasbperry Pi Debug Probe to connect to a Raspberry Pi Pico 2:
+
+```
+$ tinygo gdb -target=pico2 -programmer=cmsis-dap -ocd-commands "adapter speed 5000" examples/blinky1
 ```

--- a/content/docs/guides/debugging.md
+++ b/content/docs/guides/debugging.md
@@ -24,29 +24,23 @@ For debugging directly on a chip, you need a few more dependencies. Which depend
   * You probably need to install OpenOCD. This program is present in most package managers and it is easiest to install it directly from there.
   * Some boards require something other than OpenOCD, for example some Nordic Semiconductor boards require `JLinkGDBServer`.
 
-### Debian or Ubuntu
+### Upstream OpenOCD
+
+Many debug probes will work out of the box with the upstream version of openocd available in your package manager.
+
+#### Debian or Ubuntu
 
 You can install the most common dependencies through the package manager:
 
     sudo apt-get install gdb-multiarch openocd
 
-### Fedora
+#### Fedora
 
 Fedora's `gdb` package comes compiled with multi arch support:
   
     dnf install gdb openocd
 
-To use the picoprobe as a debugger you must compile openocd from source using Raspberry Pi's openocd. [Getting Started with Raspberry Pi Pico](https://datasheets.raspberrypi.com/pico/getting-started-with-pico.pdf) Appendix A has build instructions we can modify:
-
-    dnf install automake autoconf build-essential texinfo libtool libftdi-devel libusb1-devel
-    git clone https://github.com/raspberrypi/openocd.git --recursive --branch rp2040 --depth=1
-    cd openocd
-    ./bootstrap
-    ./configure --enable-ftdi --enable-sysfsgpio --enable-bcm2835gpio
-    make -j$(nproc)
-    sudo make install
-
-### MacOS
+#### MacOS
 
 You can install the most common dependencies through Homebrew:
 
@@ -54,10 +48,26 @@ You can install the most common dependencies through Homebrew:
     brew tap ARMmbed/homebrew-formulae
     brew install arm-none-eabi-gcc
 
-However this will not support the Raspberry Pi Pico targets or the Raspberry Pi Debug Probe. Instead, compile openocd from source using [Raspberry Pi's openocd fork](https://github.com/raspberrypi/openocd):
+### Raspberry Pi Debug Probe
+
+To use the Raspberry Pi Debug Probe as a debugger you must compile openocd from source using [Raspberry Pi's openocd fork](https://github.com/raspberrypi/openocd).
+
+### Prerequisites
+
+#### Debian or Ubuntu
+
+    sudo apt-get install gdb-multiarch libtool pkg-config libusb-1.0-0-dev make
+
+#### Fedora
+
+    sudo dnf install libtool arm-none-eabi-gcc-cs libusb1-devel gdb
+
+#### MacOS
 
     brew tap ARMmbed/homebrew-formulae
     brew install libtool automake libusb aclocal texinfo pkg-config capstone gdb arm-none-eabi-gcc
+
+### Build
 
     git clone git@github.com:raspberrypi/openocd.git
     cd openocd
@@ -69,15 +79,26 @@ However this will not support the Raspberry Pi Pico targets or the Raspberry Pi 
     ./configure --disable-werror --enable-internal-jimtcl --enable-cmsis-dap-v2 --enable-bcm2835gpio
     make -j4
 
-You can then add openocd and the required scripts to your environment like so:
+### Installation
+
+You can use `sudo make install` to copy openocd into your system directories in the same way upstream OpenOCD would be installed by package managers. However, this can create conflicts with said package managers, and is harder to remove later.
+
+A safer approach is to add openocd and the required scripts to your environment like so:
 
     export PATH=$PWD/src:$PATH
     export OPENOCD_SCRIPTS=$PWD/tcl
 
-Or add it to your `~/.zshrc` so that it persists for future sessions:
+For convenience you can add this to your shell configuration file so that it persists for future sessions.
+
+#### macOS (and other systems using zsh)
 
     echo "export PATH=\"$PWD/src:\$PATH\"" >> ~/.zshrc
     echo "export OPENOCD_SCRIPTS=\"$PWD/tcl\"" >> ~/.zshrc
+
+#### Fedora (and other systems using bash)
+
+    echo "export PATH=\"$PWD/src:\$PATH\"" >> ~/.bashrc
+    echo "export OPENOCD_SCRIPTS=\"$PWD/tcl\"" >> ~/.bashrc
 
 ## Connecting a debug probe
 


### PR DESCRIPTION
We spent a little time getting this working on Fedora and macOS, and landed up with some internal docs we figured we could just push upstream. Appendix A in "Getting Started with Raspberry Pi Pico" guide seems to be out of date and no longer works, but we have successfully used these instructions on macOS Tahoe, Fedora 43 and Ubuntu 24.04.

We also added a few notes on debugging since we found `-ocd-commands "adapter speed 5000"` needed to be added to `tinygo gdb` to get it working with the Debug Probe, and we used the other flags to debug this :)