### PR TITLE
docs(wasi): make wasmimport example a declaration-only import

### DIFF
--- a/content/docs/guides/webassembly/wasi.md
+++ b/content/docs/guides/webassembly/wasi.md
@@ -17,13 +17,14 @@ Here is a small TinyGo program for use within a WASI host application:
 package main
 
 //go:wasmimport yourmodulename add
-func add(x, y uint32) uint32 {
-	return x + y
-}
+func add(x, y uint32) uint32
 
 // main is required for the `wasip1` target, even if it isn't used.
 func main() {}
 ```
+
+`//go:wasmimport` may only appear on function declarations without a body (the
+implementation is provided by the host).
 
 To compile the above TinyGo program for use on any WASI runtime:
 


### PR DESCRIPTION
## Summary
The "Using WASI" guide showed a `//go:wasmimport` function with a body. TinyGo rejects that (`can only use //go:wasmimport on declarations`), so the documented example does not compile.

## Changes
- Make `add` a declaration-only import (no body).
- Note that the host provides the implementation.

## Test plan
- [x] Example matches TinyGo's `//go:wasmimport` rules
- [ ] `GOOS=wasip1 GOARCH=wasm tinygo build -o main.wasm main.go` succeeds for the snippet

Fixes tinygo-org/tinygo#5572
