### PR TITLE
Update MacOS installation: Brew requires 'trust' command, adding to documentation

### DIFF
--- a/content/getting-started/install/macos.md
+++ b/content/getting-started/install/macos.md
@@ -15,6 +15,7 @@ You can use Homebrew to install TinyGo using the following commands:
 
 ```shell
 brew tap tinygo-org/tools
+brew trust tinygo-org/tools
 brew install tinygo
 ```
 


### PR DESCRIPTION
Without this, getting this error:

```shell
❯ brew tap tinygo-org/tools
brew install tinygo

==> Downloading Homebrew API data
✔︎ JSON API packages.arm64_tahoe.jws.json            Downloaded   15.5MB/ 15.5MB
==> Tapping tinygo-org/tools
Cloning into '/opt/homebrew/Library/Taps/tinygo-org/homebrew-tools'...
Tapped 1 formula (14 files, 51KB).
Error: Refusing to load formula tinygo-org/tools/tinygo from untrusted tap tinygo-org/tools.
Run `brew trust --formula tinygo-org/tools/tinygo` or `brew trust tinygo-org/tools` to trust it.
```