### PR TITLE
docs: fix WASI guide example to use //go:wasmexport

### DIFF
--- a/content/docs/guides/webassembly/wasi.md
+++ b/content/docs/guides/webassembly/wasi.md
@@ -16,7 +16,7 @@ Here is a small TinyGo program for use within a WASI host application:
 ```go
 package main
 
-//go:wasmimport yourmodulename add
+//go:wasmexport add
 func add(x, y uint32) uint32 {
 	return x + y
 }


### PR DESCRIPTION
Fixes tinygo-org/tinygo#5572.

The "Using WASI" guide's example uses `//go:wasmimport` on a function with a body, which fails to compile on current TinyGo:

```
main.go:4:6: can only use //go:wasmimport on declarations
```

`//go:wasmimport` declares a *host* function (and is only valid on body-less declarations). What the example defines is a function for the host to call, which is `//go:wasmexport`.

Verified with tinygo 0.41.1: the corrected example compiles for `GOOS=wasip1 GOARCH=wasm`, and the current one fails with exactly the error reported in the issue.