### PR TITLE
getting-started: Improve Arch linux getting-started install

### DIFF
--- a/content/getting-started/install/linux.md
+++ b/content/getting-started/install/linux.md
@@ -112,7 +112,7 @@ This should allow you to flash TinyGo programs on an Arduino or other supported 
 
 ### Arch Linux
 
-There is an [Arch package](https://archlinux.org/packages/extra/x86_64/tinygo/) available for TinyGo. There is also an AUR package [`tinygo-bin`](https://aur.archlinux.org/packages/tinygo-bin) based on the GitHub releases, which may be more recently updated.
+There is an Arch package [`tinygo`](https://archlinux.org/packages/extra/x86_64/tinygo/) available for TinyGo. There is also an AUR package [`tinygo-bin`](https://aur.archlinux.org/packages/tinygo-bin) based on the GitHub releases, which may be more recently updated.
 
 If you are only interested in compiling TinyGo code for WebAssembly then you are now done with the installation.
 


### PR DESCRIPTION
It makes the Arch Linux package explicit by making the name of the package the link to the package. What also make both packages, the Arch package and the AUR package consistent.

### Note for the reviewer
It's my first PR here. I didn't find any specific guideline, so please let me know if there is a guideline to follow. 