### PR TITLE
media: add some new links to articles and reformat to conserve space

### DIFF
--- a/content/media/articles.md
+++ b/content/media/articles.md
@@ -7,53 +7,40 @@ description: >
   Articles and blog posts talking about TinyGo
 ---
 
-**Hackaday - "TinyGo Boldly Goes Where No Go Ever Did Go Before"** - *April 7, 2026*
-https://hackaday.com/2026/04/07/tinygo-boldly-goes-where-no-go-ever-did-go-before/
+**Hackster - ["TinyGo 0.41.0 Brings Wireless Support on Espressif's ESP32 Chips and Arduino UNO Q Compatibility"](https://www.hackster.io/news/tinygo-0-41-0-brings-wireless-support-on-espressif-s-esp32-chips-and-arduino-uno-q-compatibility-355336eb9f86)** - *April 21, 2026*
 
-**Hriday Keni - "TinyGo for Embedded Applications: Coding Without the Code-Phobia"** - *February 1, 2025*
-https://medium.com/@hrkeni/tinygo-for-embedded-applications-coding-without-the-code-phobia-28ed90b5bcb0
+**Seeed Studio - ["TinyGo v0.41 Is Here: Native Wireless Support for Seeed Studio XIAO ESP32-C3 & S3"](https://www.seeedstudio.com/blog/2026/04/21/tinygo-v041-wireless-support-xiao-esp32-c3-s3/)** - *April 21, 2026*
 
-**Eric Gregory - "Compile Go directly to WebAssembly components with TinyGo and WASI P2"** - *July 2, 2024*
-https://wasmcloud.com/blog/compile-go-directly-to-webassembly-components-with-tinygo-and-wasi-p2/
+**Hackaday - ["TinyGo Boldly Goes Where No Go Ever Did Go Before"](https://hackaday.com/2026/04/07/tinygo-boldly-goes-where-no-go-ever-did-go-before/)** - *April 7, 2026*
 
-**Matt Butcher - "4 Big Developments in WebAssembly"** - *April 18, 2024*
-https://thenewstack.io/4-big-developments-in-webassembly/
+**Hriday Keni - ["TinyGo for Embedded Applications: Coding Without the Code-Phobia"](https://medium.com/@hrkeni/tinygo-for-embedded-applications-coding-without-the-code-phobia-28ed90b5bcb0)** - *February 1, 2025*
 
-**Tobenna Kelvin Abanofor - Hardware Simulation with Wokwi x TinyGo** - *September 8, 2023*
-https://medium.com/@micatovin/hardware-simulation-with-wokwi-x-tinygo-d85d1a3986
+**Eric Gregory - ["Compile Go directly to WebAssembly components with TinyGo and WASI P2"](https://wasmcloud.com/blog/compile-go-directly-to-webassembly-components-with-tinygo-and-wasi-p2/)** - *July 2, 2024*
 
-**Pragmatik.tech - Multiple articles on TinyGo and Raspberry Pi Pico** - *July 2022 onwards*
-https://pragmatik.tech/tags/tinygo/
+**Matt Butcher - ["4 Big Developments in WebAssembly"](https://thenewstack.io/4-big-developments-in-webassembly/)** - *April 18, 2024*
 
-**Aurélie Vache - "Learning Go by examples: part 5 - Create a Game Boy Advance (GBA) game in Go"** - *August 11, 2021*
-https://dev.to/aurelievache/learning-go-by-examples-part-5-create-a-game-boy-advance-gba-game-in-go-5944
+**Tobenna Kelvin Abanofor - ["Hardware Simulation with Wokwi x TinyGo"](https://medium.com/@micatovin/hardware-simulation-with-wokwi-x-tinygo-d85d1a3986)** - *September 8, 2023*
 
-**Alan Wang - "TinyGo on Arduino Uno: An Introduction"** - *February 5, 2020*
-https://create.arduino.cc/projecthub/alankrantas/tinygo-on-arduino-uno-an-introduction-6130f6
+**Pragmatik.tech - [Multiple articles on TinyGo and Raspberry Pi Pico](https://pragmatik.tech/tags/tinygo/)** - *July 2022 onwards*
 
-**Arduino - "TinyGo on Arduino"** - *August 23, 2019*
-https://blog.arduino.cc/2019/08/23/tinygo-on-arduino/
+**Aurélie Vache - ["Learning Go by examples: part 5 - Create a Game Boy Advance (GBA) game in Go"](https://dev.to/aurelievache/learning-go-by-examples-part-5-create-a-game-boy-advance-gba-game-in-go-5944)** - *August 11, 2021*
 
-**Sourcegraph - "Liveblog - GopherCon 2019 - Small is going big: Go On microcontrollers"** - *July 26, 2019*
-https://about.sourcegraph.com/go/gophercon-2019-small-is-going-big-go-on-microcontrollers
+**Alan Wang - ["TinyGo on Arduino Uno: An Introduction"](https://create.arduino.cc/projecthub/alankrantas/tinygo-on-arduino-uno-an-introduction-6130f6)** - *February 5, 2020*
 
-**Ayke van Laëthem - "How the TinyGo playground simulates hardware"** - *July 17, 2019*
-https://aykevl.nl/2019/07/tinygo-plaground-simulator
+**Arduino - ["TinyGo on Arduino"](https://blog.arduino.cc/2019/08/23/tinygo-on-arduino/)** - *August 23, 2019*
 
-**Sendil Kumar N - "Reduce your WebAssembly binaries 72% - from 56KB to 26KB to 16KB"** - *July 7, 2019*
-https://dev.to/sendilkumarn/reduce-your-webassembly-binaries-72-from-56kb-to-26kb-to-16kb-40mi
+**Sourcegraph - ["Liveblog - GopherCon 2019 - Small is going big: Go On microcontrollers"](https://about.sourcegraph.com/go/gophercon-2019-small-is-going-big-go-on-microcontrollers)** - *July 26, 2019*
 
-**Sendil Kumar N - "(Tiny)Go to WebAssembly"** - *July 5, 2019*
-https://dev.to/sendilkumarn/tiny-go-to-webassembly-5168
+**Ayke van Laëthem - ["How the TinyGo playground simulates hardware"](https://aykevl.nl/2019/07/tinygo-plaground-simulator)** - *July 17, 2019*
 
-**Adafruit - "Using tinyGo on an Adafruit ItsyBitsy M0 board"** - *June 7, 2019*
-https://blog.adafruit.com/2019/06/07/using-tinggo-on-an-adafruit-itsybitsy-m0-board-golang-tinygo-microcontrollers-adafruit-adafruit-deadprogram-tinggolang/
+**Sendil Kumar N - ["Reduce your WebAssembly binaries 72% - from 56KB to 26KB to 16KB"](https://dev.to/sendilkumarn/reduce-your-webassembly-binaries-72-from-56kb-to-26kb-to-16kb-40mi)** - *July 7, 2019*
 
-**Ayke van Laëthem - "LLVM from a Go perspective"** - *April 28, 2019*
-https://aykevl.nl/2019/04/llvm-from-go
+**Sendil Kumar N - ["(Tiny)Go to WebAssembly"](https://dev.to/sendilkumarn/tiny-go-to-webassembly-5168)** - *July 5, 2019*
 
-**Adafruit - "TinyGo – Go on Microcontrollers runs on Adafruit Circuit Playground Express"** - *March 12, 2019*
-https://blog.adafruit.com/2019/03/12/tinygo-go-on-microcontrollers-tinygolang-tinygo-runs-on-adafruit-circuit-playground-express/
+**Adafruit - ["Using tinyGo on an Adafruit ItsyBitsy M0 board"](https://blog.adafruit.com/2019/06/07/using-tinggo-on-an-adafruit-itsybitsy-m0-board-golang-tinygo-microcontrollers-adafruit-adafruit-deadprogram-tinggolang/)** - *June 7, 2019*
 
-**Ayke van Laëthem - "Goroutines in TinyGo"** - *February 25, 2019*
-https://aykevl.nl/2019/02/tinygo-goroutines
+**Ayke van Laëthem - ["LLVM from a Go perspective"](https://aykevl.nl/2019/04/llvm-from-go)** - *April 28, 2019*
+
+**Adafruit - ["TinyGo – Go on Microcontrollers runs on Adafruit Circuit Playground Express"](https://blog.adafruit.com/2019/03/12/tinygo-go-on-microcontrollers-tinygolang-tinygo-runs-on-adafruit-circuit-playground-express/)** - *March 12, 2019*
+
+**Ayke van Laëthem - ["Goroutines in TinyGo"](https://aykevl.nl/2019/02/tinygo-goroutines)** - *February 25, 2019*


### PR DESCRIPTION
This PR adds some new links to the "articles" page and reformats to conserve space.