### PR TITLE
playground: handle Arduino Uno rename

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -38,3 +38,7 @@ code {
     box-shadow: var(--bs-box-shadow-inset), 0 0 0 0.25rem rgba(4, 110, 143, 0.25);
     border-color: #82b7c7;
 }
+
+#playground {
+    scroll-margin-top: 4rem;
+}

--- a/content/_index.md
+++ b/content/_index.md
@@ -10,6 +10,9 @@ title: "TinyGo Home"
 	<a class="btn btn-lg btn-primary mr-3 mb-4" href="{{< relref "/getting-started" >}}">
 		Get Started <i class="fas fa-arrow-alt-circle-right ml-2"></i>
 	</a>
+	<a class="btn btn-lg btn-primary mr-3 mb-4" href="{{< relref "#playground" >}}">
+		Try TinyGo <i class="fas fa-arrow-alt-circle-down ml-2"></i>
+	</a>
 	<a class="btn btn-lg btn-secondary mr-3 mb-4" href="https://github.com/tinygo-org/tinygo">
 		See the code <i class="fab fa-github ml-2 "></i>
 	</a>
@@ -36,6 +39,7 @@ Ready to get started? [Click here](getting-started).
 <div class="col">
 	<div class="container" id="playground">
 		<h1 class="text-center">Try TinyGo</h1>
+		<p class="text-center">Want to learn more? See the <a href="/tour/">Tour of TinyGo</a>. Just want free play with simulated devices? Explore the full <a href="/play/">TinyGo Playground</a>.</p>
 		<div class="row px-0">
 			<div class="col col-auto">
 				<div class="input-group mb-3">
@@ -50,7 +54,6 @@ Ready to get started? [Click here](getting-started).
 			</div>
 			<div class="col col-auto">
 				<button class="btn btn-secondary playground-btn-flash mb-3" disabled>Download binary</button>
-				<a href="/tour/" class="btn btn-link mb-3">Tour of TinyGo</a>
 			</div>
 		</div>
 		<div class="playground-editor mb-3" tabindex="-1"></div>

--- a/content/tour/blink/external.md
+++ b/content/tour/blink/external.md
@@ -54,7 +54,7 @@ func main() {
 }`;
 setupTour({
 	boards: {
-		'arduino': {
+		'arduino-uno': {
 			code: code.replace('machine.LED', 'machine.D2 // Arduino Uno'),
 			parts: {
 				led: {

--- a/content/tour/blink/onboard.md
+++ b/content/tour/blink/onboard.md
@@ -57,7 +57,7 @@ import { setupTour } from '/tour.js';
 setupTour({
 	boards: {
 		'arduino-nano33': {},
-		'arduino': {},
+		'arduino-uno': {},
 		'circuitplay-bluefruit': {},
 		'circuitplay-express': {},
 		'pico': {},

--- a/content/tour/button/external.md
+++ b/content/tour/button/external.md
@@ -84,7 +84,7 @@ func main() {
 }`;
 setupTour({
 	boards: {
-		'arduino': {
+		'arduino-uno': {
 			code: code.replace('EXT_BUTTON', 'machine.D2 // Arduino Uno'),
 			parts: {
 				button: {

--- a/content/tour/ws2812/animating.md
+++ b/content/tour/ws2812/animating.md
@@ -111,7 +111,7 @@ setupTour({
 		'circuitplay-bluefruit': {},
 		'circuitplay-express': {},
 		'gopher-badge': {},
-		'arduino': {
+		'arduino-uno': {
 			code: code.replace('machine.WS2812', 'machine.D7'),
 			parts: {
 				main: {

--- a/content/tour/ws2812/intro.md
+++ b/content/tour/ws2812/intro.md
@@ -115,7 +115,7 @@ setupTour({
 		'circuitplay-bluefruit': {},
 		'circuitplay-express': {},
 		'gopher-badge': {},
-		'arduino': {
+		'arduino-uno': {
 			code: code.replace('machine.WS2812', 'machine.D7'),
 			parts: {
 				main: {

--- a/static/playground-home.js
+++ b/static/playground-home.js
@@ -178,13 +178,13 @@ var examples = {
 	// Simple "blinky light" example.
 	// The Arduino Uno, despite its limitations, is very well known and many
 	// people have one. So it seems like a good testcase.
-	arduino: {
-		target: 'arduino',
+	arduino_uno: {
+		target: 'arduino_uno',
 		code: exampleBlink,
 		parts: [
 			{
 				id: 'main',
-				location: 'parts/arduino.json',
+				location: 'parts/arduino_uno.json',
 				x: 0,
 				y: 0,
 			}

--- a/static/tour-lis3dh.js
+++ b/static/tour-lis3dh.js
@@ -26,7 +26,7 @@ export function setupLIS3DH(code) {
   				{from: 'main.A4', to: 'imu.SDA'},
   			],
   		},
-  		'arduino': {
+  		'arduino-uno': {
   			code: code.replace('SCL_PIN', 'ADC5').replace('SDA_PIN', 'ADC4'),
   			parts: {
   				main: {
@@ -71,23 +71,6 @@ export function setupLIS3DH(code) {
   		'gopher-badge': {
     		code: code.replace('SCL_PIN', 'I2C0_SCL_PIN').replace('SDA_PIN', 'I2C0_SDA_PIN'),
   		},
-  		'reelboard': {
-  			code: code.replace('SCL_PIN', 'P0_27').replace('SDA_PIN', 'P0_26'),
-  			parts: {
-  				main: {
-  					x: -10,
-  				},
-  				imu: {
-  					config: imuConfig,
-  					location: 'parts/adafruit-lis3dh.json',
-  					x: 50,
-  				},
-  			},
-  			wires: [
-  				{from: 'main.P19', to: 'imu.SCL'},
-  				{from: 'main.P20', to: 'imu.SDA'},
-  			],
-  		},
   		'pico': {
   			code: code.replace('SCL_PIN', 'GP17').replace('SDA_PIN', 'GP16'),
   			parts: {
@@ -104,24 +87,6 @@ export function setupLIS3DH(code) {
   			wires: [
   				{from: 'main.GP17', to: 'imu.SCL'},
   				{from: 'main.GP16', to: 'imu.SDA'},
-  			],
-  		},
-  		'hifive1b': {
-  			code: code.replace('SCL_PIN', 'D19').replace('SDA_PIN', 'D18'),
-  			parts: {
-  				main: {
-  					x: -10,
-  				},
-  				imu: {
-  					config: imuConfig,
-  					location: 'parts/adafruit-lis3dh.json',
-  					x: 45,
-  					rotation: 180,
-  				},
-  			},
-  			wires: [
-  				{from: 'main.D19', to: 'imu.SCL'},
-  				{from: 'main.D18', to: 'imu.SDA'},
   			],
   		},
   	}});

--- a/static/tour.js
+++ b/static/tour.js
@@ -12,15 +12,13 @@ export { setupTour };
 const PLAYGROUND_API = location.hostname == 'localhost' ? 'http://localhost:8080/api' : 'https://playground-bttoqog3vq-uc.a.run.app/api';
 
 const boardNames = {
-	'arduino': 'Arduino Uno',
+	'arduino-uno': 'Arduino Uno',
 	'arduino-nano33': 'Arduino Nano 33 IoT',
 	'circuitplay-bluefruit': 'Adafruit Circuit Playground Bluefruit',
 	'circuitplay-express': 'Adafruit Circuit Playground Express',
 	'gopher-badge': 'Gopher Badge',
-	'hifive1b': 'SiFive HiFive1 rev B',
 	'microbit': 'BBC micro:bit v1',
 	'pico': 'Raspberry Pi Pico',
-	'reelboard': 'Phytec reel board',
 }
 
 // Configure the tour. This works on pages that use the "tour" layout.
@@ -29,7 +27,7 @@ const boardNames = {
 //   {
 //     code: '...',                // default code
 //     boards: {
-//       'arduino': {              // board name
+//       'arduino-uno': {              // board name
 //          code: '...',           // code for this board (optional)
 //          parts: {               // extra parts besides the main part (optional)
 //            led: { ... },        // configuration for this part


### PR DESCRIPTION
This PR is to handle the Arduino Uno renaming in the playground on the TinyGo site.

It also removes a couple of older boards from the list.

It is a follow up to #490 which must be merged first. (UPDATE: has been merged)

It also requires https://github.com/tinygo-org/playground/pull/31 be merged and the container deployed.

Hence I am marking as draft until those are completed.