### PR TITLE
Fix tinygo path in Linux installation instructions

### DIFF
--- a/content/getting-started/install/linux.md
+++ b/content/getting-started/install/linux.md
@@ -44,7 +44,7 @@ sudo dpkg -i tinygo_0.40.1_armhf.deb
 You will need to ensure that the path to the `tinygo` executable file is in your `PATH` variable.
 
 ```shell
-export PATH=$PATH:/usr/local/bin
+export PATH=$PATH:/usr/local/tinygo/bin
 ```
 
 You can test that the installation is working properly by running this code which should display the version number:


### PR DESCRIPTION
Update the PATH variable to include the correct tinygo directory.

